### PR TITLE
Add pest workout parser PoC observations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,8 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "pest",
+ "pest_derive",
  "reqwest",
  "serde",
  "serde_json",
@@ -736,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1219,7 +1221,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1886,6 +1888,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,7 +2072,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2064,7 +2109,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2276,7 +2321,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3010,6 +3055,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ opentelemetry-appender-tracing = { version = "0.28.1", features = ["experimental
 opentelemetry-http = "0.28"
 opentelemetry-otlp = { version = "0.28", default-features = false, features = ["grpc-tonic", "logs", "trace"] }
 opentelemetry_sdk = { version = "0.28", features = ["logs", "rt-tokio"] }
+pest = "2.8.0"
+pest_derive = "2.8.0"
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/docs/superpowers/plans/2026-04-11-pest-parser-poc-workout.md
+++ b/docs/superpowers/plans/2026-04-11-pest-parser-poc-workout.md
@@ -18,7 +18,6 @@
 - `src/domain/intervals/workout/pest_parser/ast.rs`
 - `src/domain/intervals/workout/pest_parser/error.rs`
 - `src/domain/intervals/workout/pest_parser/parser.rs`
-- `src/domain/intervals/workout/pest_parser/mapping.rs`
 - `src/domain/intervals/pest_parser_poc.rs`
 - `src/adapters/mongo/pest_parser_poc_workouts.rs`
 - `tests/intervals_pest_parser_poc.rs`

--- a/docs/superpowers/plans/2026-04-11-pest-parser-poc-workout.md
+++ b/docs/superpowers/plans/2026-04-11-pest-parser-poc-workout.md
@@ -1,0 +1,106 @@
+# Pest Parser PoC Workout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Pest-based shadow parser for Intervals.icu `workout_doc`, persist both successful and failed parse attempts into Mongo collection `pest_parser_poc_workout`, and trigger that persistence on every inbound Intervals read and every outbound sync/push to Intervals without changing the current application behavior.
+
+**Architecture:** Keep the current public `parse_workout_doc` behavior intact. Introduce a new internal Pest parser with a local AST and error type inside `src/domain/intervals/workout/`. Add a dedicated Mongo adapter for PoC persistence, then wrap the live Intervals API adapter so inbound `list_events`/`get_event` and outbound `create_event`/`update_event` perform observational parse-and-store side effects while never blocking the main Intervals flow.
+
+**Tech Stack:** Rust 2021, Pest, MongoDB, tracing, existing Intervals adapter and domain models.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/domain/intervals/workout/pest_parser/mod.rs`
+- `src/domain/intervals/workout/pest_parser/workout.pest`
+- `src/domain/intervals/workout/pest_parser/ast.rs`
+- `src/domain/intervals/workout/pest_parser/error.rs`
+- `src/domain/intervals/workout/pest_parser/parser.rs`
+- `src/domain/intervals/workout/pest_parser/mapping.rs`
+- `src/domain/intervals/pest_parser_poc.rs`
+- `src/adapters/mongo/pest_parser_poc_workouts.rs`
+- `tests/intervals_pest_parser_poc.rs`
+
+**Modify:**
+- `Cargo.toml`
+- `src/domain/intervals/workout.rs`
+- `src/domain/intervals/mod.rs`
+- `src/domain/intervals/ports.rs`
+- `src/adapters/mongo/mod.rs`
+- `src/main.rs`
+- `src/adapters/intervals_icu/client/api.rs`
+
+## Execution Notes
+
+- Keep the current `parse_workout_doc(...)` signature unchanged.
+- Persistence happens only at the Intervals adapter boundary.
+- Persist both parsed and failed observations.
+- Observation failures must not break inbound or outbound Intervals flows.
+- Follow TDD: write failing tests first, verify the failure, then implement the minimum code to pass.
+
+## Task Groups
+
+### 1. Parser scaffolding and dependency wiring
+- Add `pest` and `pest_derive` dependencies.
+- Add the `pest_parser` workout submodule.
+- Add parser smoke tests that fail first.
+- Introduce the initial AST and error types.
+
+### 2. Grammar and AST parsing
+- Implement the `.pest` grammar for the approved PoC subset.
+- Add tests for simple FTP, repeat blocks, pace, HR/LTHR, ramp, cadence, and text metadata.
+- Ensure malformed input returns a structured error and never panics.
+
+### 3. Mapping into existing parsed workout model
+- Map the AST into `ParsedWorkoutDoc` for comparison and persistence.
+- Preserve current summary semantics and percent-zone projection where applicable.
+- Keep unsupported richer syntax visible in normalized output and PoC payload.
+
+### 4. PoC domain model and repository port
+- Add record types for parsed and failed observations.
+- Add a no-op repository implementation.
+- Keep repository behavior behind a domain port.
+
+### 5. Mongo adapter
+- Add `MongoPestParserPocWorkoutRepository` for collection `pest_parser_poc_workout`.
+- Create indexes for lookup by user/time and by status/time.
+- Persist both parsed and failed records.
+
+### 6. Safe observation helper
+- Add a pure helper that observes a workout string, runs the Pest parser, builds a PoC record, and keeps a legacy projection from the current parser.
+- No panics, no main-flow breakage.
+
+### 7. Inbound Intervals observation
+- Observe and persist on `list_events(...)`.
+- Include `get_event(...)` as the single-event inbound path if the wiring stays small and testable.
+- Return the same `Event` values as before.
+
+### 8. Outbound Intervals observation
+- Observe and persist before `create_event(...)` and `update_event(...)` HTTP calls.
+- Do not block outbound sync if parser or Mongo persistence fails.
+
+### 9. Verification
+- Run parser-specific tests.
+- Run Mongo adapter tests.
+- Run relevant Intervals and sync-related tests.
+- Run `cargo fmt --all --check`.
+- Run `cargo clippy --all-targets --all-features -- -D warnings`.
+
+## Final Verification Commands
+
+- `cargo fmt --all --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --test intervals_workout_analysis -- --nocapture`
+- `cargo test --test intervals_pest_parser_poc -- --nocapture`
+- `cargo test --test intervals_rest -- --nocapture`
+
+## Success Criteria
+
+- New Pest parser exists and is tested.
+- `pest_parser_poc_workout` records are stored for inbound and outbound Intervals operations.
+- Both success and failure cases are persisted.
+- No syntax error can panic the process.
+- Existing public behavior remains stable.
+- Relevant tests, formatting, and clippy pass.

--- a/docs/superpowers/specs/2026-04-11-pest-parser-poc-workout-design.md
+++ b/docs/superpowers/specs/2026-04-11-pest-parser-poc-workout-design.md
@@ -44,7 +44,6 @@ Parser internals live under the workout domain area:
 - `src/domain/intervals/workout/pest_parser/ast.rs`
 - `src/domain/intervals/workout/pest_parser/error.rs`
 - `src/domain/intervals/workout/pest_parser/parser.rs`
-- `src/domain/intervals/workout/pest_parser/mapping.rs`
 
 PoC record types and repository port:
 - `src/domain/intervals/pest_parser_poc.rs`
@@ -134,7 +133,7 @@ The AST-to-`ParsedWorkoutDoc` mapping is intentionally lossy where the public mo
 
 Preserve where possible:
 - repeat counts
-n- duration seconds for time-based steps
+- duration seconds for time-based steps
 - zone IDs
 - FTP percent min/max values
 - canonical normalized step definitions
@@ -183,19 +182,19 @@ Field semantics:
 Recommended indexes:
 - `{ user_id: 1, parsed_at_epoch_seconds: -1 }`
 - `{ status: 1, parsed_at_epoch_seconds: -1 }`
-- `{ source_type: 1, source_ref: 1, parsed_at_epoch_seconds: -1 }`
+- `{ operation: 1, source_ref: 1, parsed_at_epoch_seconds: -1 }`
 
 ## Integration Points
 
 Persistence should happen only at the Intervals adapter boundary, not inside the public parser function itself.
 
 Inbound reads:
-- `list_events(...)` in `src/adapters/intervals_icu/client/api.rs`
+- `list_events(...)` in `src/domain/intervals/service/events.rs`
 - optionally `get_event(...)` as the single-event inbound path
 
 Outbound pushes:
-- `create_event(...)` in `src/adapters/intervals_icu/client/api.rs`
-- `update_event(...)` in `src/adapters/intervals_icu/client/api.rs`
+- `create_event(...)` in `src/domain/intervals/service/events.rs`
+- `update_event(...)` in `src/domain/intervals/service/events.rs`
 
 Reasoning:
 - this matches the requested trigger semantics exactly

--- a/docs/superpowers/specs/2026-04-11-pest-parser-poc-workout-design.md
+++ b/docs/superpowers/specs/2026-04-11-pest-parser-poc-workout-design.md
@@ -1,0 +1,245 @@
+# Pest Parser PoC Workout Design
+
+**Goal:** Add a Pest-based shadow parser for Intervals.icu `workout_doc`, persist both successful and failed parse attempts to Mongo collection `pest_parser_poc_workout`, and trigger persistence on every inbound Intervals read and every outbound push/sync to Intervals without breaking the current application flow.
+
+## Scope
+
+Primary target:
+- `workout_doc` parsing only
+
+Out of scope for this PoC:
+- replacing the current public `parse_workout_doc(...)` behavior
+- changing existing REST response shapes
+- expanding public domain workout models to fully represent pace, HR, LTHR, cadence, and metadata
+- changing `planned_workout` parsing as the primary implementation target
+
+## Current Context
+
+The repo currently has two different parsers:
+- a lenient `parse_workout_doc(...)` under `src/domain/intervals/workout/parser.rs`
+- a strict `parse_planned_workout(...)` under `src/domain/intervals/planned_workout/parser.rs`
+
+`parse_workout_doc(...)` is infallible today and is consumed by REST mapping and training-context flows. That behavior is observable and must remain stable during the PoC.
+
+## Recommended Architecture
+
+Use a shadow-parser design:
+- keep the current `parse_workout_doc(...)` as the source of behavior for the application
+- add a new internal Pest parser that is a pure function:
+  - `fn parse_workout_ast(input: &str) -> Result<WorkoutAst, WorkoutPestParseError>`
+- map the AST into the existing `ParsedWorkoutDoc` model only for comparison and persistence
+- never let a Pest parser failure block inbound or outbound Intervals flows
+
+This is the smallest correct change and matches the repo rules:
+- clear boundaries
+- no Mongo leakage into domain parser logic
+- no panic on malformed input
+- non-breaking integration
+
+## Module Layout
+
+Parser internals live under the workout domain area:
+- `src/domain/intervals/workout/pest_parser/mod.rs`
+- `src/domain/intervals/workout/pest_parser/workout.pest`
+- `src/domain/intervals/workout/pest_parser/ast.rs`
+- `src/domain/intervals/workout/pest_parser/error.rs`
+- `src/domain/intervals/workout/pest_parser/parser.rs`
+- `src/domain/intervals/workout/pest_parser/mapping.rs`
+
+PoC record types and repository port:
+- `src/domain/intervals/pest_parser_poc.rs`
+
+Mongo adapter:
+- `src/adapters/mongo/pest_parser_poc_workouts.rs`
+
+## AST Design
+
+The AST is internal and intentionally richer than the current public `ParsedWorkoutDoc` model.
+
+Proposed core shapes:
+- `WorkoutAst { items: Vec<WorkoutItem> }`
+- `WorkoutItem::Step(WorkoutStepAst)`
+- `WorkoutItem::RepeatBlock(RepeatBlockAst)`
+- `RepeatBlockAst { title: Option<String>, count: usize, steps: Vec<WorkoutStepAst> }`
+- `WorkoutStepAst { cue: Option<String>, amount: StepAmount, kind: StepKind, target: Option<ParserTarget>, cadence: Option<CadenceRange>, text: Option<String> }`
+
+Internal enums:
+- `StepAmount::{Time(Vec<TimePart>), Distance { value: f64, unit: DistanceUnit }}`
+- `StepKind::{Steady, Ramp, FreeRide}`
+- `ParserTarget::{PercentFtp, Watts, PercentHr, PercentLthr, Pace, Zone}`
+
+This keeps parser semantics local and avoids premature public-model expansion.
+
+## Grammar Direction
+
+The `.pest` grammar should support the subset needed by the PoC:
+- simple steps
+- repeat headers with child steps
+- time and distance amounts
+- FTP percent targets and ranges
+- watt targets and ranges
+- HR and LTHR targets
+- pace targets
+- zone targets
+- cadence metadata
+- `text="..."` metadata
+- ramp and freeride modifiers
+
+Important parsing conventions:
+- `m` means minutes
+- meters should prefer `mtr` in parsing examples to avoid ambiguity
+- warmup, cooldown, recovery are semantic cue labels, not grammar keywords
+- malformed input must return a structured parser error, never panic
+
+## Proposed Grammar Structure
+
+Top-level:
+- `workout = { SOI ~ line* ~ EOI }`
+- `line = _{ blank_line | repeat_header_line | bullet_step_line | text_line }`
+
+Repeat blocks:
+- `repeat_header_line = { indent? ~ repeat_title? ~ repeat_count ~ line_end }`
+- `repeat_count = { int ~ "x" }`
+- `repeat_title = { (!repeat_count ~ !line_end ~ ANY)+ }`
+
+Step lines:
+- `bullet_step_line = { indent? ~ "-" ~ ws* ~ step_body ~ line_end }`
+- `step_body = { cue_prefix? ~ amount ~ ws+ ~ step_modifier? ~ ws* ~ target? ~ ws* ~ cadence? ~ ws* ~ metadata* }`
+
+Units:
+- `amount = { time_amount | distance_amount }`
+- `time_amount = { time_part+ }`
+- `time_part = { number ~ ("h" | "hr" | "hrs" | "m" | "min" | "mins" | "s" | "sec" | "secs" | "'" | "\"") }`
+- `distance_amount = { number ~ ("mtr" | "km" | "mi" | "m") }`
+
+Targets:
+- `target = _{ ftp_target | watts_target | hr_target | lthr_target | pace_target | zone_target }`
+- `ftp_target = { number ~ ("-" ~ number)? ~ "%" }`
+- `watts_target = { int ~ ("-" ~ int)? ~ ^"w" }`
+- `hr_target = { (number ~ ("-" ~ number)? ~ "%" | zone_expr) ~ ws* ~ ^"HR" }`
+- `lthr_target = { (number ~ ("-" ~ number)? ~ "%" | zone_expr) ~ ws* ~ ^"LTHR" }`
+- `pace_target = { (pace_value | number ~ ("-" ~ number)? ~ "%" | zone_expr) ~ ws* ~ ^"Pace" }`
+- `zone_target = { zone_expr }`
+- `zone_expr = { ^"Z" ~ int }`
+
+Metadata:
+- `cadence = { cadence_value ~ ^"rpm" }`
+- `cadence_value = { int ~ ("-" ~ int)? }`
+- `metadata = { text_metadata }`
+- `text_metadata = { ^"text" ~ "=" ~ quoted_string }`
+
+## Mapping Policy
+
+The AST-to-`ParsedWorkoutDoc` mapping is intentionally lossy where the public model is narrower.
+
+Preserve where possible:
+- repeat counts
+n- duration seconds for time-based steps
+- zone IDs
+- FTP percent min/max values
+- canonical normalized step definitions
+
+Current model projection rules:
+- `% FTP` maps directly to percent bounds
+- `Z1..Z7` maps through the existing percent fallback logic
+- unsupported target families such as pace, HR, and LTHR can remain visible in normalized text but do not need a fake percent projection unless the current behavior already has a clear equivalent
+- cadence and `text="..."` remain represented in normalized text and persisted PoC payload, not in the public `ParsedWorkoutDoc` fields
+
+## PoC Persistence
+
+Use a dedicated Mongo collection:
+- `pest_parser_poc_workout`
+
+Persist both successful and failed parse attempts.
+
+Each record represents one parser observation.
+
+Proposed fields:
+- `user_id`
+- `direction`
+- `operation`
+- `source_ref`
+- `source_text`
+- `parser_version`
+- `parsed_at_epoch_seconds`
+- `status`
+- `normalized_workout`
+- `parsed_payload`
+- `legacy_projection`
+- `error_message`
+- `error_kind`
+- `intervals_event_id`
+- `http_sync_status`
+
+Field semantics:
+- `status = "parsed" | "failed"`
+- `direction = "inbound" | "outbound"`
+- `operation = "list_events" | "get_event" | "create_event" | "update_event"`
+- `normalized_workout` is set only on success
+- `parsed_payload` is set only on success
+- `error_message` and `error_kind` are set only on failure
+- `legacy_projection` is optional and used for comparison against the current parser result
+
+Recommended indexes:
+- `{ user_id: 1, parsed_at_epoch_seconds: -1 }`
+- `{ status: 1, parsed_at_epoch_seconds: -1 }`
+- `{ source_type: 1, source_ref: 1, parsed_at_epoch_seconds: -1 }`
+
+## Integration Points
+
+Persistence should happen only at the Intervals adapter boundary, not inside the public parser function itself.
+
+Inbound reads:
+- `list_events(...)` in `src/adapters/intervals_icu/client/api.rs`
+- optionally `get_event(...)` as the single-event inbound path
+
+Outbound pushes:
+- `create_event(...)` in `src/adapters/intervals_icu/client/api.rs`
+- `update_event(...)` in `src/adapters/intervals_icu/client/api.rs`
+
+Reasoning:
+- this matches the requested trigger semantics exactly
+- it avoids duplicate persistence from every internal call site using `parse_workout_doc(...)`
+- the parser remains pure and side-effect free
+
+## Safety Rules
+
+Non-negotiable behavior:
+- parser function is pure
+- malformed input returns `Err`, never panics
+- Mongo persistence failures log with `tracing::error!` and do not break main Intervals flows
+- parser failures log and persist a failed record but do not block inbound or outbound Intervals operations
+- current public `parse_workout_doc(...)` signature remains unchanged
+
+## Testing Strategy
+
+Tests must cover:
+- simple workout parsing
+- repeat block parsing
+- running workout pace syntax
+- HR and LTHR syntax
+- ramp plus cadence plus `text="..."`
+- malformed syntax returning structured errors without panic
+- observation helper producing parsed and failed records
+- Mongo document persistence for both parsed and failed states
+- inbound `list_events` persistence behavior
+- outbound `create_event` and `update_event` persistence behavior
+- existing Intervals flows remaining non-breaking
+
+Relevant existing suites to keep green:
+- `tests/intervals_workout_analysis.rs`
+- `tests/intervals_rest/...`
+- sync-related tests around calendar/Intervals integration
+
+## Open Constraints Confirmed
+
+Confirmed decisions from the discussion:
+- primary target is `workout_doc`
+- persist both successful and failed parse attempts
+- trigger persistence on every read from Intervals
+- trigger persistence on every push/sync from the app to Intervals
+- implement in the current workspace, not a worktree
+
+## Summary
+
+The PoC will add a new Pest parser beside the current `workout_doc` parser, keep the existing behavior stable, and persist parser observations into `pest_parser_poc_workout` at the Intervals adapter boundary for both inbound and outbound flows. This provides a safe path to evaluate grammar coverage and failure patterns before any later switch of production behavior.

--- a/src/adapters/mongo/mod.rs
+++ b/src/adapters/mongo/mod.rs
@@ -7,6 +7,7 @@ pub mod coach_reply_operations;
 mod error;
 pub mod llm_context_cache;
 pub mod login_state;
+pub mod pest_parser_poc_workouts;
 pub mod planned_workout_syncs;
 pub mod races;
 pub mod sessions;

--- a/src/adapters/mongo/pest_parser_poc_workouts.rs
+++ b/src/adapters/mongo/pest_parser_poc_workouts.rs
@@ -6,9 +6,9 @@ use mongodb::{
 use serde::{Deserialize, Serialize};
 
 use crate::domain::intervals::{
-    BoxFuture, IntervalsError, PestParserPocDirection, PestParserPocOperation,
+    BoxFuture, IntervalsError, ParsedWorkoutDoc, PestParserPocDirection, PestParserPocOperation,
     PestParserPocParsedPayload, PestParserPocRepositoryPort, PestParserPocStatus,
-    PestParserPocWorkoutRecord,
+    PestParserPocWorkoutRecord, WorkoutIntervalDefinition, WorkoutSegment, WorkoutSummary,
 };
 
 #[derive(Clone)]
@@ -29,12 +29,58 @@ struct PestParserPocWorkoutDocument {
     parsed_at_epoch_seconds: i64,
     status: String,
     normalized_workout: Option<String>,
-    parsed_payload: Option<PestParserPocParsedPayload>,
-    legacy_projection: Option<crate::domain::intervals::ParsedWorkoutDoc>,
+    parsed_payload: Option<PestParserPocParsedPayloadDocument>,
+    legacy_projection: Option<ParsedWorkoutDocDocument>,
     error_message: Option<String>,
     error_kind: Option<String>,
     intervals_event_id: Option<i64>,
     http_sync_status: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PestParserPocParsedPayloadDocument {
+    normalized_workout: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ParsedWorkoutDocDocument {
+    intervals: Vec<WorkoutIntervalDefinitionDocument>,
+    segments: Vec<WorkoutSegmentDocument>,
+    summary: WorkoutSummaryDocument,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct WorkoutIntervalDefinitionDocument {
+    definition: String,
+    repeat_count: usize,
+    duration_seconds: Option<i32>,
+    target_percent_ftp: Option<f64>,
+    min_target_percent_ftp: Option<f64>,
+    max_target_percent_ftp: Option<f64>,
+    zone_id: Option<i32>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct WorkoutSegmentDocument {
+    order: usize,
+    label: String,
+    duration_seconds: i32,
+    start_offset_seconds: i32,
+    end_offset_seconds: i32,
+    target_percent_ftp: Option<f64>,
+    min_target_percent_ftp: Option<f64>,
+    max_target_percent_ftp: Option<f64>,
+    zone_id: Option<i32>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct WorkoutSummaryDocument {
+    total_segments: usize,
+    total_duration_seconds: i32,
+    estimated_normalized_power_watts: Option<i32>,
+    estimated_average_power_watts: Option<i32>,
+    estimated_intensity_factor: Option<f64>,
+    estimated_training_stress_score: Option<f64>,
 }
 
 impl MongoPestParserPocWorkoutRepository {
@@ -120,11 +166,76 @@ fn map_record_to_document(record: PestParserPocWorkoutRecord) -> PestParserPocWo
         }
         .to_string(),
         normalized_workout: record.normalized_workout,
-        parsed_payload: record.parsed_payload,
-        legacy_projection: record.legacy_projection,
+        parsed_payload: record.parsed_payload.map(map_parsed_payload_to_document),
+        legacy_projection: record
+            .legacy_projection
+            .map(map_legacy_projection_to_document),
         error_message: record.error_message,
         error_kind: record.error_kind,
         intervals_event_id: record.intervals_event_id,
         http_sync_status: record.http_sync_status,
+    }
+}
+
+fn map_parsed_payload_to_document(
+    payload: PestParserPocParsedPayload,
+) -> PestParserPocParsedPayloadDocument {
+    PestParserPocParsedPayloadDocument {
+        normalized_workout: payload.normalized_workout,
+    }
+}
+
+fn map_legacy_projection_to_document(parsed: ParsedWorkoutDoc) -> ParsedWorkoutDocDocument {
+    ParsedWorkoutDocDocument {
+        intervals: parsed
+            .intervals
+            .into_iter()
+            .map(map_interval_definition_to_document)
+            .collect(),
+        segments: parsed
+            .segments
+            .into_iter()
+            .map(map_segment_to_document)
+            .collect(),
+        summary: map_summary_to_document(parsed.summary),
+    }
+}
+
+fn map_interval_definition_to_document(
+    interval: WorkoutIntervalDefinition,
+) -> WorkoutIntervalDefinitionDocument {
+    WorkoutIntervalDefinitionDocument {
+        definition: interval.definition,
+        repeat_count: interval.repeat_count,
+        duration_seconds: interval.duration_seconds,
+        target_percent_ftp: interval.target_percent_ftp,
+        min_target_percent_ftp: interval.min_target_percent_ftp,
+        max_target_percent_ftp: interval.max_target_percent_ftp,
+        zone_id: interval.zone_id,
+    }
+}
+
+fn map_segment_to_document(segment: WorkoutSegment) -> WorkoutSegmentDocument {
+    WorkoutSegmentDocument {
+        order: segment.order,
+        label: segment.label,
+        duration_seconds: segment.duration_seconds,
+        start_offset_seconds: segment.start_offset_seconds,
+        end_offset_seconds: segment.end_offset_seconds,
+        target_percent_ftp: segment.target_percent_ftp,
+        min_target_percent_ftp: segment.min_target_percent_ftp,
+        max_target_percent_ftp: segment.max_target_percent_ftp,
+        zone_id: segment.zone_id,
+    }
+}
+
+fn map_summary_to_document(summary: WorkoutSummary) -> WorkoutSummaryDocument {
+    WorkoutSummaryDocument {
+        total_segments: summary.total_segments,
+        total_duration_seconds: summary.total_duration_seconds,
+        estimated_normalized_power_watts: summary.estimated_normalized_power_watts,
+        estimated_average_power_watts: summary.estimated_average_power_watts,
+        estimated_intensity_factor: summary.estimated_intensity_factor,
+        estimated_training_stress_score: summary.estimated_training_stress_score,
     }
 }

--- a/src/adapters/mongo/pest_parser_poc_workouts.rs
+++ b/src/adapters/mongo/pest_parser_poc_workouts.rs
@@ -1,0 +1,130 @@
+use mongodb::{
+    bson::{doc, oid::ObjectId},
+    options::IndexOptions,
+    Collection, IndexModel,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::intervals::{
+    BoxFuture, IntervalsError, PestParserPocDirection, PestParserPocOperation,
+    PestParserPocParsedPayload, PestParserPocRepositoryPort, PestParserPocStatus,
+    PestParserPocWorkoutRecord,
+};
+
+#[derive(Clone)]
+pub struct MongoPestParserPocWorkoutRepository {
+    collection: Collection<PestParserPocWorkoutDocument>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PestParserPocWorkoutDocument {
+    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    id: Option<ObjectId>,
+    user_id: String,
+    direction: String,
+    operation: String,
+    source_ref: Option<String>,
+    source_text: String,
+    parser_version: String,
+    parsed_at_epoch_seconds: i64,
+    status: String,
+    normalized_workout: Option<String>,
+    parsed_payload: Option<PestParserPocParsedPayload>,
+    legacy_projection: Option<crate::domain::intervals::ParsedWorkoutDoc>,
+    error_message: Option<String>,
+    error_kind: Option<String>,
+    intervals_event_id: Option<i64>,
+    http_sync_status: Option<String>,
+}
+
+impl MongoPestParserPocWorkoutRepository {
+    pub fn new(client: mongodb::Client, database: impl AsRef<str>) -> Self {
+        Self {
+            collection: client
+                .database(database.as_ref())
+                .collection("pest_parser_poc_workout"),
+        }
+    }
+
+    pub async fn ensure_indexes(&self) -> Result<(), IntervalsError> {
+        self.collection
+            .create_indexes([
+                IndexModel::builder()
+                    .keys(doc! { "user_id": 1, "parsed_at_epoch_seconds": -1 })
+                    .options(
+                        IndexOptions::builder()
+                            .name("pest_parser_poc_workout_user_time".to_string())
+                            .build(),
+                    )
+                    .build(),
+                IndexModel::builder()
+                    .keys(doc! { "status": 1, "parsed_at_epoch_seconds": -1 })
+                    .options(
+                        IndexOptions::builder()
+                            .name("pest_parser_poc_workout_status_time".to_string())
+                            .build(),
+                    )
+                    .build(),
+                IndexModel::builder()
+                    .keys(doc! { "operation": 1, "source_ref": 1, "parsed_at_epoch_seconds": -1 })
+                    .options(
+                        IndexOptions::builder()
+                            .name("pest_parser_poc_workout_operation_source_time".to_string())
+                            .build(),
+                    )
+                    .build(),
+            ])
+            .await
+            .map_err(|error| IntervalsError::Internal(error.to_string()))?;
+        Ok(())
+    }
+}
+
+impl PestParserPocRepositoryPort for MongoPestParserPocWorkoutRepository {
+    fn insert(&self, record: PestParserPocWorkoutRecord) -> BoxFuture<Result<(), IntervalsError>> {
+        let collection = self.collection.clone();
+        let document = map_record_to_document(record);
+        Box::pin(async move {
+            collection
+                .insert_one(document)
+                .await
+                .map_err(|error| IntervalsError::Internal(error.to_string()))?;
+            Ok(())
+        })
+    }
+}
+
+fn map_record_to_document(record: PestParserPocWorkoutRecord) -> PestParserPocWorkoutDocument {
+    PestParserPocWorkoutDocument {
+        id: None,
+        user_id: record.user_id,
+        direction: match record.direction {
+            PestParserPocDirection::Inbound => "inbound",
+            PestParserPocDirection::Outbound => "outbound",
+        }
+        .to_string(),
+        operation: match record.operation {
+            PestParserPocOperation::ListEvents => "list_events",
+            PestParserPocOperation::GetEvent => "get_event",
+            PestParserPocOperation::CreateEvent => "create_event",
+            PestParserPocOperation::UpdateEvent => "update_event",
+        }
+        .to_string(),
+        source_ref: record.source_ref,
+        source_text: record.source_text,
+        parser_version: record.parser_version,
+        parsed_at_epoch_seconds: record.parsed_at_epoch_seconds,
+        status: match record.status {
+            PestParserPocStatus::Parsed => "parsed",
+            PestParserPocStatus::Failed => "failed",
+        }
+        .to_string(),
+        normalized_workout: record.normalized_workout,
+        parsed_payload: record.parsed_payload,
+        legacy_projection: record.legacy_projection,
+        error_message: record.error_message,
+        error_kind: record.error_kind,
+        intervals_event_id: record.intervals_event_id,
+        http_sync_status: record.http_sync_status,
+    }
+}

--- a/src/domain/intervals/mod.rs
+++ b/src/domain/intervals/mod.rs
@@ -1,4 +1,5 @@
 mod model;
+mod pest_parser_poc;
 mod planned_workout;
 mod ports;
 mod service;
@@ -12,6 +13,11 @@ pub use model::{
     ActivityUploadOperationStatus, ActivityZoneTime, CreateEvent, DateRange, Event, EventCategory,
     EventFileUpload, IntervalsCredentials, IntervalsError, UpdateActivity, UpdateEvent,
     UploadActivity, UploadedActivities,
+};
+pub use pest_parser_poc::{
+    NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation,
+    PestParserPocParsedPayload, PestParserPocRecordContext, PestParserPocRepositoryPort,
+    PestParserPocSource, PestParserPocStatus, PestParserPocWorkoutRecord, PestParserPocWriter,
 };
 pub use planned_workout::{
     parse_planned_workout, parse_planned_workout_days, serialize_planned_workout, PlannedWorkout,

--- a/src/domain/intervals/pest_parser_poc.rs
+++ b/src/domain/intervals/pest_parser_poc.rs
@@ -91,6 +91,7 @@ impl PestParserPocWorkoutRecord {
         context: PestParserPocRecordContext,
         error_message: String,
         error_kind: String,
+        legacy_projection: ParsedWorkoutDoc,
     ) -> Self {
         Self {
             user_id: context.user_id,
@@ -103,7 +104,7 @@ impl PestParserPocWorkoutRecord {
             status: PestParserPocStatus::Failed,
             normalized_workout: None,
             parsed_payload: None,
-            legacy_projection: None,
+            legacy_projection: Some(legacy_projection),
             error_message: Some(error_message),
             error_kind: Some(error_kind),
             intervals_event_id: None,

--- a/src/domain/intervals/pest_parser_poc.rs
+++ b/src/domain/intervals/pest_parser_poc.rs
@@ -1,0 +1,145 @@
+use serde::{Deserialize, Serialize};
+
+use super::{BoxFuture, IntervalsError, ParsedWorkoutDoc};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PestParserPocDirection {
+    Inbound,
+    Outbound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PestParserPocOperation {
+    ListEvents,
+    GetEvent,
+    CreateEvent,
+    UpdateEvent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PestParserPocStatus {
+    Parsed,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PestParserPocSource {
+    pub direction: PestParserPocDirection,
+    pub operation: PestParserPocOperation,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PestParserPocParsedPayload {
+    pub normalized_workout: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PestParserPocWorkoutRecord {
+    pub user_id: String,
+    pub direction: PestParserPocDirection,
+    pub operation: PestParserPocOperation,
+    pub source_ref: Option<String>,
+    pub source_text: String,
+    pub parser_version: String,
+    pub parsed_at_epoch_seconds: i64,
+    pub status: PestParserPocStatus,
+    pub normalized_workout: Option<String>,
+    pub parsed_payload: Option<PestParserPocParsedPayload>,
+    pub legacy_projection: Option<ParsedWorkoutDoc>,
+    pub error_message: Option<String>,
+    pub error_kind: Option<String>,
+    pub intervals_event_id: Option<i64>,
+    pub http_sync_status: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PestParserPocRecordContext {
+    pub user_id: String,
+    pub source: PestParserPocSource,
+    pub source_ref: Option<String>,
+    pub source_text: String,
+    pub parser_version: String,
+    pub parsed_at_epoch_seconds: i64,
+}
+
+impl PestParserPocWorkoutRecord {
+    pub fn parsed(
+        context: PestParserPocRecordContext,
+        normalized_workout: String,
+        legacy_projection: ParsedWorkoutDoc,
+    ) -> Self {
+        Self {
+            user_id: context.user_id,
+            direction: context.source.direction,
+            operation: context.source.operation,
+            source_ref: context.source_ref,
+            source_text: context.source_text,
+            parser_version: context.parser_version,
+            parsed_at_epoch_seconds: context.parsed_at_epoch_seconds,
+            status: PestParserPocStatus::Parsed,
+            normalized_workout: Some(normalized_workout.clone()),
+            parsed_payload: Some(PestParserPocParsedPayload { normalized_workout }),
+            legacy_projection: Some(legacy_projection),
+            error_message: None,
+            error_kind: None,
+            intervals_event_id: None,
+            http_sync_status: None,
+        }
+    }
+
+    pub fn failed(
+        context: PestParserPocRecordContext,
+        error_message: String,
+        error_kind: String,
+    ) -> Self {
+        Self {
+            user_id: context.user_id,
+            direction: context.source.direction,
+            operation: context.source.operation,
+            source_ref: context.source_ref,
+            source_text: context.source_text,
+            parser_version: context.parser_version,
+            parsed_at_epoch_seconds: context.parsed_at_epoch_seconds,
+            status: PestParserPocStatus::Failed,
+            normalized_workout: None,
+            parsed_payload: None,
+            legacy_projection: None,
+            error_message: Some(error_message),
+            error_kind: Some(error_kind),
+            intervals_event_id: None,
+            http_sync_status: None,
+        }
+    }
+}
+
+pub trait PestParserPocRepositoryPort: Clone + Send + Sync + 'static {
+    fn insert(&self, record: PestParserPocWorkoutRecord) -> BoxFuture<Result<(), IntervalsError>>;
+}
+
+pub trait PestParserPocWriter: Send + Sync + 'static {
+    fn insert_record(
+        &self,
+        record: PestParserPocWorkoutRecord,
+    ) -> BoxFuture<Result<(), IntervalsError>>;
+}
+
+impl<T> PestParserPocWriter for T
+where
+    T: PestParserPocRepositoryPort,
+{
+    fn insert_record(
+        &self,
+        record: PestParserPocWorkoutRecord,
+    ) -> BoxFuture<Result<(), IntervalsError>> {
+        self.insert(record)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NoopPestParserPocRepository;
+
+impl PestParserPocRepositoryPort for NoopPestParserPocRepository {
+    fn insert(&self, _record: PestParserPocWorkoutRecord) -> BoxFuture<Result<(), IntervalsError>> {
+        Box::pin(async { Ok(()) })
+    }
+}

--- a/src/domain/intervals/service.rs
+++ b/src/domain/intervals/service.rs
@@ -298,9 +298,12 @@ where
                 normalize_workout_text(&source_text),
                 legacy_projection,
             ),
-            Err(error) => {
-                PestParserPocWorkoutRecord::failed(context, error.to_string(), "syntax".to_string())
-            }
+            Err(error) => PestParserPocWorkoutRecord::failed(
+                context,
+                error.to_string(),
+                "syntax".to_string(),
+                legacy_projection,
+            ),
         };
 
         if let Err(error) = repository.insert(record).await {

--- a/src/domain/intervals/service.rs
+++ b/src/domain/intervals/service.rs
@@ -9,9 +9,14 @@ use super::{
     ports::{ActivityFileIdentityExtractorPort, BoxFuture},
     Activity, ActivityRepositoryPort, ActivityUploadOperation, ActivityUploadOperationClaimResult,
     ActivityUploadOperationRepositoryPort, ActivityUploadOperationStatus, CreateEvent, DateRange,
-    EnrichedEvent, Event, IntervalsApiPort, IntervalsError, IntervalsSettingsPort, UpdateActivity,
+    EnrichedEvent, Event, IntervalsApiPort, IntervalsError, IntervalsSettingsPort,
+    NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation,
+    PestParserPocRepositoryPort, PestParserPocSource, PestParserPocWorkoutRecord, UpdateActivity,
     UpdateEvent, UploadActivity, UploadedActivities,
 };
+use crate::domain::identity::Clock;
+use crate::domain::intervals::workout::parse_workout_ast;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::warn;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -152,23 +157,42 @@ pub trait IntervalsUseCases: Send + Sync {
 }
 
 #[derive(Clone)]
-pub struct IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
-where
+pub struct IntervalsService<
+    Api,
+    Settings,
+    Activities,
+    UploadOperations,
+    Extractor,
+    PocRepo = NoopPestParserPocRepository,
+    Time = LiveClock,
+> where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     api: Api,
     settings: Settings,
     activities: Activities,
     upload_operations: UploadOperations,
     identity_extractor: Extractor,
+    pest_parser_poc_repository: Option<PocRepo>,
+    clock: Time,
 }
 
 impl<Api, Settings, Activities, UploadOperations, Extractor>
-    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+    IntervalsService<
+        Api,
+        Settings,
+        Activities,
+        UploadOperations,
+        Extractor,
+        NoopPestParserPocRepository,
+        LiveClock,
+    >
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
@@ -189,18 +213,134 @@ where
             activities,
             upload_operations,
             identity_extractor,
+            pest_parser_poc_repository: None,
+            clock: LiveClock,
         }
     }
 }
 
-impl<Api, Settings, Activities, UploadOperations, Extractor> IntervalsUseCases
-    for IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
+{
+    pub fn with_pest_parser_poc_repository<Repo>(
+        self,
+        repository: Repo,
+    ) -> IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, Repo, Time>
+    where
+        Repo: PestParserPocRepositoryPort,
+    {
+        IntervalsService {
+            api: self.api,
+            settings: self.settings,
+            activities: self.activities,
+            upload_operations: self.upload_operations,
+            identity_extractor: self.identity_extractor,
+            pest_parser_poc_repository: Some(repository),
+            clock: self.clock,
+        }
+    }
+
+    pub fn with_clock<NewTime>(
+        self,
+        clock: NewTime,
+    ) -> IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, NewTime>
+    where
+        NewTime: Clock,
+    {
+        IntervalsService {
+            api: self.api,
+            settings: self.settings,
+            activities: self.activities,
+            upload_operations: self.upload_operations,
+            identity_extractor: self.identity_extractor,
+            pest_parser_poc_repository: self.pest_parser_poc_repository,
+            clock,
+        }
+    }
+
+    pub(super) async fn observe_workout_text(
+        &self,
+        user_id: &str,
+        source: PestParserPocSource,
+        source_ref: Option<String>,
+        workout_text: Option<&str>,
+    ) {
+        let Some(repository) = &self.pest_parser_poc_repository else {
+            return;
+        };
+        let Some(workout_text) = workout_text.filter(|value| !value.trim().is_empty()) else {
+            return;
+        };
+
+        let parsed_at_epoch_seconds = self.clock.now_epoch_seconds();
+        let parser_version = "pest-parser-poc-v1".to_string();
+        let source_text = workout_text.trim().to_string();
+        let legacy_projection = parse_workout_doc(Some(&source_text), None);
+        let context = super::PestParserPocRecordContext {
+            user_id: user_id.to_string(),
+            source,
+            source_ref,
+            source_text: source_text.clone(),
+            parser_version,
+            parsed_at_epoch_seconds,
+        };
+        let record = match parse_workout_ast(&source_text) {
+            Ok(_) => PestParserPocWorkoutRecord::parsed(
+                context,
+                normalize_workout_text(&source_text),
+                legacy_projection,
+            ),
+            Err(error) => {
+                PestParserPocWorkoutRecord::failed(context, error.to_string(), "syntax".to_string())
+            }
+        };
+
+        if let Err(error) = repository.insert(record).await {
+            tracing::error!(%user_id, %error, "failed to persist pest parser poc workout record");
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct LiveClock;
+
+impl Clock for LiveClock {
+    fn now_epoch_seconds(&self) -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    }
+}
+
+fn normalize_workout_text(input: &str) -> String {
+    input
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches('-').trim())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time> IntervalsUseCases
+    for IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+where
+    Api: IntervalsApiPort,
+    Settings: IntervalsSettingsPort,
+    Activities: ActivityRepositoryPort,
+    UploadOperations: ActivityUploadOperationRepositoryPort,
+    Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     fn list_events(
         &self,

--- a/src/domain/intervals/service/activities.rs
+++ b/src/domain/intervals/service/activities.rs
@@ -1,13 +1,15 @@
 use super::*;
 
-impl<Api, Settings, Activities, UploadOperations, Extractor>
-    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     pub(super) async fn list_activities_impl(
         &self,

--- a/src/domain/intervals/service/enriched.rs
+++ b/src/domain/intervals/service/enriched.rs
@@ -1,13 +1,15 @@
 use super::*;
 
-impl<Api, Settings, Activities, UploadOperations, Extractor>
-    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     pub(super) async fn get_enriched_event_impl(
         &self,

--- a/src/domain/intervals/service/events.rs
+++ b/src/domain/intervals/service/events.rs
@@ -69,6 +69,7 @@ where
             event
                 .workout_doc
                 .as_deref()
+                .filter(|text| !text.trim().is_empty())
                 .or(event.description.as_deref()),
         )
         .await;
@@ -92,6 +93,7 @@ where
             event
                 .workout_doc
                 .as_deref()
+                .filter(|text| !text.trim().is_empty())
                 .or(event.description.as_deref()),
         )
         .await;

--- a/src/domain/intervals/service/events.rs
+++ b/src/domain/intervals/service/events.rs
@@ -1,13 +1,15 @@
 use super::*;
 
-impl<Api, Settings, Activities, UploadOperations, Extractor>
-    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     pub(super) async fn list_events_impl(
         &self,
@@ -15,7 +17,20 @@ where
         range: &DateRange,
     ) -> Result<Vec<Event>, IntervalsError> {
         let credentials = self.settings.get_credentials(user_id).await?;
-        self.api.list_events(&credentials, range).await
+        let events = self.api.list_events(&credentials, range).await?;
+        for event in &events {
+            self.observe_workout_text(
+                user_id,
+                PestParserPocSource {
+                    direction: PestParserPocDirection::Inbound,
+                    operation: PestParserPocOperation::ListEvents,
+                },
+                Some(event.id.to_string()),
+                event.structured_workout_text(),
+            )
+            .await;
+        }
+        Ok(events)
     }
 
     pub(super) async fn get_event_impl(
@@ -24,7 +39,18 @@ where
         event_id: i64,
     ) -> Result<Event, IntervalsError> {
         let credentials = self.settings.get_credentials(user_id).await?;
-        self.api.get_event(&credentials, event_id).await
+        let event = self.api.get_event(&credentials, event_id).await?;
+        self.observe_workout_text(
+            user_id,
+            PestParserPocSource {
+                direction: PestParserPocDirection::Inbound,
+                operation: PestParserPocOperation::GetEvent,
+            },
+            Some(event.id.to_string()),
+            event.structured_workout_text(),
+        )
+        .await;
+        Ok(event)
     }
 
     pub(super) async fn create_event_impl(
@@ -33,6 +59,19 @@ where
         event: CreateEvent,
     ) -> Result<Event, IntervalsError> {
         let credentials = self.settings.get_credentials(user_id).await?;
+        self.observe_workout_text(
+            user_id,
+            PestParserPocSource {
+                direction: PestParserPocDirection::Outbound,
+                operation: PestParserPocOperation::CreateEvent,
+            },
+            None,
+            event
+                .workout_doc
+                .as_deref()
+                .or(event.description.as_deref()),
+        )
+        .await;
         self.api.create_event(&credentials, event).await
     }
 
@@ -43,6 +82,19 @@ where
         event: UpdateEvent,
     ) -> Result<Event, IntervalsError> {
         let credentials = self.settings.get_credentials(user_id).await?;
+        self.observe_workout_text(
+            user_id,
+            PestParserPocSource {
+                direction: PestParserPocDirection::Outbound,
+                operation: PestParserPocOperation::UpdateEvent,
+            },
+            Some(event_id.to_string()),
+            event
+                .workout_doc
+                .as_deref()
+                .or(event.description.as_deref()),
+        )
+        .await;
         self.api.update_event(&credentials, event_id, event).await
     }
 

--- a/src/domain/intervals/service/upload.rs
+++ b/src/domain/intervals/service/upload.rs
@@ -1,13 +1,15 @@
 use super::*;
 
-impl<Api, Settings, Activities, UploadOperations, Extractor>
-    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor>
+impl<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+    IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
 where
     Api: IntervalsApiPort,
     Settings: IntervalsSettingsPort,
     Activities: ActivityRepositoryPort,
     UploadOperations: ActivityUploadOperationRepositoryPort,
     Extractor: ActivityFileIdentityExtractorPort,
+    PocRepo: PestParserPocRepositoryPort,
+    Time: Clock,
 {
     pub(super) async fn recover_uploaded_operation(
         &self,

--- a/src/domain/intervals/workout.rs
+++ b/src/domain/intervals/workout.rs
@@ -93,7 +93,9 @@ fn round_to(value: f64, decimals: u32) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::pest_parser::{parse_workout_ast, ParserTarget, StepAmount, StepKind, WorkoutItem};
+    use super::pest_parser::{
+        parse_workout_ast, CadenceRange, ParserTarget, StepAmount, StepKind, WorkoutItem,
+    };
 
     #[test]
     fn pest_parser_parses_simple_ftp_workout() {
@@ -121,6 +123,38 @@ mod tests {
     }
 
     #[test]
+    fn pest_parser_supports_hour_and_second_units() {
+        let hour = parse_workout_ast("- 1h 95%").expect("hour parse should succeed");
+        let seconds = parse_workout_ast("- 30s 55%").expect("seconds parse should succeed");
+
+        let WorkoutItem::Step(hour_step) = &hour.items[0] else {
+            panic!("expected hour step item");
+        };
+        let WorkoutItem::Step(seconds_step) = &seconds.items[0] else {
+            panic!("expected seconds step item");
+        };
+
+        assert_eq!(hour_step.amount, StepAmount::DurationMinutes(60));
+        assert_eq!(seconds_step.amount, StepAmount::DurationMinutes(1));
+    }
+
+    #[test]
+    fn pest_parser_supports_meter_and_mile_distances() {
+        let meters = parse_workout_ast("- 400mtr 55%").expect("meters parse");
+        let miles = parse_workout_ast("- 1mi 8:00/mi Pace").expect("miles parse");
+
+        let WorkoutItem::Step(meter_step) = &meters.items[0] else {
+            panic!("expected meter step item");
+        };
+        let WorkoutItem::Step(mile_step) = &miles.items[0] else {
+            panic!("expected mile step item");
+        };
+
+        assert_eq!(meter_step.amount, StepAmount::DistanceKilometers(0.4));
+        assert_eq!(mile_step.amount, StepAmount::DistanceKilometers(1.609_344));
+    }
+
+    #[test]
     fn pest_parser_parses_repeat_block() {
         let parsed =
             parse_workout_ast("Main Set 4x\n- 2m 95%\n- 2m 55%").expect("parse should succeed");
@@ -133,6 +167,13 @@ mod tests {
         let error = parse_workout_ast("- 10m ???").expect_err("parse should fail");
 
         assert!(!error.to_string().is_empty());
+    }
+
+    #[test]
+    fn pest_parser_rejects_zero_repeat_count() {
+        let error = parse_workout_ast("Main Set 0x\n- 2m 95%").expect_err("parse should fail");
+
+        assert!(error.to_string().contains("repeat count"));
     }
 
     #[test]
@@ -154,8 +195,8 @@ mod tests {
 
     #[test]
     fn pest_parser_parses_hr_and_lthr_targets() {
-        let hr = parse_workout_ast("- 20m 75-80% HR").expect("hr parse");
-        let lthr = parse_workout_ast("- 20m 90-95% LTHR").expect("lthr parse");
+        let hr = parse_workout_ast("- 20m 75-80% Hr").expect("hr parse");
+        let lthr = parse_workout_ast("- 20m 90-95% lThR").expect("lthr parse");
 
         let WorkoutItem::Step(hr_step) = &hr.items[0] else {
             panic!("expected hr step item");
@@ -182,7 +223,7 @@ mod tests {
 
     #[test]
     fn pest_parser_parses_ramp_cadence_and_text_metadata() {
-        let parsed = parse_workout_ast("- Warmup 10m ramp 50-70% 90rpm text=\"Relax shoulders\"")
+        let parsed = parse_workout_ast("- Warmup 10m ramp 50-70% 90RpM text=\"Relax shoulders\"")
             .expect("parse should succeed");
 
         let WorkoutItem::Step(step) = &parsed.items[0] else {
@@ -198,7 +239,13 @@ mod tests {
                 max: 70.0,
             })
         );
-        assert_eq!(step.cadence_rpm, Some((90, 90)));
+        assert_eq!(
+            step.cadence_rpm,
+            Some(CadenceRange {
+                min_rpm: 90,
+                max_rpm: 90,
+            })
+        );
         assert_eq!(step.text.as_deref(), Some("Relax shoulders"));
     }
 
@@ -212,5 +259,13 @@ mod tests {
         };
 
         assert_eq!(step.text.as_deref(), Some("Relax \"now\""));
+    }
+
+    #[test]
+    fn pest_parser_rejects_multiline_text_metadata() {
+        let error = parse_workout_ast("- Warmup 10m text=\"line one\nline two\"")
+            .expect_err("parse should fail");
+
+        assert!(!error.to_string().is_empty());
     }
 }

--- a/src/domain/intervals/workout.rs
+++ b/src/domain/intervals/workout.rs
@@ -166,6 +166,40 @@ mod tests {
     }
 
     #[test]
+    fn pest_parser_rejects_non_positive_time_amounts() {
+        let zero_minutes = parse_workout_ast("- 0m 55%").expect_err("0m should fail");
+        let zero_hours = parse_workout_ast("- 0h 55%").expect_err("0h should fail");
+        let zero_seconds = parse_workout_ast("- 0s 55%").expect_err("0s should fail");
+
+        assert!(zero_minutes
+            .to_string()
+            .contains("time amount must be positive"));
+        assert!(zero_hours
+            .to_string()
+            .contains("time amount must be positive"));
+        assert!(zero_seconds
+            .to_string()
+            .contains("time amount must be positive"));
+    }
+
+    #[test]
+    fn pest_parser_rejects_non_positive_distance_amounts() {
+        let zero_km = parse_workout_ast("- 0km 55%").expect_err("0km should fail");
+        let zero_meters = parse_workout_ast("- 0mtr 55%").expect_err("0mtr should fail");
+        let zero_miles = parse_workout_ast("- 0mi 8:00/mi Pace").expect_err("0mi should fail");
+
+        assert!(zero_km
+            .to_string()
+            .contains("distance amount must be positive"));
+        assert!(zero_meters
+            .to_string()
+            .contains("distance amount must be positive"));
+        assert!(zero_miles
+            .to_string()
+            .contains("distance amount must be positive"));
+    }
+
+    #[test]
     fn pest_parser_parses_repeat_block() {
         let parsed =
             parse_workout_ast("Main Set 4x\n- 2m 95%\n- 2m 55%").expect("parse should succeed");

--- a/src/domain/intervals/workout.rs
+++ b/src/domain/intervals/workout.rs
@@ -139,6 +139,17 @@ mod tests {
     }
 
     #[test]
+    fn pest_parser_normalizes_arbitrary_second_granularity() {
+        let parsed = parse_workout_ast("- 45s 55%").expect("parse should succeed");
+
+        let WorkoutItem::Step(step) = &parsed.items[0] else {
+            panic!("expected step item");
+        };
+
+        assert_eq!(step.amount, StepAmount::DurationMinutes(1));
+    }
+
+    #[test]
     fn pest_parser_supports_meter_and_mile_distances() {
         let meters = parse_workout_ast("- 400mtr 55%").expect("meters parse");
         let miles = parse_workout_ast("- 1mi 8:00/mi Pace").expect("miles parse");
@@ -160,6 +171,31 @@ mod tests {
             parse_workout_ast("Main Set 4x\n- 2m 95%\n- 2m 55%").expect("parse should succeed");
 
         assert_eq!(parsed.items.len(), 1);
+    }
+
+    #[test]
+    fn pest_parser_ends_repeat_block_at_blank_line() {
+        let parsed = parse_workout_ast("Main Set 2x\n- 2m 95%\n- 2m 55%\n\n- 10m 60%")
+            .expect("parse should succeed");
+
+        assert_eq!(parsed.items.len(), 2);
+
+        let WorkoutItem::RepeatBlock(repeat) = &parsed.items[0] else {
+            panic!("expected repeat block item");
+        };
+        let WorkoutItem::Step(step) = &parsed.items[1] else {
+            panic!("expected trailing step item");
+        };
+
+        assert_eq!(repeat.steps.len(), 2);
+        assert_eq!(step.amount, StepAmount::DurationMinutes(10));
+    }
+
+    #[test]
+    fn pest_parser_rejects_repeat_block_without_steps() {
+        let error = parse_workout_ast("Main Set 4x").expect_err("parse should fail");
+
+        assert!(error.to_string().contains("repeat block"));
     }
 
     #[test]

--- a/src/domain/intervals/workout.rs
+++ b/src/domain/intervals/workout.rs
@@ -1,10 +1,12 @@
 mod matching;
 mod parser;
+mod pest_parser;
 
 use serde::{Deserialize, Serialize};
 
 pub use matching::find_best_activity_match;
 pub use parser::parse_workout_doc;
+pub(crate) use pest_parser::parse_workout_ast;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParsedWorkoutDoc {
@@ -87,4 +89,128 @@ pub struct MatchedWorkoutInterval {
 fn round_to(value: f64, decimals: u32) -> f64 {
     let factor = 10_f64.powi(decimals as i32);
     (value * factor).round() / factor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pest_parser::{parse_workout_ast, ParserTarget, StepAmount, StepKind, WorkoutItem};
+
+    #[test]
+    fn pest_parser_parses_simple_ftp_workout() {
+        let parsed = parse_workout_ast("- 10m 95%").expect("parse should succeed");
+
+        assert_eq!(parsed.items.len(), 1);
+    }
+
+    #[test]
+    fn pest_parser_parses_minute_suffix_variant() {
+        let parsed = parse_workout_ast("- 5min 55%").expect("parse should succeed");
+
+        let WorkoutItem::Step(step) = &parsed.items[0] else {
+            panic!("expected step item");
+        };
+
+        assert_eq!(step.amount, StepAmount::DurationMinutes(5));
+        assert_eq!(
+            step.target,
+            Some(ParserTarget::PercentFtp {
+                min: 55.0,
+                max: 55.0,
+            })
+        );
+    }
+
+    #[test]
+    fn pest_parser_parses_repeat_block() {
+        let parsed =
+            parse_workout_ast("Main Set 4x\n- 2m 95%\n- 2m 55%").expect("parse should succeed");
+
+        assert_eq!(parsed.items.len(), 1);
+    }
+
+    #[test]
+    fn pest_parser_rejects_malformed_input_without_panicking() {
+        let error = parse_workout_ast("- 10m ???").expect_err("parse should fail");
+
+        assert!(!error.to_string().is_empty());
+    }
+
+    #[test]
+    fn pest_parser_parses_pace_step() {
+        let parsed = parse_workout_ast("- 5km 5:00/km Pace").expect("parse should succeed");
+
+        let WorkoutItem::Step(step) = &parsed.items[0] else {
+            panic!("expected step item");
+        };
+
+        assert_eq!(step.amount, StepAmount::DistanceKilometers(5.0));
+        assert_eq!(
+            step.target,
+            Some(ParserTarget::Pace {
+                value: "5:00/km".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pest_parser_parses_hr_and_lthr_targets() {
+        let hr = parse_workout_ast("- 20m 75-80% HR").expect("hr parse");
+        let lthr = parse_workout_ast("- 20m 90-95% LTHR").expect("lthr parse");
+
+        let WorkoutItem::Step(hr_step) = &hr.items[0] else {
+            panic!("expected hr step item");
+        };
+        let WorkoutItem::Step(lthr_step) = &lthr.items[0] else {
+            panic!("expected lthr step item");
+        };
+
+        assert_eq!(
+            hr_step.target,
+            Some(ParserTarget::PercentHr {
+                min: 75.0,
+                max: 80.0,
+            })
+        );
+        assert_eq!(
+            lthr_step.target,
+            Some(ParserTarget::PercentLthr {
+                min: 90.0,
+                max: 95.0,
+            })
+        );
+    }
+
+    #[test]
+    fn pest_parser_parses_ramp_cadence_and_text_metadata() {
+        let parsed = parse_workout_ast("- Warmup 10m ramp 50-70% 90rpm text=\"Relax shoulders\"")
+            .expect("parse should succeed");
+
+        let WorkoutItem::Step(step) = &parsed.items[0] else {
+            panic!("expected step item");
+        };
+
+        assert_eq!(step.cue.as_deref(), Some("Warmup"));
+        assert_eq!(step.kind, StepKind::Ramp);
+        assert_eq!(
+            step.target,
+            Some(ParserTarget::PercentFtp {
+                min: 50.0,
+                max: 70.0,
+            })
+        );
+        assert_eq!(step.cadence_rpm, Some((90, 90)));
+        assert_eq!(step.text.as_deref(), Some("Relax shoulders"));
+    }
+
+    #[test]
+    fn pest_parser_parses_escaped_quotes_in_text_metadata() {
+        let parsed = parse_workout_ast("- Warmup 10m text=\"Relax \\\"now\\\"\"")
+            .expect("parse should succeed");
+
+        let WorkoutItem::Step(step) = &parsed.items[0] else {
+            panic!("expected step item");
+        };
+
+        assert_eq!(step.text.as_deref(), Some("Relax \"now\""));
+    }
 }

--- a/src/domain/intervals/workout/pest_parser/ast.rs
+++ b/src/domain/intervals/workout/pest_parser/ast.rs
@@ -16,6 +16,12 @@ pub enum StepKind {
     FreeRide,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CadenceRange {
+    pub min_rpm: i32,
+    pub max_rpm: i32,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParserTarget {
     PercentFtp { min: f64, max: f64 },
@@ -43,7 +49,7 @@ pub struct WorkoutStepAst {
     pub amount: StepAmount,
     pub kind: StepKind,
     pub target: Option<ParserTarget>,
-    pub cadence_rpm: Option<(i32, i32)>,
+    pub cadence_rpm: Option<CadenceRange>,
     pub text: Option<String>,
     pub raw: String,
 }

--- a/src/domain/intervals/workout/pest_parser/ast.rs
+++ b/src/domain/intervals/workout/pest_parser/ast.rs
@@ -1,0 +1,49 @@
+#[derive(Clone, Debug, PartialEq)]
+pub struct WorkoutAst {
+    pub items: Vec<WorkoutItem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StepAmount {
+    DurationMinutes(i32),
+    DistanceKilometers(f64),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StepKind {
+    Steady,
+    Ramp,
+    FreeRide,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParserTarget {
+    PercentFtp { min: f64, max: f64 },
+    PercentHr { min: f64, max: f64 },
+    PercentLthr { min: f64, max: f64 },
+    Pace { value: String },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum WorkoutItem {
+    Step(WorkoutStepAst),
+    RepeatBlock(RepeatBlockAst),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RepeatBlockAst {
+    pub title: Option<String>,
+    pub count: usize,
+    pub steps: Vec<WorkoutStepAst>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct WorkoutStepAst {
+    pub cue: Option<String>,
+    pub amount: StepAmount,
+    pub kind: StepKind,
+    pub target: Option<ParserTarget>,
+    pub cadence_rpm: Option<(i32, i32)>,
+    pub text: Option<String>,
+    pub raw: String,
+}

--- a/src/domain/intervals/workout/pest_parser/error.rs
+++ b/src/domain/intervals/workout/pest_parser/error.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, Debug, PartialEq)]
+pub struct WorkoutPestParseError {
+    message: String,
+}
+
+impl WorkoutPestParseError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for WorkoutPestParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl std::error::Error for WorkoutPestParseError {}

--- a/src/domain/intervals/workout/pest_parser/mod.rs
+++ b/src/domain/intervals/workout/pest_parser/mod.rs
@@ -1,0 +1,7 @@
+mod ast;
+mod error;
+mod parser;
+
+#[cfg(test)]
+pub(crate) use ast::{ParserTarget, StepAmount, StepKind, WorkoutItem};
+pub(crate) use parser::parse_workout_ast;

--- a/src/domain/intervals/workout/pest_parser/mod.rs
+++ b/src/domain/intervals/workout/pest_parser/mod.rs
@@ -3,5 +3,5 @@ mod error;
 mod parser;
 
 #[cfg(test)]
-pub(crate) use ast::{ParserTarget, StepAmount, StepKind, WorkoutItem};
+pub(crate) use ast::{CadenceRange, ParserTarget, StepAmount, StepKind, WorkoutItem};
 pub(crate) use parser::parse_workout_ast;

--- a/src/domain/intervals/workout/pest_parser/parser.rs
+++ b/src/domain/intervals/workout/pest_parser/parser.rs
@@ -25,7 +25,9 @@ pub fn parse_workout_ast(input: &str) -> Result<WorkoutAst, WorkoutPestParseErro
 
     for pair in workout.into_inner() {
         match pair.as_rule() {
-            Rule::blank_line => {}
+            Rule::blank_line => {
+                push_pending_repeat(&mut items, &mut pending_repeat)?;
+            }
             Rule::step_line => {
                 let step = parse_step_line(pair)?;
                 if let Some(repeat) = pending_repeat.as_mut() {
@@ -35,25 +37,37 @@ pub fn parse_workout_ast(input: &str) -> Result<WorkoutAst, WorkoutPestParseErro
                 }
             }
             Rule::repeat_header_line => {
-                if let Some(repeat) = pending_repeat.take() {
-                    items.push(WorkoutItem::RepeatBlock(repeat));
-                }
+                push_pending_repeat(&mut items, &mut pending_repeat)?;
                 pending_repeat = Some(parse_repeat_header(pair)?);
             }
             Rule::text_line => {
-                if let Some(repeat) = pending_repeat.take() {
-                    items.push(WorkoutItem::RepeatBlock(repeat));
-                }
+                push_pending_repeat(&mut items, &mut pending_repeat)?;
             }
             _ => {}
         }
     }
 
-    if let Some(repeat) = pending_repeat {
-        items.push(WorkoutItem::RepeatBlock(repeat));
-    }
+    push_pending_repeat(&mut items, &mut pending_repeat)?;
 
     Ok(WorkoutAst { items })
+}
+
+fn push_pending_repeat(
+    items: &mut Vec<WorkoutItem>,
+    pending_repeat: &mut Option<RepeatBlockAst>,
+) -> Result<(), WorkoutPestParseError> {
+    let Some(repeat) = pending_repeat.take() else {
+        return Ok(());
+    };
+
+    if repeat.steps.is_empty() {
+        return Err(WorkoutPestParseError::new(
+            "repeat block must include at least one step",
+        ));
+    }
+
+    items.push(WorkoutItem::RepeatBlock(repeat));
+    Ok(())
 }
 
 fn parse_step_line(step_line: Pair<'_, Rule>) -> Result<WorkoutStepAst, WorkoutPestParseError> {
@@ -192,12 +206,12 @@ fn parse_time_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
             .checked_mul(60)
             .ok_or_else(|| WorkoutPestParseError::new("invalid time amount"))?,
         "secs" | "sec" | "s" => {
-            if amount <= 0 || amount % 30 != 0 {
+            if amount <= 0 {
                 return Err(WorkoutPestParseError::new(
-                    "time amount in seconds must be a positive multiple of 30",
+                    "time amount in seconds must be positive",
                 ));
             }
-            ((amount + 30) / 60).max(1)
+            ((amount - 1) / 60) + 1
         }
         _ => return Err(WorkoutPestParseError::new("unsupported time unit")),
     };

--- a/src/domain/intervals/workout/pest_parser/parser.rs
+++ b/src/domain/intervals/workout/pest_parser/parser.rs
@@ -4,7 +4,8 @@ use pest_derive::Parser;
 
 use super::{
     ast::{
-        ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst,
+        CadenceRange, ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem,
+        WorkoutStepAst,
     },
     error::WorkoutPestParseError,
 };
@@ -79,13 +80,15 @@ fn parse_repeat_header(
                 }
             }
             Rule::repeat_count => {
-                count = Some(
-                    pair.as_str()
-                        .trim_end_matches('x')
-                        .parse::<usize>()
-                        .map_err(|_| WorkoutPestParseError::new("invalid repeat count"))?
-                        .max(1),
-                );
+                let parsed = pair
+                    .as_str()
+                    .trim_end_matches('x')
+                    .parse::<usize>()
+                    .map_err(|_| WorkoutPestParseError::new("invalid repeat count"))?;
+                if parsed == 0 {
+                    return Err(WorkoutPestParseError::new("invalid repeat count"));
+                }
+                count = Some(parsed);
             }
             _ => {}
         }
@@ -156,23 +159,71 @@ fn parse_step_body(
 }
 
 fn parse_time_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
-    let minutes = value
-        .strip_suffix("mins")
-        .or_else(|| value.strip_suffix("min"))
-        .or_else(|| value.strip_suffix('m'))
-        .ok_or_else(|| WorkoutPestParseError::new("unsupported time unit"))?
+    let lower = value.to_ascii_lowercase();
+    let (raw_amount, unit) = if let Some(amount) = lower.strip_suffix("mins") {
+        (amount, "mins")
+    } else if let Some(amount) = lower.strip_suffix("min") {
+        (amount, "min")
+    } else if let Some(amount) = lower.strip_suffix('m') {
+        (amount, "m")
+    } else if let Some(amount) = lower.strip_suffix("hrs") {
+        (amount, "hrs")
+    } else if let Some(amount) = lower.strip_suffix("hr") {
+        (amount, "hr")
+    } else if let Some(amount) = lower.strip_suffix('h') {
+        (amount, "h")
+    } else if let Some(amount) = lower.strip_suffix("secs") {
+        (amount, "secs")
+    } else if let Some(amount) = lower.strip_suffix("sec") {
+        (amount, "sec")
+    } else if let Some(amount) = lower.strip_suffix('s') {
+        (amount, "s")
+    } else {
+        return Err(WorkoutPestParseError::new("unsupported time unit"));
+    };
+
+    let amount = raw_amount
         .parse::<i32>()
         .map_err(|_| WorkoutPestParseError::new("invalid time amount"))?;
+
+    let minutes = match unit {
+        "mins" | "min" | "m" => amount,
+        "hrs" | "hr" | "h" => amount
+            .checked_mul(60)
+            .ok_or_else(|| WorkoutPestParseError::new("invalid time amount"))?,
+        "secs" | "sec" | "s" => {
+            if amount <= 0 || amount % 30 != 0 {
+                return Err(WorkoutPestParseError::new(
+                    "time amount in seconds must be a positive multiple of 30",
+                ));
+            }
+            ((amount + 30) / 60).max(1)
+        }
+        _ => return Err(WorkoutPestParseError::new("unsupported time unit")),
+    };
 
     Ok(StepAmount::DurationMinutes(minutes))
 }
 
 fn parse_distance_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
-    let kilometers = value
-        .strip_suffix("km")
-        .ok_or_else(|| WorkoutPestParseError::new("unsupported distance unit"))?
-        .parse::<f64>()
-        .map_err(|_| WorkoutPestParseError::new("invalid distance amount"))?;
+    let lower = value.to_ascii_lowercase();
+    let kilometers = if let Some(amount) = lower.strip_suffix("km") {
+        amount
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid distance amount"))?
+    } else if let Some(amount) = lower.strip_suffix("mtr") {
+        amount
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid distance amount"))?
+            / 1000.0
+    } else if let Some(amount) = lower.strip_suffix("mi") {
+        amount
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid distance amount"))?
+            * 1.609_344
+    } else {
+        return Err(WorkoutPestParseError::new("unsupported distance unit"));
+    };
 
     Ok(StepAmount::DistanceKilometers(kilometers))
 }
@@ -205,11 +256,11 @@ fn parse_target_pair(pair: Pair<'_, Rule>) -> Result<ParserTarget, WorkoutPestPa
     }
 }
 
-fn parse_cadence_pair(pair: Pair<'_, Rule>) -> Result<(i32, i32), WorkoutPestParseError> {
-    let raw = pair
-        .as_str()
-        .trim_end_matches("rpm")
-        .trim_end_matches("RPM");
+fn parse_cadence_pair(pair: Pair<'_, Rule>) -> Result<CadenceRange, WorkoutPestParseError> {
+    let lower = pair.as_str().to_ascii_lowercase();
+    let raw = lower
+        .strip_suffix("rpm")
+        .ok_or_else(|| WorkoutPestParseError::new("invalid cadence value"))?;
     if let Some((start, end)) = raw.split_once('-') {
         let start = start
             .parse::<i32>()
@@ -217,13 +268,19 @@ fn parse_cadence_pair(pair: Pair<'_, Rule>) -> Result<(i32, i32), WorkoutPestPar
         let end = end
             .parse::<i32>()
             .map_err(|_| WorkoutPestParseError::new("invalid cadence value"))?;
-        return Ok((start.min(end), start.max(end)));
+        return Ok(CadenceRange {
+            min_rpm: start.min(end),
+            max_rpm: start.max(end),
+        });
     }
 
     let cadence = raw
         .parse::<i32>()
         .map_err(|_| WorkoutPestParseError::new("invalid cadence value"))?;
-    Ok((cadence, cadence))
+    Ok(CadenceRange {
+        min_rpm: cadence,
+        max_rpm: cadence,
+    })
 }
 
 fn parse_text_metadata_pair(pair: Pair<'_, Rule>) -> Result<String, WorkoutPestParseError> {
@@ -250,10 +307,11 @@ fn parse_percent_target(
     value: &str,
     kind: PercentTargetKind,
 ) -> Result<ParserTarget, WorkoutPestParseError> {
-    let raw = value
+    let lower = value.to_ascii_lowercase();
+    let raw = lower
         .trim()
-        .trim_end_matches("LTHR")
-        .trim_end_matches("HR")
+        .trim_end_matches("lthr")
+        .trim_end_matches("hr")
         .trim()
         .trim_end_matches('%');
     let (min, max) = if let Some((start, end)) = raw.split_once('-') {

--- a/src/domain/intervals/workout/pest_parser/parser.rs
+++ b/src/domain/intervals/workout/pest_parser/parser.rs
@@ -201,15 +201,19 @@ fn parse_time_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
         .map_err(|_| WorkoutPestParseError::new("invalid time amount"))?;
 
     let minutes = match unit {
-        "mins" | "min" | "m" => amount,
+        "mins" | "min" | "m" => {
+            if amount <= 0 {
+                return Err(WorkoutPestParseError::new("time amount must be positive"));
+            }
+            amount
+        }
         "hrs" | "hr" | "h" => amount
             .checked_mul(60)
-            .ok_or_else(|| WorkoutPestParseError::new("invalid time amount"))?,
+            .filter(|minutes| *minutes > 0)
+            .ok_or_else(|| WorkoutPestParseError::new("time amount must be positive"))?,
         "secs" | "sec" | "s" => {
             if amount <= 0 {
-                return Err(WorkoutPestParseError::new(
-                    "time amount in seconds must be positive",
-                ));
+                return Err(WorkoutPestParseError::new("time amount must be positive"));
             }
             ((amount - 1) / 60) + 1
         }
@@ -238,6 +242,12 @@ fn parse_distance_amount(value: &str) -> Result<StepAmount, WorkoutPestParseErro
     } else {
         return Err(WorkoutPestParseError::new("unsupported distance unit"));
     };
+
+    if kilometers <= 0.0 {
+        return Err(WorkoutPestParseError::new(
+            "distance amount must be positive",
+        ));
+    }
 
     Ok(StepAmount::DistanceKilometers(kilometers))
 }

--- a/src/domain/intervals/workout/pest_parser/parser.rs
+++ b/src/domain/intervals/workout/pest_parser/parser.rs
@@ -1,0 +1,307 @@
+use pest::iterators::Pair;
+use pest::Parser;
+use pest_derive::Parser;
+
+use super::{
+    ast::{
+        ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst,
+    },
+    error::WorkoutPestParseError,
+};
+
+#[derive(Parser)]
+#[grammar = "domain/intervals/workout/pest_parser/workout.pest"]
+struct WorkoutDocParser;
+
+pub fn parse_workout_ast(input: &str) -> Result<WorkoutAst, WorkoutPestParseError> {
+    let mut pairs = WorkoutDocParser::parse(Rule::workout, input)
+        .map_err(|error| WorkoutPestParseError::new(format!("invalid workout syntax: {error}")))?;
+    let workout = pairs
+        .next()
+        .ok_or_else(|| WorkoutPestParseError::new("missing workout document"))?;
+    let mut items = Vec::new();
+    let mut pending_repeat: Option<RepeatBlockAst> = None;
+
+    for pair in workout.into_inner() {
+        match pair.as_rule() {
+            Rule::blank_line => {}
+            Rule::step_line => {
+                let step = parse_step_line(pair)?;
+                if let Some(repeat) = pending_repeat.as_mut() {
+                    repeat.steps.push(step);
+                } else {
+                    items.push(WorkoutItem::Step(step));
+                }
+            }
+            Rule::repeat_header_line => {
+                if let Some(repeat) = pending_repeat.take() {
+                    items.push(WorkoutItem::RepeatBlock(repeat));
+                }
+                pending_repeat = Some(parse_repeat_header(pair)?);
+            }
+            Rule::text_line => {
+                if let Some(repeat) = pending_repeat.take() {
+                    items.push(WorkoutItem::RepeatBlock(repeat));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(repeat) = pending_repeat {
+        items.push(WorkoutItem::RepeatBlock(repeat));
+    }
+
+    Ok(WorkoutAst { items })
+}
+
+fn parse_step_line(step_line: Pair<'_, Rule>) -> Result<WorkoutStepAst, WorkoutPestParseError> {
+    let raw = step_line.as_str().trim();
+    let step_body = step_line
+        .into_inner()
+        .find(|pair| pair.as_rule() == Rule::step_body)
+        .ok_or_else(|| WorkoutPestParseError::new("missing step body"))?;
+    parse_step_body(step_body, raw)
+}
+
+fn parse_repeat_header(
+    header_line: Pair<'_, Rule>,
+) -> Result<RepeatBlockAst, WorkoutPestParseError> {
+    let mut title = None;
+    let mut count = None;
+
+    for pair in header_line.into_inner() {
+        match pair.as_rule() {
+            Rule::repeat_title => {
+                let value = pair.as_str().trim();
+                if !value.is_empty() {
+                    title = Some(value.to_string());
+                }
+            }
+            Rule::repeat_count => {
+                count = Some(
+                    pair.as_str()
+                        .trim_end_matches('x')
+                        .parse::<usize>()
+                        .map_err(|_| WorkoutPestParseError::new("invalid repeat count"))?
+                        .max(1),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    Ok(RepeatBlockAst {
+        title,
+        count: count.ok_or_else(|| WorkoutPestParseError::new("missing repeat count"))?,
+        steps: Vec::new(),
+    })
+}
+
+fn parse_step_body(
+    step_body: Pair<'_, Rule>,
+    original_line: &str,
+) -> Result<WorkoutStepAst, WorkoutPestParseError> {
+    let mut cue = None;
+    let mut amount = None;
+    let mut kind = StepKind::Steady;
+    let mut target = None;
+    let mut cadence_rpm = None;
+    let mut text = None;
+
+    for pair in step_body.into_inner() {
+        match pair.as_rule() {
+            Rule::cue_prefix => {
+                let value = pair.as_str().trim();
+                if !value.is_empty() {
+                    cue = Some(value.to_string());
+                }
+            }
+            Rule::amount => {
+                amount = Some(parse_amount_pair(pair)?);
+            }
+            Rule::modifier => {
+                kind = parse_kind_pair(pair)?;
+            }
+            Rule::target => {
+                target = Some(parse_target_pair(pair)?);
+            }
+            Rule::cadence => {
+                cadence_rpm = Some(parse_cadence_pair(pair)?);
+            }
+            Rule::text_metadata => {
+                text = Some(parse_text_metadata_pair(pair)?);
+            }
+            _ => {}
+        }
+    }
+
+    let amount = amount.ok_or_else(|| {
+        WorkoutPestParseError::new(format!("invalid workout syntax: {original_line}"))
+    })?;
+
+    Ok(WorkoutStepAst {
+        cue,
+        amount,
+        kind,
+        target,
+        cadence_rpm,
+        text,
+        raw: original_line
+            .trim()
+            .trim_start_matches('-')
+            .trim()
+            .to_string(),
+    })
+}
+
+fn parse_time_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
+    let minutes = value
+        .strip_suffix("mins")
+        .or_else(|| value.strip_suffix("min"))
+        .or_else(|| value.strip_suffix('m'))
+        .ok_or_else(|| WorkoutPestParseError::new("unsupported time unit"))?
+        .parse::<i32>()
+        .map_err(|_| WorkoutPestParseError::new("invalid time amount"))?;
+
+    Ok(StepAmount::DurationMinutes(minutes))
+}
+
+fn parse_distance_amount(value: &str) -> Result<StepAmount, WorkoutPestParseError> {
+    let kilometers = value
+        .strip_suffix("km")
+        .ok_or_else(|| WorkoutPestParseError::new("unsupported distance unit"))?
+        .parse::<f64>()
+        .map_err(|_| WorkoutPestParseError::new("invalid distance amount"))?;
+
+    Ok(StepAmount::DistanceKilometers(kilometers))
+}
+
+fn parse_kind_pair(pair: Pair<'_, Rule>) -> Result<StepKind, WorkoutPestParseError> {
+    let modifier = pair
+        .into_inner()
+        .next()
+        .ok_or_else(|| WorkoutPestParseError::new("missing step modifier"))?;
+
+    match modifier.as_rule() {
+        Rule::ramp => Ok(StepKind::Ramp),
+        Rule::freeride => Ok(StepKind::FreeRide),
+        _ => Err(WorkoutPestParseError::new("invalid step modifier")),
+    }
+}
+
+fn parse_target_pair(pair: Pair<'_, Rule>) -> Result<ParserTarget, WorkoutPestParseError> {
+    let target = pair
+        .into_inner()
+        .next()
+        .ok_or_else(|| WorkoutPestParseError::new("missing target"))?;
+
+    match target.as_rule() {
+        Rule::ftp_target => parse_percent_target(target.as_str(), PercentTargetKind::Ftp),
+        Rule::hr_target => parse_percent_target(target.as_str(), PercentTargetKind::Hr),
+        Rule::lthr_target => parse_percent_target(target.as_str(), PercentTargetKind::Lthr),
+        Rule::pace_target => parse_pace_target(target),
+        _ => Err(WorkoutPestParseError::new("invalid target")),
+    }
+}
+
+fn parse_cadence_pair(pair: Pair<'_, Rule>) -> Result<(i32, i32), WorkoutPestParseError> {
+    let raw = pair
+        .as_str()
+        .trim_end_matches("rpm")
+        .trim_end_matches("RPM");
+    if let Some((start, end)) = raw.split_once('-') {
+        let start = start
+            .parse::<i32>()
+            .map_err(|_| WorkoutPestParseError::new("invalid cadence value"))?;
+        let end = end
+            .parse::<i32>()
+            .map_err(|_| WorkoutPestParseError::new("invalid cadence value"))?;
+        return Ok((start.min(end), start.max(end)));
+    }
+
+    let cadence = raw
+        .parse::<i32>()
+        .map_err(|_| WorkoutPestParseError::new("invalid cadence value"))?;
+    Ok((cadence, cadence))
+}
+
+fn parse_text_metadata_pair(pair: Pair<'_, Rule>) -> Result<String, WorkoutPestParseError> {
+    let quoted = pair
+        .into_inner()
+        .find(|inner| inner.as_rule() == Rule::quoted_string)
+        .ok_or_else(|| WorkoutPestParseError::new("missing text metadata"))?;
+    let raw = quoted.as_str();
+    let unquoted = raw
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .ok_or_else(|| WorkoutPestParseError::new("invalid text metadata"))?;
+
+    Ok(unquoted.replace("\\\"", "\""))
+}
+
+enum PercentTargetKind {
+    Ftp,
+    Hr,
+    Lthr,
+}
+
+fn parse_percent_target(
+    value: &str,
+    kind: PercentTargetKind,
+) -> Result<ParserTarget, WorkoutPestParseError> {
+    let raw = value
+        .trim()
+        .trim_end_matches("LTHR")
+        .trim_end_matches("HR")
+        .trim()
+        .trim_end_matches('%');
+    let (min, max) = if let Some((start, end)) = raw.split_once('-') {
+        let start = start
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid percent target"))?;
+        let end = end
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid percent target"))?;
+        (start.min(end), start.max(end))
+    } else {
+        let value = raw
+            .parse::<f64>()
+            .map_err(|_| WorkoutPestParseError::new("invalid percent target"))?;
+        (value, value)
+    };
+
+    let target = match kind {
+        PercentTargetKind::Ftp => ParserTarget::PercentFtp { min, max },
+        PercentTargetKind::Hr => ParserTarget::PercentHr { min, max },
+        PercentTargetKind::Lthr => ParserTarget::PercentLthr { min, max },
+    };
+
+    Ok(target)
+}
+
+fn parse_pace_target(pair: Pair<'_, Rule>) -> Result<ParserTarget, WorkoutPestParseError> {
+    let pace_value = pair
+        .into_inner()
+        .find(|inner| inner.as_rule() == Rule::pace_value)
+        .ok_or_else(|| WorkoutPestParseError::new("missing pace value"))?;
+
+    Ok(ParserTarget::Pace {
+        value: pace_value.as_str().to_string(),
+    })
+}
+
+fn parse_amount_pair(pair: Pair<'_, Rule>) -> Result<StepAmount, WorkoutPestParseError> {
+    let amount = pair
+        .into_inner()
+        .next()
+        .ok_or_else(|| WorkoutPestParseError::new("missing amount"))?;
+
+    match amount.as_rule() {
+        Rule::distance_amount => parse_distance_amount(amount.as_str()),
+        Rule::time_amount => parse_time_amount(amount.as_str()),
+        _ => Err(WorkoutPestParseError::new("unsupported amount")),
+    }
+}

--- a/src/domain/intervals/workout/pest_parser/workout.pest
+++ b/src/domain/intervals/workout/pest_parser/workout.pest
@@ -19,8 +19,8 @@ ramp = { ^"ramp" }
 freeride = { ^"freeride" }
 
 amount = { time_amount | distance_amount }
-time_amount = @{ ASCII_DIGIT+ ~ ("hrs" | "hr" | "h" | "mins" | "min" | "m" | "secs" | "sec" | "s") }
-distance_amount = @{ ASCII_DIGIT+ ~ ("km" | "mtr" | "mi") }
+time_amount = @{ ASCII_DIGIT+ ~ ("hrs" | "hr" | "h" | "mins" | "min" | "m" | "secs" | "sec" | "s") ~ !ASCII_ALPHA }
+distance_amount = @{ ASCII_DIGIT+ ~ ("km" | "mtr" | "mi") ~ !ASCII_ALPHA }
 
 target = { hr_target | lthr_target | pace_target | ftp_target }
 ftp_target = @{ number ~ ("-" ~ number)? ~ "%" }
@@ -31,7 +31,7 @@ pace_value = @{ ASCII_DIGIT+ ~ ":" ~ ASCII_DIGIT+ ~ "/" ~ ("km" | "mi" | "100m" 
 
 cadence = @{ ASCII_DIGIT+ ~ ("-" ~ ASCII_DIGIT+)? ~ ^"rpm" }
 text_metadata = { ^"text" ~ "=" ~ quoted_string }
-quoted_string = @{ "\"" ~ ( "\\\"" | !("\"") ~ ANY )* ~ "\"" }
+quoted_string = @{ "\"" ~ ( "\\\"" | !NEWLINE ~ !("\"") ~ ANY )* ~ "\"" }
 
 number = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 line_end = _{ NEWLINE | EOI }

--- a/src/domain/intervals/workout/pest_parser/workout.pest
+++ b/src/domain/intervals/workout/pest_parser/workout.pest
@@ -1,0 +1,37 @@
+WHITESPACE = _{ " " | "\t" }
+NEWLINE = _{ "\r\n" | "\n" }
+
+workout = { SOI ~ line* ~ EOI }
+line = _{ blank_line | repeat_header_line | step_line | text_line }
+
+blank_line = { WHITESPACE* ~ NEWLINE }
+repeat_header_line = { WHITESPACE* ~ repeat_title? ~ repeat_count ~ WHITESPACE* ~ line_end }
+step_line = { WHITESPACE* ~ "-" ~ WHITESPACE* ~ step_body ~ WHITESPACE* ~ line_end }
+text_line = { WHITESPACE* ~ !"-" ~ (!NEWLINE ~ ANY)+ ~ line_end }
+
+repeat_title = { (!(repeat_count ~ WHITESPACE* ~ NEWLINE?) ~ !NEWLINE ~ ANY)+ }
+repeat_count = @{ ASCII_DIGIT+ ~ "x" }
+
+step_body = { cue_prefix? ~ amount ~ modifier? ~ target? ~ cadence? ~ text_metadata? }
+cue_prefix = { (!(amount) ~ !NEWLINE ~ ANY)+ }
+modifier = { ramp | freeride }
+ramp = { ^"ramp" }
+freeride = { ^"freeride" }
+
+amount = { time_amount | distance_amount }
+time_amount = @{ ASCII_DIGIT+ ~ ("hrs" | "hr" | "h" | "mins" | "min" | "m" | "secs" | "sec" | "s") }
+distance_amount = @{ ASCII_DIGIT+ ~ ("km" | "mtr" | "mi") }
+
+target = { hr_target | lthr_target | pace_target | ftp_target }
+ftp_target = @{ number ~ ("-" ~ number)? ~ "%" }
+hr_target = { number ~ ("-" ~ number)? ~ "%" ~ ^"HR" }
+lthr_target = { number ~ ("-" ~ number)? ~ "%" ~ ^"LTHR" }
+pace_target = { pace_value ~ ^"Pace" }
+pace_value = @{ ASCII_DIGIT+ ~ ":" ~ ASCII_DIGIT+ ~ "/" ~ ("km" | "mi" | "100m" | "400m") }
+
+cadence = @{ ASCII_DIGIT+ ~ ("-" ~ ASCII_DIGIT+)? ~ ^"rpm" }
+text_metadata = { ^"text" ~ "=" ~ quoted_string }
+quoted_string = @{ "\"" ~ ( "\\\"" | !("\"") ~ ANY )* ~ "\"" }
+
+number = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+line_end = _{ NEWLINE | EOI }

--- a/tests/intervals_pest_parser_poc.rs
+++ b/tests/intervals_pest_parser_poc.rs
@@ -1,0 +1,225 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use futures::TryStreamExt;
+use mongodb::{
+    bson::{doc, Document},
+    Client,
+};
+
+use aiwattcoach::{
+    adapters::mongo::pest_parser_poc_workouts::MongoPestParserPocWorkoutRepository,
+    domain::intervals::{
+        parse_workout_doc, NoopPestParserPocRepository, PestParserPocDirection,
+        PestParserPocOperation, PestParserPocRecordContext, PestParserPocRepositoryPort,
+        PestParserPocSource, PestParserPocStatus, PestParserPocWorkoutRecord,
+    },
+    Settings,
+};
+
+static TEST_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn builds_failed_poc_record() {
+    let record = PestParserPocWorkoutRecord::failed(
+        PestParserPocRecordContext {
+            user_id: "user-1".to_string(),
+            source: PestParserPocSource {
+                direction: PestParserPocDirection::Inbound,
+                operation: PestParserPocOperation::ListEvents,
+            },
+            source_ref: Some("event-7".to_string()),
+            source_text: "- 10m ???".to_string(),
+            parser_version: "v1".to_string(),
+            parsed_at_epoch_seconds: 123,
+        },
+        "invalid target".to_string(),
+        "syntax".to_string(),
+    );
+
+    assert_eq!(record.status, PestParserPocStatus::Failed);
+    assert_eq!(record.error_kind.as_deref(), Some("syntax"));
+}
+
+#[test]
+fn builds_parsed_poc_record() {
+    let parsed = parse_workout_doc(Some("- 10m 95%"), Some(300));
+
+    let record = PestParserPocWorkoutRecord::parsed(
+        PestParserPocRecordContext {
+            user_id: "user-1".to_string(),
+            source: PestParserPocSource {
+                direction: PestParserPocDirection::Outbound,
+                operation: PestParserPocOperation::UpdateEvent,
+            },
+            source_ref: None,
+            source_text: "- 10m 95%".to_string(),
+            parser_version: "v1".to_string(),
+            parsed_at_epoch_seconds: 123,
+        },
+        "10m 95%".to_string(),
+        parsed,
+    );
+
+    assert_eq!(record.status, PestParserPocStatus::Parsed);
+    assert_eq!(record.normalized_workout.as_deref(), Some("10m 95%"));
+}
+
+#[test]
+fn noop_poc_repository_accepts_records() {
+    let repository = NoopPestParserPocRepository;
+    let result =
+        futures::executor::block_on(repository.insert(PestParserPocWorkoutRecord::failed(
+            PestParserPocRecordContext {
+                user_id: "user-1".to_string(),
+                source: PestParserPocSource {
+                    direction: PestParserPocDirection::Inbound,
+                    operation: PestParserPocOperation::GetEvent,
+                },
+                source_ref: None,
+                source_text: "bad".to_string(),
+                parser_version: "v1".to_string(),
+                parsed_at_epoch_seconds: 1,
+            },
+            "err".to_string(),
+            "syntax".to_string(),
+        )));
+
+    assert_eq!(result, Ok(()));
+}
+
+#[tokio::test]
+async fn pest_parser_poc_repository_inserts_failed_record_document() {
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository =
+        MongoPestParserPocWorkoutRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    repository
+        .insert(PestParserPocWorkoutRecord::failed(
+            PestParserPocRecordContext {
+                user_id: "user-1".to_string(),
+                source: PestParserPocSource {
+                    direction: PestParserPocDirection::Inbound,
+                    operation: PestParserPocOperation::ListEvents,
+                },
+                source_ref: Some("event-1".to_string()),
+                source_text: "- 10m ???".to_string(),
+                parser_version: "v1".to_string(),
+                parsed_at_epoch_seconds: 101,
+            },
+            "invalid syntax".to_string(),
+            "syntax".to_string(),
+        ))
+        .await
+        .unwrap();
+
+    let document = fixture
+        .collection()
+        .find_one(doc! {})
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(document.get_str("user_id").unwrap(), "user-1");
+    assert_eq!(document.get_str("status").unwrap(), "failed");
+    assert_eq!(document.get_str("error_kind").unwrap(), "syntax");
+
+    fixture.cleanup().await;
+}
+
+#[tokio::test]
+async fn pest_parser_poc_repository_creates_expected_indexes() {
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository =
+        MongoPestParserPocWorkoutRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    let indexes = fixture
+        .collection()
+        .list_indexes()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert!(indexes.iter().any(|index| {
+        index
+            .options
+            .as_ref()
+            .and_then(|options| options.name.as_deref())
+            == Some("pest_parser_poc_workout_user_time")
+            && index.keys == doc! { "user_id": 1, "parsed_at_epoch_seconds": -1 }
+    }));
+    assert!(indexes.iter().any(|index| {
+        index
+            .options
+            .as_ref()
+            .and_then(|options| options.name.as_deref())
+            == Some("pest_parser_poc_workout_status_time")
+            && index.keys == doc! { "status": 1, "parsed_at_epoch_seconds": -1 }
+    }));
+
+    fixture.cleanup().await;
+}
+
+struct MongoFixture {
+    client: Client,
+    database: String,
+}
+
+async fn mongo_fixture_or_skip() -> Option<MongoFixture> {
+    match MongoFixture::new().await {
+        Ok(fixture) => Some(fixture),
+        Err(error) => {
+            if std::env::var("REQUIRE_MONGO_IN_CI").as_deref() == Ok("true") {
+                panic!("intervals_pest_parser_poc test requires Mongo in CI: {error}");
+            }
+            eprintln!("skipping intervals_pest_parser_poc test: {error}");
+            None
+        }
+    }
+}
+
+impl MongoFixture {
+    async fn new() -> Result<Self, String> {
+        let settings = Settings::test_defaults();
+        let mongo_uri = settings.mongo.uri.clone();
+        let client = Client::with_uri_str(&settings.mongo.uri)
+            .await
+            .map_err(|error| {
+                format!("failed to create test mongo client for {mongo_uri}: {error}")
+            })?;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            client.database("admin").run_command(doc! { "ping": 1 }),
+        )
+        .await
+        .map_err(|_| format!("timed out connecting to Mongo at {mongo_uri}"))?
+        .map_err(|error| format!("failed to connect to Mongo at {mongo_uri}: {error}"))?;
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = TEST_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let database = format!("aiwattcoach_pest_parser_poc_{unique}_{counter}");
+
+        Ok(Self { client, database })
+    }
+
+    fn collection(&self) -> mongodb::Collection<Document> {
+        self.client
+            .database(&self.database)
+            .collection("pest_parser_poc_workout")
+    }
+
+    async fn cleanup(&self) {
+        let _ = self.client.database(&self.database).drop().await;
+    }
+}

--- a/tests/intervals_pest_parser_poc.rs
+++ b/tests/intervals_pest_parser_poc.rs
@@ -37,10 +37,12 @@ fn builds_failed_poc_record() {
         },
         "invalid target".to_string(),
         "syntax".to_string(),
+        parse_workout_doc(Some("- 10m ???"), None),
     );
 
     assert_eq!(record.status, PestParserPocStatus::Failed);
     assert_eq!(record.error_kind.as_deref(), Some("syntax"));
+    assert!(record.legacy_projection.is_some());
 }
 
 #[test]
@@ -85,6 +87,7 @@ fn noop_poc_repository_accepts_records() {
             },
             "err".to_string(),
             "syntax".to_string(),
+            parse_workout_doc(Some("bad"), None),
         )));
 
     assert_eq!(result, Ok(()));
@@ -114,6 +117,7 @@ async fn pest_parser_poc_repository_inserts_failed_record_document() {
             },
             "invalid syntax".to_string(),
             "syntax".to_string(),
+            parse_workout_doc(Some("- 10m ???"), None),
         ))
         .await
         .unwrap();

--- a/tests/intervals_pest_parser_poc.rs
+++ b/tests/intervals_pest_parser_poc.rs
@@ -165,6 +165,14 @@ async fn pest_parser_poc_repository_creates_expected_indexes() {
             == Some("pest_parser_poc_workout_status_time")
             && index.keys == doc! { "status": 1, "parsed_at_epoch_seconds": -1 }
     }));
+    assert!(indexes.iter().any(|index| {
+        index
+            .options
+            .as_ref()
+            .and_then(|options| options.name.as_deref())
+            == Some("pest_parser_poc_workout_operation_source_time")
+            && index.keys == doc! { "operation": 1, "source_ref": 1, "parsed_at_epoch_seconds": -1 }
+    }));
 
     fixture.cleanup().await;
 }

--- a/tests/intervals_service/events.rs
+++ b/tests/intervals_service/events.rs
@@ -272,3 +272,38 @@ async fn create_event_stores_poc_record_for_outbound_push() {
     assert_eq!(stored[0].operation, PestParserPocOperation::CreateEvent);
     assert_eq!(stored[0].status, PestParserPocStatus::Parsed);
 }
+
+#[tokio::test]
+async fn create_event_stores_failed_poc_record_for_malformed_workout() {
+    let created = sample_event(11, "Broken Workout");
+    let api = FakeIntervalsApi::with_created_event(created);
+    let settings = FakeSettingsPort::with_credentials(valid_credentials());
+    let poc_repository = FakePestParserPocRepository::default();
+    let records = poc_repository.records.clone();
+    let service = test_service(api, settings)
+        .with_pest_parser_poc_repository(poc_repository)
+        .with_clock(FixedClock);
+
+    service
+        .create_event(
+            "user-1",
+            CreateEvent {
+                category: EventCategory::Workout,
+                start_date_local: "2026-04-01".to_string(),
+                event_type: Some("Ride".to_string()),
+                name: Some("Broken Workout".to_string()),
+                description: Some("fallback description".to_string()),
+                indoor: true,
+                color: Some("blue".to_string()),
+                workout_doc: Some("- 10m ???".to_string()),
+                file_upload: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let stored = records.lock().unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].operation, PestParserPocOperation::CreateEvent);
+    assert_eq!(stored[0].status, PestParserPocStatus::Failed);
+}

--- a/tests/intervals_service/events.rs
+++ b/tests/intervals_service/events.rs
@@ -306,4 +306,5 @@ async fn create_event_stores_failed_poc_record_for_malformed_workout() {
     assert_eq!(stored.len(), 1);
     assert_eq!(stored[0].operation, PestParserPocOperation::CreateEvent);
     assert_eq!(stored[0].status, PestParserPocStatus::Failed);
+    assert!(stored[0].legacy_projection.is_some());
 }

--- a/tests/intervals_service/events.rs
+++ b/tests/intervals_service/events.rs
@@ -1,26 +1,50 @@
+use aiwattcoach::domain::identity::Clock;
 use aiwattcoach::domain::intervals::{
     CreateEvent, DateRange, EventCategory, IntervalsError, IntervalsService, IntervalsUseCases,
     NoopActivityFileIdentityExtractor, NoopActivityRepository,
-    NoopActivityUploadOperationRepository, UpdateEvent,
+    NoopActivityUploadOperationRepository, PestParserPocOperation, PestParserPocStatus,
+    UpdateEvent,
 };
 
 use crate::{
     common::{sample_event, valid_credentials},
-    fakes::{ApiCall, FakeIntervalsApi, FakeSettingsPort},
+    fakes::{ApiCall, FakeIntervalsApi, FakePestParserPocRepository, FakeSettingsPort},
 };
+
+#[derive(Clone)]
+struct FixedClock;
+
+impl Clock for FixedClock {
+    fn now_epoch_seconds(&self) -> i64 {
+        1_234
+    }
+}
+
+fn test_service(
+    api: FakeIntervalsApi,
+    settings: FakeSettingsPort,
+) -> IntervalsService<
+    FakeIntervalsApi,
+    FakeSettingsPort,
+    NoopActivityRepository,
+    NoopActivityUploadOperationRepository,
+    NoopActivityFileIdentityExtractor,
+> {
+    IntervalsService::new(
+        api,
+        settings,
+        NoopActivityRepository::default(),
+        NoopActivityUploadOperationRepository::default(),
+        NoopActivityFileIdentityExtractor,
+    )
+}
 
 #[tokio::test]
 async fn list_events_returns_events_from_api() {
     let event = sample_event(42, "Workout A");
     let api = FakeIntervalsApi::with_events(vec![event.clone()]);
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let events = service
         .list_events(
@@ -41,13 +65,7 @@ async fn list_events_fails_when_credentials_not_configured() {
     let api = FakeIntervalsApi::default();
     let calls = api.call_log.clone();
     let settings = FakeSettingsPort::without_credentials();
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let result = service
         .list_events(
@@ -68,13 +86,7 @@ async fn get_event_returns_single_event() {
     let event = sample_event(7, "Threshold");
     let api = FakeIntervalsApi::with_get_event(event.clone());
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let result = service.get_event("user-1", 7).await.unwrap();
 
@@ -87,13 +99,7 @@ async fn create_event_passes_event_to_api() {
     let api = FakeIntervalsApi::with_created_event(created.clone());
     let calls = api.call_log.clone();
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let input = CreateEvent {
         category: EventCategory::Workout,
@@ -119,13 +125,7 @@ async fn update_event_forwards_to_api() {
     let api = FakeIntervalsApi::with_updated_event(updated.clone());
     let calls = api.call_log.clone();
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let input = UpdateEvent {
         category: Some(EventCategory::Workout),
@@ -159,13 +159,7 @@ async fn delete_event_calls_api_and_returns_ok() {
     let api = FakeIntervalsApi::default();
     let calls = api.call_log.clone();
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let result = service.delete_event("user-1", 77).await;
 
@@ -177,13 +171,7 @@ async fn delete_event_calls_api_and_returns_ok() {
 async fn download_fit_returns_bytes() {
     let api = FakeIntervalsApi::with_fit_bytes(vec![1, 2, 3, 4]);
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let bytes = service.download_fit("user-1", 33).await.unwrap();
 
@@ -194,13 +182,7 @@ async fn download_fit_returns_bytes() {
 async fn api_error_propagated_to_caller() {
     let api = FakeIntervalsApi::with_error(IntervalsError::ApiError("bad gateway".to_string()));
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let result = service.get_event("user-1", 99).await;
 
@@ -218,13 +200,7 @@ async fn get_enriched_event_propagates_activity_lookup_failure() {
         IntervalsError::ConnectionError("upstream down".to_string()),
     );
     let settings = FakeSettingsPort::with_credentials(valid_credentials());
-    let service = IntervalsService::new(
-        api,
-        settings,
-        NoopActivityRepository::default(),
-        NoopActivityUploadOperationRepository::default(),
-        NoopActivityFileIdentityExtractor,
-    );
+    let service = test_service(api, settings);
 
     let result = service.get_enriched_event("user-1", 77).await;
 
@@ -232,4 +208,67 @@ async fn get_enriched_event_propagates_activity_lookup_failure() {
         result,
         Err(IntervalsError::ConnectionError("upstream down".to_string()))
     );
+}
+
+#[tokio::test]
+async fn list_events_stores_poc_record_for_inbound_read() {
+    let event = sample_event(42, "Workout A");
+    let api = FakeIntervalsApi::with_events(vec![event]);
+    let settings = FakeSettingsPort::with_credentials(valid_credentials());
+    let poc_repository = FakePestParserPocRepository::default();
+    let records = poc_repository.records.clone();
+    let service = test_service(api, settings)
+        .with_pest_parser_poc_repository(poc_repository)
+        .with_clock(FixedClock);
+
+    service
+        .list_events(
+            "user-1",
+            &DateRange {
+                oldest: "2026-03-01".to_string(),
+                newest: "2026-03-31".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let stored = records.lock().unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].operation, PestParserPocOperation::ListEvents);
+    assert_eq!(stored[0].status, PestParserPocStatus::Parsed);
+}
+
+#[tokio::test]
+async fn create_event_stores_poc_record_for_outbound_push() {
+    let created = sample_event(10, "New Workout");
+    let api = FakeIntervalsApi::with_created_event(created);
+    let settings = FakeSettingsPort::with_credentials(valid_credentials());
+    let poc_repository = FakePestParserPocRepository::default();
+    let records = poc_repository.records.clone();
+    let service = test_service(api, settings)
+        .with_pest_parser_poc_repository(poc_repository)
+        .with_clock(FixedClock);
+
+    service
+        .create_event(
+            "user-1",
+            CreateEvent {
+                category: EventCategory::Workout,
+                start_date_local: "2026-04-01".to_string(),
+                event_type: Some("Ride".to_string()),
+                name: Some("New Workout".to_string()),
+                description: Some("4x8min".to_string()),
+                indoor: true,
+                color: Some("blue".to_string()),
+                workout_doc: Some("- 8m 95%".to_string()),
+                file_upload: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let stored = records.lock().unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].operation, PestParserPocOperation::CreateEvent);
+    assert_eq!(stored[0].status, PestParserPocStatus::Parsed);
 }

--- a/tests/intervals_service/fakes/mod.rs
+++ b/tests/intervals_service/fakes/mod.rs
@@ -1,12 +1,14 @@
 mod activity_repository;
 mod api;
 mod identity_extractor;
+mod pest_parser_poc;
 mod settings;
 mod upload_operations;
 
 pub(crate) use activity_repository::{FakeActivityRepository, RepoCall};
 pub(crate) use api::{ApiCall, FakeIntervalsApi};
 pub(crate) use identity_extractor::FakeActivityIdentityExtractor;
+pub(crate) use pest_parser_poc::FakePestParserPocRepository;
 pub(crate) use settings::FakeSettingsPort;
 pub(crate) use upload_operations::{
     FakeActivityUploadOperationRepository, UploadOperationRepoCall,

--- a/tests/intervals_service/fakes/pest_parser_poc.rs
+++ b/tests/intervals_service/fakes/pest_parser_poc.rs
@@ -1,0 +1,23 @@
+use std::sync::{Arc, Mutex};
+
+use aiwattcoach::domain::intervals::{
+    BoxFuture, IntervalsError, PestParserPocRepositoryPort, PestParserPocWorkoutRecord,
+};
+
+#[derive(Clone, Default)]
+pub(crate) struct FakePestParserPocRepository {
+    pub(crate) records: Arc<Mutex<Vec<PestParserPocWorkoutRecord>>>,
+}
+
+impl PestParserPocRepositoryPort for FakePestParserPocRepository {
+    fn insert(&self, record: PestParserPocWorkoutRecord) -> BoxFuture<Result<(), IntervalsError>> {
+        let records = self.records.clone();
+        Box::pin(async move {
+            records
+                .lock()
+                .expect("poc repo mutex poisoned")
+                .push(record);
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- add a Pest-based shadow parser for Intervals `workout_doc` and record parsed or failed observations without changing current workout behavior
- persist PoC parser records in Mongo and trigger observation on inbound Intervals reads plus outbound create/update event syncs
- add parser, repository, and service coverage for supported workout syntax and observation persistence

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- bun run verify:frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workout text parser for steps, repeats, targets, cadence, and metadata plus non‑blocking observation that records parse successes and failures.
* **Chores**
  * Added parser test dependencies.
* **Documentation**
  * Added design and implementation plans for the parser proof‑of‑concept.
* **Tests**
  * Added unit/integration tests, test fakes, and Mongo-backed persistence/indexing tests for parser observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->