### PR TITLE
docs: add agent guardrails for focused changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,31 @@ Before changing behavior, use this order:
 4. integration and recovery path if external APIs are involved
 5. only then propose or implement the change
 
+## Karpathy Guardrails for Agents
+
+Adapted from `forrestchang/andrej-karpathy-skills` for OpenCode work in this repo.
+
+- Think before changing:
+  - State assumptions when they matter.
+  - If multiple valid interpretations exist, surface them instead of silently picking one.
+  - If a simpler approach works, prefer it and say so.
+  - If something important is unclear, stop and ask instead of guessing.
+- Simplicity first:
+  - Write the minimum code that solves the requested problem.
+  - Do not add speculative abstractions, flexibility, or configurability that were not requested.
+  - Avoid handling impossible scenarios just to look complete.
+  - If a solution feels overbuilt, reduce it before shipping it.
+- Surgical changes:
+  - Touch only what is needed for the request.
+  - Do not refactor unrelated code, formatting, or comments while making a focused change.
+  - Match existing local style unless the task explicitly includes a broader cleanup.
+  - Remove only the imports, variables, or helpers that your change made unnecessary.
+- Goal-driven verification:
+  - Turn requests into verifiable outcomes before editing.
+  - Prefer checks that prove the requested behavior, not generic confidence.
+  - For multi-step work, keep a short plan with a concrete verification step for each part.
+  - Do not call the work done until the relevant commands or checks were actually run and their output was read.
+
 ## Important Directories
 
 - `src/domain/` - domain models, ports, services.

--- a/docs/plans/2026-04-12-agents-karpathy-guardrails-design.md
+++ b/docs/plans/2026-04-12-agents-karpathy-guardrails-design.md
@@ -1,0 +1,34 @@
+# AGENTS Karpathy Guardrails Design
+
+## Goal
+
+Add a compact set of behavioral guardrails to `AGENTS.md`, adapted from `forrestchang/andrej-karpathy-skills`, so OpenCode follows the same caution-first mindset inside `AiWattCoach`.
+
+## Recommended Approach
+
+Add one dedicated section to `AGENTS.md` instead of scattering the guidance across existing sections. This keeps the source of truth easy to find, preserves the current repo-specific instructions, and makes the imported guidance clearly identifiable as an additional layer rather than a rewrite of the whole file.
+
+## Scope
+
+- Add a new section named `Karpathy Guardrails for Agents`.
+- Keep the section short and project-compatible.
+- Translate the upstream `CLAUDE.md` ideas into OpenCode-friendly wording.
+- Avoid duplicating rules that already exist unless the new wording adds a useful emphasis.
+
+## Section Structure
+
+- `Think Before Changing` for ambiguity, assumptions, and surfacing tradeoffs.
+- `Simplicity First` for minimal implementations and avoiding speculative abstractions.
+- `Surgical Changes` for small diffs and avoiding unrelated cleanup.
+- `Goal-Driven Verification` for turning requests into verifiable outcomes.
+
+## Constraints
+
+- Do not mention `CLAUDE.md` as the integration target.
+- Do not introduce instructions that conflict with the repo's existing verification and architecture rules.
+- Keep the diff minimal and readable.
+
+## Verification
+
+- Read the updated `AGENTS.md` section for tone and consistency.
+- Run `git diff -- AGENTS.md docs/plans/2026-04-12-agents-karpathy-guardrails-design.md` to verify the change set is limited to the intended files.

--- a/docs/plans/2026-04-12-agents-karpathy-guardrails-implementation-plan.md
+++ b/docs/plans/2026-04-12-agents-karpathy-guardrails-implementation-plan.md
@@ -1,0 +1,55 @@
+# AGENTS Karpathy Guardrails Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a small repo-tracked section to `AGENTS.md` that adapts the upstream Andrej Karpathy coding guardrails for OpenCode in `AiWattCoach`.
+
+**Architecture:** Keep the change documentation-only and localized to `AGENTS.md`. Add one new section near the top-level workflow guidance so the rules are visible early without rewriting existing project constraints.
+
+**Tech Stack:** Markdown, repository agent instructions
+
+---
+
+### Task 1: Add the new guidance section
+
+**Files:**
+- Modify: `AGENTS.md`
+
+**Step 1: Draft the new section**
+
+- Add `## Karpathy Guardrails for Agents`.
+- Add four concise bullet groups:
+  - think before changing
+  - simplicity first
+  - surgical changes
+  - goal-driven verification
+
+**Step 2: Keep the wording repo-compatible**
+
+- Preserve existing OpenCode and repo-specific terminology.
+- Avoid references to `CLAUDE.md`.
+- Do not duplicate large existing sections.
+
+**Step 3: Verify readability**
+
+Run: `git diff -- AGENTS.md`
+
+Expected: One focused documentation diff with the new section only.
+
+### Task 2: Verify the final change set
+
+**Files:**
+- Modify: `AGENTS.md`
+- Create: `docs/plans/2026-04-12-agents-karpathy-guardrails-design.md`
+- Create: `docs/plans/2026-04-12-agents-karpathy-guardrails-implementation-plan.md`
+
+**Step 1: Inspect the final diff**
+
+Run: `git diff -- AGENTS.md docs/plans/2026-04-12-agents-karpathy-guardrails-design.md docs/plans/2026-04-12-agents-karpathy-guardrails-implementation-plan.md`
+
+Expected: Only the intended docs changes appear.
+
+**Step 2: Stop after verification**
+
+- Do not widen scope into other instruction files.
+- Do not edit unrelated docs.


### PR DESCRIPTION
## Summary
- add a repo-tracked Karpathy-inspired guardrails section to AGENTS.md for OpenCode agents
- document the design and implementation approach in docs/plans
- keep the change scoped to agent guidance without altering runtime code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced behavioral guardrails for agents with guidance on deliberate pre-change thinking, prioritizing simplicity in design, executing surgical and minimal modifications, and implementing goal-driven verification processes including mandatory output validation before task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->