### PR TITLE
fix import refresh coverage and graphify rebuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,4 +299,4 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- After modifying code files in this session, run `./scripts/rebuild_graphify.sh` to keep the graph current

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ graphify hook install
 Then regenerate or query from the repo root:
 
 ```bash
-graphify . --no-viz --update
+./scripts/rebuild_graphify.sh
 graphify query "show the calendar and races flow"
-graphify explain "CalendarService"
 ```
+
+`./scripts/rebuild_graphify.sh` prefers `GRAPHIFY_PYTHON`, then a valid executable path from `graphify-out/.graphify_python`, and finally the default `pipx` venv at `~/.local/pipx/venvs/graphifyy/bin/python`.
 
 `.graphifyignore` excludes generated outputs and build directories so the graph does not index its own artifacts.
 

--- a/graphify-out/.graphify_python
+++ b/graphify-out/.graphify_python
@@ -1,1 +1,1 @@
-C:\Python313\python.exe
+/Users/andrzej.witkowski/.local/pipx/venvs/graphifyy/bin/python

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-04-12)
+# Graph Report - .  (2026-04-16)
 
 ## Corpus Check
-- 523 files · ~312,105 words
+- 566 files · ~299,144 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4341 nodes · 5068 edges · 640 communities detected
+- 5177 nodes · 6320 edges · 669 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -650,6 +650,35 @@
 - [[_COMMUNITY_Community 637|Community 637]]
 - [[_COMMUNITY_Community 638|Community 638]]
 - [[_COMMUNITY_Community 639|Community 639]]
+- [[_COMMUNITY_Community 640|Community 640]]
+- [[_COMMUNITY_Community 641|Community 641]]
+- [[_COMMUNITY_Community 642|Community 642]]
+- [[_COMMUNITY_Community 643|Community 643]]
+- [[_COMMUNITY_Community 644|Community 644]]
+- [[_COMMUNITY_Community 645|Community 645]]
+- [[_COMMUNITY_Community 646|Community 646]]
+- [[_COMMUNITY_Community 647|Community 647]]
+- [[_COMMUNITY_Community 648|Community 648]]
+- [[_COMMUNITY_Community 649|Community 649]]
+- [[_COMMUNITY_Community 650|Community 650]]
+- [[_COMMUNITY_Community 651|Community 651]]
+- [[_COMMUNITY_Community 652|Community 652]]
+- [[_COMMUNITY_Community 653|Community 653]]
+- [[_COMMUNITY_Community 654|Community 654]]
+- [[_COMMUNITY_Community 655|Community 655]]
+- [[_COMMUNITY_Community 656|Community 656]]
+- [[_COMMUNITY_Community 657|Community 657]]
+- [[_COMMUNITY_Community 658|Community 658]]
+- [[_COMMUNITY_Community 659|Community 659]]
+- [[_COMMUNITY_Community 660|Community 660]]
+- [[_COMMUNITY_Community 661|Community 661]]
+- [[_COMMUNITY_Community 662|Community 662]]
+- [[_COMMUNITY_Community 663|Community 663]]
+- [[_COMMUNITY_Community 664|Community 664]]
+- [[_COMMUNITY_Community 665|Community 665]]
+- [[_COMMUNITY_Community 666|Community 666]]
+- [[_COMMUNITY_Community 667|Community 667]]
+- [[_COMMUNITY_Community 668|Community 668]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `resolve_user_id()` - 34 edges
@@ -657,23 +686,23 @@
 3. `FakeIntervalsApi` - 25 edges
 4. `required_settings_map()` - 20 edges
 5. `TestIntervalsService` - 20 edges
-6. `new_call_log()` - 17 edges
-7. `WorkoutSummaryService<Repo, Ops, Time, Ids>` - 16 edges
-8. `TestWorkoutSummaryService` - 16 edges
-9. `IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>` - 15 edges
-10. `capture_request()` - 15 edges
+6. `WorkoutSummaryService<Repo, Ops, Time, Ids>` - 19 edges
+7. `()` - 19 edges
+8. `InMemoryIntervalsService` - 18 edges
+9. `TestWorkoutSummaryService` - 18 edges
+10. `new_call_log()` - 17 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `get_event()` --calls--> `resolve_user_id()`  [EXTRACTED]
-  src\adapters\rest\intervals\handlers.rs → src\adapters\rest\workout_summary\handlers.rs
-- `create_event()` --calls--> `resolve_user_id()`  [EXTRACTED]
-  src\adapters\rest\intervals\handlers.rs → src\adapters\rest\workout_summary\handlers.rs
-- `update_event()` --calls--> `resolve_user_id()`  [EXTRACTED]
-  src\adapters\rest\intervals\handlers.rs → src\adapters\rest\workout_summary\handlers.rs
-- `delete_event()` --calls--> `resolve_user_id()`  [EXTRACTED]
-  src\adapters\rest\intervals\handlers.rs → src\adapters\rest\workout_summary\handlers.rs
-- `download_fit()` --calls--> `resolve_user_id()`  [EXTRACTED]
-  src\adapters\rest\intervals\handlers.rs → src\adapters\rest\workout_summary\handlers.rs
+- `logout()` --calls--> `buildAuthUrl()`  [EXTRACTED]
+  src/adapters/rest/auth.rs → frontend/src/features/auth/api/auth.ts
+- `capture_tracing_logs_restores_outer_capture_after_nested_call()` --calls--> `capture_tracing_logs()`  [EXTRACTED]
+  tests/settings_rest/tracing_capture.rs → tests/health_check/tracing_capture.rs
+- `truncates_logged_openrouter_response_bodies()` --calls--> `truncate_logged_response_body()`  [EXTRACTED]
+  src/adapters/llm/openrouter/client.rs → src/adapters/intervals_icu/client.rs
+- `list_events_hydrates_actual_workout_from_linked_completed_workout()` --calls--> `sample_completed_workout()`  [EXTRACTED]
+  src/domain/calendar/tests.rs → src/domain/calendar_view/tests.rs
+- `settings_test_app_with_athlete_summary()` --calls--> `frontend_fixture()`  [EXTRACTED]
+  tests/settings_rest/shared/app.rs → tests/intervals_rest/app.rs
 
 ## Hyperedges (group relationships)
 - **Durable Coach Reply Workflow** — agents_persist_before_side_effects, llm_coach_reply_state_machine_coach_reply_operation, llm_coach_reply_state_machine_pending_state, llm_coach_reply_state_machine_recovery_rules, llm_coach_reply_state_machine_local_write_retries, llm_coach_reply_state_machine_compare_and_swap_reclaim [INFERRED 0.90]
@@ -685,1268 +714,1320 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.03
-Nodes (24): capture_request(), CapturedRequest, CapturingChatPort, FailingReusableCacheRepository, FixedClock, FixedGeminiConfigProvider, FtpOrderingIntervalsService, gemini_cache_handler() (+16 more)
+Cohesion: 0.02
+Nodes (37): capture_request(), CapturedRequest, CapturingChatPort, FailingReusableCacheRepository, FixedClock, FixedGeminiConfigProvider, gemini_cache_handler(), gemini_generate_handler() (+29 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.04
-Nodes (19): auth_test_app(), auth_test_app_with_custom_settings(), auth_test_app_with_settings(), auth_test_app_without_identity(), frontend_fixture(), FrontendFixture, health_test_app(), HealthTestApp (+11 more)
+Nodes (18): FakeIntervalsService, FakeProjectionRepository, FixedClock, FixedIds, InMemoryCalendarEntryViewRepository, InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutSyncRepository, InMemoryProviderPollStateRepository (+10 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.09
-Nodes (30): assert_event_order(), completed_operation(), completed_operation_at(), ensure_fresh_summary_generates_when_missing(), ensure_fresh_summary_reads_repository_once_when_summary_is_fresh(), ensure_fresh_summary_regenerates_when_older_than_monday(), ensure_fresh_summary_reuses_summary_generated_this_week(), failed_operation() (+22 more)
+Cohesion: 0.04
+Nodes (19): auth_test_app(), auth_test_app_with_custom_settings(), auth_test_app_with_settings(), auth_test_app_without_identity(), frontend_fixture(), FrontendFixture, health_test_app(), HealthTestApp (+11 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.07
-Nodes (30): build_create_event(), build_projected_calendar_event(), build_update_event(), CalendarService, CalendarService<Intervals, Projections, Syncs, Hidden, Time>, find_existing_remote_event(), format_projected_step_duration(), format_projected_step_target() (+22 more)
+Cohesion: 0.06
+Nodes (32): calendar_entry_view_service_lists_mixed_entries_by_date_range(), completed_workout_projection_carries_local_summary(), completed_workout_projection_handles_short_start_date_local_without_panicking(), planned_workout_projection_builds_local_entry(), race_projection_keeps_label_shape_and_sync_metadata(), race_projection_panics_when_intervals_external_id_is_not_numeric(), rebuild_for_user_keeps_sync_on_merged_planned_entry_without_standalone_completed_entry(), rebuild_for_user_preserves_existing_sync_metadata() (+24 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.05
-Nodes (14): default_dev_coach(), DevWorkoutCoach, existing_summary(), existing_summary_with_finished_conversation(), PersistCheckingTrainingPlanService, RecordingLatestCompletedActivityService, RecordingTrainingPlanService, RefreshingTrainingPlanService (+6 more)
+Nodes (28): EmptyCalendarLabelSource, EmptyTrainingPlanProjectionRepository, frontend_fixture(), FrontendFixture, get_json(), InMemoryCalendarEntryViewRepository, InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutSyncRepository (+20 more)
 
 ### Community 5 - "Community 5"
+Cohesion: 0.09
+Nodes (30): assert_event_order(), completed_operation(), completed_operation_at(), ensure_fresh_summary_generates_when_missing(), ensure_fresh_summary_reads_repository_once_when_summary_is_fresh(), ensure_fresh_summary_regenerates_when_older_than_monday(), ensure_fresh_summary_reuses_summary_generated_this_week(), failed_operation() (+22 more)
+
+### Community 6 - "Community 6"
+Cohesion: 0.04
+Nodes (16): default_dev_coach(), DevWorkoutCoach, existing_summary(), existing_summary_with_finished_conversation(), PersistCheckingTrainingPlanService, RecordingCompletedWorkoutTargetService, RecordingLatestCompletedActivityService, RecordingTrainingPlanService (+8 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.05
+Nodes (19): create_race_persists_and_syncs_to_intervals(), create_race_retry_after_lost_final_sync_write_updates_existing_remote_event(), create_race_retry_without_external_id_reuses_existing_remote_event(), delete_race_deletes_remote_event_before_local_remove(), delete_race_keeps_sync_state_when_local_delete_fails(), delete_race_refreshes_calendar_view_when_sync_state_delete_fails_after_local_delete(), FailingCalendarRefresh, InMemoryExternalSyncStateRepository (+11 more)
+
+### Community 8 - "Community 8"
+Cohesion: 0.06
+Nodes (40): AiAgentsDocument, AvailabilityDayDocument, AvailabilityDocument, bootstrap_intervals_updated_at(), build_intervals_poll_bootstrap_filter(), build_intervals_poll_bootstrap_filter_matches_non_empty_credentials_or_existing_users(), build_intervals_poll_bootstrap_filter_omits_user_id_clause_without_existing_users(), build_settings_document() (+32 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.1
+Nodes (21): find_settings_does_not_create_defaults_when_missing(), InMemoryProviderPollStateRepository, InMemoryUserSettingsRepository, normalize_intervals_config(), normalize_optional_non_empty(), RecordingCacheRepository, should_invalidate_llm_cache(), sync_poll_states_after_intervals_update() (+13 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.08
 Nodes (41): buildCompletedWorkoutBars(), buildCompletedWorkoutPreviewBars(), buildExpandedPlannedSegments(), buildPlannedTargetLabel(), buildPlannedWorkoutBars(), buildPlannedWorkoutChartIntervals(), buildPlannedWorkoutIntervalDetail(), buildPlannedWorkoutPowerSeries() (+33 more)
 
-### Community 6 - "Community 6"
+### Community 11 - "Community 11"
+Cohesion: 0.05
+Nodes (9): AssertingIntervalsApi, FakeIntervalsApi, FakeIntervalsSettings, FixedIdGenerator, RecordingCalendarRefresh, RecordingImportService, RecordingIntervalsApi, RecordingProviderPollStateRepository (+1 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.1
 Nodes (41): admin_get_user_settings(), athlete_summary_service(), auth_and_get_calendar_labels_service(), auth_and_get_calendar_service(), connection_tester(), create_activity(), create_event(), create_summary() (+33 more)
 
-### Community 7 - "Community 7"
+### Community 13 - "Community 13"
 Cohesion: 0.08
 Nodes (40): build_workout_summary(), format_number(), is_exact_date(), mean_target_percent(), mean_target_percent_from_bounds(), normalize_definition(), normalize_spaces(), parse_amount_pair() (+32 more)
 
-### Community 8 - "Community 8"
-Cohesion: 0.07
-Nodes (21): EmptyCalendarLabelSource, EmptyHiddenCalendarEventSource, EmptyTrainingPlanProjectionRepository, frontend_fixture(), FrontendFixture, get_json(), InMemoryPlannedWorkoutSyncRepository, intervals_test_app() (+13 more)
+### Community 14 - "Community 14"
+Cohesion: 0.09
+Nodes (24): build_direct_event_matches(), build_local_events(), canonical_event_id(), CompletedWorkoutReadPort, date_key(), default_special_day_name(), DefaultTrainingContextBuilder, DefaultTrainingContextBuilder<Time> (+16 more)
 
-### Community 9 - "Community 9"
-Cohesion: 0.06
-Nodes (28): Activity, ActivityDeduplicationIdentity, ActivityDetails, ActivityFallbackIdentity, ActivityInterval, ActivityIntervalGroup, ActivityMetrics, ActivityStream (+20 more)
-
-### Community 10 - "Community 10"
+### Community 15 - "Community 15"
 Cohesion: 0.05
 Nodes (10): capture_request(), CapturedRequest, gemini_cache_handler(), gemini_generate_handler(), MockServerState, openai_handler(), openrouter_handler(), ServerState (+2 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (28): AiAgentsDocument, AvailabilityDayDocument, AvailabilityDocument, build_settings_document(), CyclingDocument, default_availability_day_documents(), default_availability_document(), has_complete_explicit_week() (+20 more)
+### Community 16 - "Community 16"
+Cohesion: 0.06
+Nodes (28): Activity, ActivityDeduplicationIdentity, ActivityDetails, ActivityFallbackIdentity, ActivityInterval, ActivityIntervalGroup, ActivityMetrics, ActivityStream (+20 more)
 
-### Community 12 - "Community 12"
-Cohesion: 0.05
-Nodes (35): ActivityDetailsDto, ActivityDto, ActivityIntervalDto, ActivityIntervalGroupDto, ActivityMetricsDto, ActivityPath, ActivityStreamDto, ActivityZoneTimeDto (+27 more)
-
-### Community 13 - "Community 13"
+### Community 17 - "Community 17"
 Cohesion: 0.05
 Nodes (1): RecordingMissingSettingsService
 
-### Community 14 - "Community 14"
+### Community 18 - "Community 18"
+Cohesion: 0.05
+Nodes (35): ActivityDetailsDto, ActivityDto, ActivityIntervalDto, ActivityIntervalGroupDto, ActivityMetricsDto, ActivityPath, ActivityStreamDto, ActivityZoneTimeDto (+27 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (19): AlwaysFailingCoach, CapturingAthleteSummaryCoach, CountingCoach, FailingAthleteSummaryService, generate_coach_reply_continues_when_athlete_summary_is_unavailable(), generate_coach_reply_marks_when_athlete_summary_was_regenerated(), generate_coach_reply_passes_fresh_athlete_summary_text_to_coach_once(), generate_coach_reply_preserves_oversized_context_error() (+11 more)
 
-### Community 15 - "Community 15"
+### Community 20 - "Community 20"
+Cohesion: 0.08
+Nodes (19): choose_preferred_planned_workout_link(), completed_workout_refresh_dates(), existing_link_candidate(), ExternalCompletedWorkoutImport, ExternalImportCommand, ExternalImportError, ExternalImportOutcome, ExternalImportService (+11 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.08
 Nodes (18): AiAgentsConfig, AnalysisOptions, availability_from_days_derives_configured_state(), availability_from_days_orders_weekdays_canonically(), availability_is_not_configured_without_any_available_days(), AvailabilityDay, AvailabilitySettings, cycling_settings_debug_redacts_sensitive_profile_fields() (+10 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.12
-Nodes (11): find_settings_does_not_create_defaults_when_missing(), InMemoryUserSettingsRepository, RecordingCacheRepository, should_invalidate_llm_cache(), TestClock, update_ai_agents_invalidates_llm_cache_when_provider_config_changes(), update_ai_agents_skips_llm_cache_invalidation_when_provider_config_is_unchanged(), update_availability_normalizes_inconsistent_configured_flag() (+3 more)
-
-### Community 17 - "Community 17"
+### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (9): ApiFailure, GeminiClient, IntervalsIcuClient, map_error(), normalize_gemini_model_name(), OpenAiClient, OpenRouterClient, truncate_logged_response_body() (+1 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (8): create_race_persists_and_syncs_to_intervals(), delete_race_deletes_remote_event_before_local_remove(), InMemoryExternalSyncStateRepository, InMemoryRaceRepository, RecordingIntervalsService, TestClock, TestIdGenerator, update_race_marks_failure_when_intervals_update_fails()
+### Community 23 - "Community 23"
+Cohesion: 0.11
+Nodes (13): canonical_race_id_marker(), is_valid_date_format(), parse_intervals_event_id(), projected_event_category(), projected_event_description(), projected_event_name(), projected_event_start_date_local(), projected_event_type() (+5 more)
 
-### Community 19 - "Community 19"
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (0): 
 
-### Community 20 - "Community 20"
+### Community 25 - "Community 25"
+Cohesion: 0.13
+Nodes (28): activity_hash_changes_when_persisted_details_change(), event_date(), FixedIdGenerator, hash_activity(), hash_event(), infer_race_discipline(), infer_race_distance_meters(), kilometers_to_meters() (+20 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.09
+Nodes (19): completed_workout_document_round_trip_preserves_fields(), CompletedWorkoutDetailsDocument, CompletedWorkoutDocument, CompletedWorkoutIntervalDocument, CompletedWorkoutIntervalGroupDocument, CompletedWorkoutMetricsDocument, CompletedWorkoutStreamDocument, CompletedWorkoutZoneTimeDocument (+11 more)
+
+### Community 27 - "Community 27"
+Cohesion: 0.11
+Nodes (24): imported_planned_workout_document_rejects_unknown_step_kind(), imported_planned_workout_document_round_trip_preserves_fields(), ImportedPlannedWorkoutDocument, load_imported_workouts(), load_projected_workouts(), load_snapshot_start_dates(), map_domain_line_to_stored_line(), map_domain_target_to_stored_target() (+16 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.06
+Nodes (12): CanonicalEntityKind, CanonicalEntityRef, ConflictStatus, ExternalObjectKind, ExternalObservation, ExternalObservationParams, ExternalProvider, ExternalSyncRepositoryError (+4 more)
+
+### Community 29 - "Community 29"
 Cohesion: 0.07
 Nodes (14): CoachReply, CoachReplyClaimResult, CoachReplyOperation, CoachReplyOperationFailureKind, CoachReplyOperationStatus, CompletedCoachReply, ConversationMessage, MessageRole (+6 more)
 
-### Community 21 - "Community 21"
+### Community 30 - "Community 30"
 Cohesion: 0.13
 Nodes (19): build_log_bridge_layer(), build_logger_provider(), build_resource(), build_tracer_provider(), combine_shutdown_errors(), combine_shutdown_errors_preserves_both_messages(), get_otlp_endpoint(), init_telemetry() (+11 more)
 
-### Community 22 - "Community 22"
+### Community 31 - "Community 31"
 Cohesion: 0.12
 Nodes (14): ConversationMessageDocument, current_workout_id_filter(), document_identity_filter(), editable_document_identity_filter(), find_preferred_document(), find_preferred_documents(), find_preferred_message_lookup_document(), legacy_event_id_filter() (+6 more)
 
-### Community 23 - "Community 23"
+### Community 32 - "Community 32"
 Cohesion: 0.11
 Nodes (2): ApiCall, FakeIntervalsApi
 
-### Community 24 - "Community 24"
+### Community 33 - "Community 33"
 Cohesion: 0.17
 Nodes (23): BodyLoggingMode, execute_and_log(), execute_and_log_no_body(), execute_and_log_with_body(), execute_and_log_without_body(), format_binary_body(), format_binary_body_formats_binary_payloads(), format_request_body() (+15 more)
 
-### Community 25 - "Community 25"
+### Community 34 - "Community 34"
 Cohesion: 0.08
-Nodes (7): IntervalsConnectionError, IntervalsConnectionTester, IntervalsService, IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>, IntervalsUseCases, LiveClock, normalize_workout_text()
+Nodes (7): IntervalsConnectionError, IntervalsConnectionTester, IntervalsService, IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>, IntervalsUseCases, LiveClock, normalize_workout_text()
 
-### Community 26 - "Community 26"
-Cohesion: 0.08
-Nodes (6): ActualWorkoutMatch, MatchedWorkoutInterval, ParsedWorkoutDoc, WorkoutIntervalDefinition, WorkoutSegment, WorkoutSummary
-
-### Community 27 - "Community 27"
+### Community 35 - "Community 35"
 Cohesion: 0.15
 Nodes (22): env_lock(), google_oauth_settings_debug_redacts_client_secret(), required_settings_map(), settings_allow_cross_site_cookie_when_secure_and_same_site_none(), settings_allow_dev_auth_without_google_oauth_credentials(), settings_allow_dev_intervals_toggle(), settings_allow_dev_llm_coach_toggle(), settings_from_env_rejects_non_unicode_values() (+14 more)
 
-### Community 28 - "Community 28"
+### Community 36 - "Community 36"
 Cohesion: 0.1
 Nodes (8): delete_race_returns_204(), EmptyHiddenSource, EmptyLabelSource, get_race_returns_race_for_existing_id(), list_races_is_scoped_to_authenticated_user(), list_races_returns_all_races(), RecordingRaceService, update_race_returns_updated_race_payload()
 
-### Community 29 - "Community 29"
+### Community 37 - "Community 37"
 Cohesion: 0.1
 Nodes (4): FailingUpsertTrainingPlanOperationRepository, InMemoryTrainingPlanOperationRepository, InMemoryTrainingPlanProjectedDayRepository, InMemoryTrainingPlanSnapshotRepository
 
-### Community 30 - "Community 30"
+### Community 38 - "Community 38"
+Cohesion: 0.08
+Nodes (6): ActualWorkoutMatch, MatchedWorkoutInterval, ParsedWorkoutDoc, WorkoutIntervalDefinition, WorkoutSegment, WorkoutSummary
+
+### Community 39 - "Community 39"
+Cohesion: 0.18
+Nodes (9): ActiveLogBufferGuard, capture_tracing_logs(), capture_tracing_logs_restores_outer_capture_after_nested_call(), CurrentCaptureScope, global_log_writer_commits_each_event_atomically(), GlobalLogRouter, GlobalLogWriter, init_test_tracing_subscriber() (+1 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.08
 Nodes (14): ActivityIdResponse, ActivityIntervalGroupResponse, ActivityIntervalResponse, ActivityIntervalsResponse, ActivityResponse, ActivityStreamResponse, CreateEventRequest, EventResponse (+6 more)
 
-### Community 31 - "Community 31"
+### Community 41 - "Community 41"
 Cohesion: 0.16
 Nodes (12): activity_detail_richness(), ActivityDocument, build_activity_document(), infer_event_id_hint(), merge_activity_details(), merge_activity_for_storage(), merge_activity_metrics(), MongoActivityRepository (+4 more)
 
-### Community 32 - "Community 32"
-Cohesion: 0.08
-Nodes (5): FixedClock, FixedIds, NonRepositoryFailingReplyOperations, StubReplyOperations, StubSummaryRepository
-
-### Community 33 - "Community 33"
-Cohesion: 0.12
-Nodes (15): AttemptRecordDocument, map_attempt_to_document(), map_document_to_attempt(), map_document_to_failure(), map_document_to_operation(), map_document_to_phase(), map_document_to_status(), map_failure_to_document() (+7 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.13
-Nodes (10): body_logging_enabled(), default_config_disables_body_logging(), EndpointLogConfig, full_config_enables_both(), insert_log_config_service_overrides_existing_config(), InsertLogConfigLayer, InsertLogConfigService, InsertLogConfigService<S> (+2 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.09
-Nodes (18): AiAgentsDto, AvailabilityDayDto, AvailabilityDayRequest, AvailabilityDto, CyclingDto, IntervalsDto, OptionalStringInput, OptionsDto (+10 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.09
-Nodes (10): CanonicalEntityKind, CanonicalEntityRef, ConflictStatus, ExternalObjectKind, ExternalObservation, ExternalProvider, ExternalSyncState, ExternalSyncStatus (+2 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.09
-Nodes (10): activity_date(), ActivityFileIdentityExtractorPort, ActivityRepositoryPort, ActivityUploadOperationRepositoryPort, EnrichedEvent, IntervalsApiPort, IntervalsSettingsPort, NoopActivityFileIdentityExtractor (+2 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.14
-Nodes (15): build_planned_workout(), build_planned_workout_blocks(), build_projected_planned_workout(), build_recent_day_contexts(), build_recent_workout(), build_upcoming_day_contexts(), EventActivityMatches, flush_repeated_steps() (+7 more)
-
-### Community 39 - "Community 39"
+### Community 42 - "Community 42"
 Cohesion: 0.14
 Nodes (2): RepositoryErrorSettingsService, TestSettingsService
 
-### Community 40 - "Community 40"
-Cohesion: 0.17
-Nodes (16): collect_body(), format_body_for_logging(), format_response_body_for_logging(), log_request(), log_response(), preserves_large_request_body_when_body_logging_enabled(), preserves_large_response_body_when_body_logging_enabled(), request_logging_json_preview_honors_configured_limit() (+8 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.11
-Nodes (12): approximate_token_budget_for_model(), LlmCacheUsage, LlmChatMessage, LlmChatRequest, LlmChatResponse, LlmContextCache, LlmMessageRole, LlmProvider (+4 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.13
-Nodes (11): is_allowed_availability_duration(), validate_availability(), validate_availability_day(), validate_availability_derives_not_configured_when_all_days_unavailable(), validate_availability_ignores_incoming_false_configured_when_days_are_available(), validate_availability_rejects_duration_for_unavailable_day(), validate_availability_rejects_invalid_duration_for_available_day(), validate_optional_profile_text() (+3 more)
-
 ### Community 43 - "Community 43"
-Cohesion: 0.12
-Nodes (8): GeneratedTrainingPlan, TrainingPlanDay, TrainingPlanError, TrainingPlanFailureState, TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation, TrainingPlanProjectedDay, TrainingPlanSnapshot
+Cohesion: 0.11
+Nodes (5): get_activity_returns_requested_seeded_activity(), InMemoryIntervalsService, list_and_get_activity_scope_results_by_user_id(), sample_activity(), sample_activity_uses_current_date_for_recent_window()
 
 ### Community 44 - "Community 44"
+Cohesion: 0.12
+Nodes (15): AttemptRecordDocument, map_attempt_to_document(), map_document_to_attempt(), map_document_to_failure(), map_document_to_operation(), map_document_to_phase(), map_document_to_status(), map_failure_to_document() (+7 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.17
+Nodes (15): canonical_entity_kind_as_str(), conflict_status_as_str(), ExternalSyncStateDocument, map_canonical_entity_kind(), map_conflict_status(), map_document_to_sync_state(), map_provider(), map_sync_state_to_document() (+7 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.09
+Nodes (18): AiAgentsDto, AvailabilityDayDto, AvailabilityDayRequest, AvailabilityDto, CyclingDto, IntervalsDto, OptionalStringInput, OptionsDto (+10 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.13
+Nodes (10): body_logging_enabled(), default_config_disables_body_logging(), EndpointLogConfig, full_config_enables_both(), insert_log_config_service_overrides_existing_config(), InsertLogConfigLayer, InsertLogConfigService, InsertLogConfigService<S> (+2 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.09
+Nodes (10): activity_date(), ActivityFileIdentityExtractorPort, ActivityRepositoryPort, ActivityUploadOperationRepositoryPort, EnrichedEvent, IntervalsApiPort, IntervalsSettingsPort, NoopActivityFileIdentityExtractor (+2 more)
+
+### Community 49 - "Community 49"
+Cohesion: 0.14
+Nodes (15): build_planned_workout(), build_planned_workout_blocks(), build_projected_planned_workout(), build_recent_day_contexts(), build_recent_workout(), build_upcoming_day_contexts(), EventActivityMatches, flush_repeated_steps() (+7 more)
+
+### Community 50 - "Community 50"
 Cohesion: 0.1
 Nodes (7): EmptyHiddenSource, HiddenIdsSource, list_calendar_events_hides_intervals_events_linked_to_labels(), list_calendar_labels_is_scoped_to_authenticated_user(), list_calendar_labels_returns_race_labels_grouped_by_date(), RaceLabelSource, StubRaceService
 
-### Community 45 - "Community 45"
-Cohesion: 0.1
-Nodes (10): PlannedWorkout, PlannedWorkoutDay, PlannedWorkoutDays, PlannedWorkoutLine, PlannedWorkoutParseError, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind (+2 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.1
-Nodes (20): AthleteProfileContext, FuturePlannedEventContext, HistoricalLoadTrendPoint, HistoricalTrainingContext, HistoricalWorkoutContext, IntervalsStatusContext, PlannedWorkoutBlockContext, PlannedWorkoutContext (+12 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.16
-Nodes (19): ActivityPath, AthletePath, capture_request(), create_event_handler(), delete_activity_handler(), delete_event_handler(), download_fit_handler(), EventPath (+11 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.11
-Nodes (1): TestIntervalsService
-
-### Community 49 - "Community 49"
+### Community 51 - "Community 51"
 Cohesion: 0.13
 Nodes (8): activity_date(), activity_detail_richness(), FakeActivityRepository, merge_activity_details(), merge_activity_for_storage(), merge_activity_metrics(), prefer_non_empty(), RepoCall
 
-### Community 50 - "Community 50"
-Cohesion: 0.17
-Nodes (17): accepts_html(), apply_incoming_trace_context(), internal_error_response(), is_api_route(), is_file_like_path(), is_health_request(), log_response_event(), make_request_span() (+9 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.23
-Nodes (7): ActiveLogBufferGuard, capture_tracing_logs(), global_log_writer_commits_each_event_atomically(), GlobalLogRouter, GlobalLogWriter, init_test_tracing_subscriber(), SharedLogBuffer
-
 ### Community 52 - "Community 52"
-Cohesion: 0.2
-Nodes (13): canonical_entity_kind_as_str(), conflict_status_as_str(), ExternalSyncStateDocument, map_canonical_entity_kind(), map_conflict_status(), map_document_to_sync_state(), map_provider(), map_sync_state_to_document() (+5 more)
+Cohesion: 0.12
+Nodes (8): ctrl_c_registration_error_logs_and_finishes_shutdown_future(), FixedClock, reconcile_intervals_poll_states_seeds_missing_states_for_existing_connected_users(), SharedLogBuffer, sigterm_registration_error_logs_and_finishes_shutdown_future(), test_mongo_client_or_skip(), test_mongo_uri(), unique_test_database_name()
 
 ### Community 53 - "Community 53"
 Cohesion: 0.16
-Nodes (13): compress_encoded_runs(), compress_power_stream(), compress_stream_chunks(), encode_power_level(), EncodedPowerRun, extract_and_average_stream(), extract_raw_stream(), format_encoded_runs() (+5 more)
+Nodes (8): advance_calendar_cursor(), advance_completed_workout_cursor(), epoch_seconds_to_date(), format_date(), parse_date_cursor(), ProviderPollingService, ProviderPollingService<Api, Settings, PollStates, Imports, Time, Ids, Refresh>, spawn_provider_polling_loop()
 
 ### Community 54 - "Community 54"
-Cohesion: 0.23
-Nodes (15): escaped_near_limit_valid_payload_is_still_accepted(), frontend_fixture(), FrontendFixture, log_ingestion_does_not_emit_request_body_log(), log_ingestion_rejects_requests_with_mismatched_origin(), log_ingestion_rejects_requests_without_origin(), log_ingestion_returns_not_found_when_disabled(), logs_request() (+7 more)
+Cohesion: 0.17
+Nodes (16): collect_body(), format_body_for_logging(), format_response_body_for_logging(), log_request(), log_response(), preserves_large_request_body_when_body_logging_enabled(), preserves_large_response_body_when_body_logging_enabled(), request_logging_json_preview_honors_configured_limit() (+8 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.11
-Nodes (8): ResponseActivity, ResponseActivityGroup, ResponseActivityId, ResponseActivityInterval, ResponseActivityIntervals, ResponseActivityStream, ResponseEvent, ResponseUpload
+Cohesion: 0.13
+Nodes (11): is_allowed_availability_duration(), validate_availability(), validate_availability_day(), validate_availability_derives_not_configured_when_all_days_unavailable(), validate_availability_ignores_incoming_false_configured_when_days_are_available(), validate_availability_rejects_duration_for_unavailable_day(), validate_availability_rejects_invalid_duration_for_available_day(), validate_optional_profile_text() (+3 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.13
-Nodes (7): build_planned_workout(), list_calendar_events_returns_predicted_events_with_positive_safe_ids(), projected_day(), sync_planned_workout_is_scoped_to_authenticated_user(), sync_planned_workout_preserves_existing_remote_description(), sync_planned_workout_returns_synced_calendar_event(), TestTrainingPlanProjectionRepository
+Cohesion: 0.11
+Nodes (12): approximate_token_budget_for_model(), LlmCacheUsage, LlmChatMessage, LlmChatRequest, LlmChatResponse, LlmContextCache, LlmMessageRole, LlmProvider (+4 more)
 
 ### Community 57 - "Community 57"
-Cohesion: 0.14
-Nodes (5): FixedClock, new_call_log(), push_call(), StubTrainingPlanGenerator, StubWorkoutSummaryPort
+Cohesion: 0.12
+Nodes (8): GeneratedTrainingPlan, TrainingPlanDay, TrainingPlanError, TrainingPlanFailureState, TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation, TrainingPlanProjectedDay, TrainingPlanSnapshot
 
 ### Community 58 - "Community 58"
 Cohesion: 0.16
-Nodes (14): AuthMeResponse, build_session_cookie(), buildAuthUrl(), buildGoogleLoginUrl(), clear_session_cookie(), current_user(), CurrentUserDto, finish_google_login() (+6 more)
+Nodes (19): ActivityPath, AthletePath, capture_request(), create_event_handler(), delete_activity_handler(), delete_event_handler(), download_fit_handler(), EventPath (+11 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.14
-Nodes (9): AppUser, assign_roles(), authorize_admin_access(), AuthSession, GoogleIdentity, IdentityError, LoginState, normalize_email() (+1 more)
+Cohesion: 0.12
+Nodes (7): build_planned_workout(), list_calendar_events_returns_predicted_events_with_positive_safe_ids(), projected_day(), sync_planned_workout_is_scoped_to_authenticated_user(), sync_planned_workout_preserves_existing_remote_description(), sync_planned_workout_returns_synced_calendar_event(), TestTrainingPlanProjectionRepository
 
 ### Community 60 - "Community 60"
-Cohesion: 0.16
-Nodes (9): compute_session_expiry(), GoogleLoginStart, GoogleLoginSuccess, IdentityService, IdentityService<Users, Sessions, LoginStates, GoogleOAuth, Time, Ids>, IdentityServiceConfig, IdentityUseCases, sanitize_return_to() (+1 more)
+Cohesion: 0.11
+Nodes (1): TestIntervalsService
 
 ### Community 61 - "Community 61"
+Cohesion: 0.1
+Nodes (10): PlannedWorkout, PlannedWorkoutDay, PlannedWorkoutDays, PlannedWorkoutLine, PlannedWorkoutParseError, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind (+2 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.1
+Nodes (20): AthleteProfileContext, FuturePlannedEventContext, HistoricalLoadTrendPoint, HistoricalTrainingContext, HistoricalWorkoutContext, IntervalsStatusContext, PlannedWorkoutBlockContext, PlannedWorkoutContext (+12 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.16
+Nodes (12): build_due_filter(), due_filter_respects_backoff_window(), map_document_to_poll_state(), map_poll_state_to_document(), map_provider(), map_stream(), MongoProviderPollStateRepository, poll_state_document_rejects_unknown_stream() (+4 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.17
+Nodes (17): accepts_html(), apply_incoming_trace_context(), internal_error_response(), is_api_route(), is_file_like_path(), is_health_request(), log_response_event(), make_request_span() (+9 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.15
+Nodes (1): WorkoutSummaryService<Repo, Ops, Time, Ids>
+
+### Community 66 - "Community 66"
+Cohesion: 0.1
+Nodes (1): ()
+
+### Community 67 - "Community 67"
+Cohesion: 0.23
+Nodes (15): escaped_near_limit_valid_payload_is_still_accepted(), frontend_fixture(), FrontendFixture, log_ingestion_does_not_emit_request_body_log(), log_ingestion_rejects_requests_with_mismatched_origin(), log_ingestion_rejects_requests_without_origin(), log_ingestion_returns_not_found_when_disabled(), logs_request() (+7 more)
+
+### Community 68 - "Community 68"
+Cohesion: 0.32
+Nodes (16): completed_workout_repository_round_trips_canonical_completed_workouts(), mongo_fixture_or_skip(), MongoFixture, planned_completed_link_repository_round_trips_and_indexes_links(), planned_workout_repository_excludes_snapshot_start_date_even_when_it_has_workout(), planned_workout_repository_merges_imported_and_projected_workouts(), planned_workout_repository_reads_active_projected_days_as_canonical_workouts(), planned_workout_token_repository_round_trips_and_indexes_tokens() (+8 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.11
+Nodes (8): ResponseActivity, ResponseActivityGroup, ResponseActivityId, ResponseActivityInterval, ResponseActivityIntervals, ResponseActivityStream, ResponseEvent, ResponseUpload
+
+### Community 70 - "Community 70"
+Cohesion: 0.16
+Nodes (1): TestWorkoutSummaryService
+
+### Community 71 - "Community 71"
+Cohesion: 0.14
+Nodes (5): FixedClock, new_call_log(), push_call(), StubTrainingPlanGenerator, StubWorkoutSummaryPort
+
+### Community 72 - "Community 72"
 Cohesion: 0.36
 Nodes (14): mongo_fixture_or_skip(), MongoFixture, sample_operation(), sample_projected_days(), sample_snapshot(), sample_snapshot_for_user(), training_plan_generation_operation_repository_round_trips_and_reclaims_failed_operations(), training_plan_generation_operation_repository_round_trips_recap_timestamp() (+6 more)
 
-### Community 62 - "Community 62"
+### Community 73 - "Community 73"
 Cohesion: 0.11
 Nodes (0): 
 
-### Community 63 - "Community 63"
-Cohesion: 0.13
-Nodes (10): map_legacy_projection_to_document(), map_record_to_document(), map_summary_to_document(), MongoPestParserPocWorkoutRepository, ParsedWorkoutDocDocument, PestParserPocParsedPayloadDocument, PestParserPocWorkoutDocument, WorkoutIntervalDefinitionDocument (+2 more)
+### Community 74 - "Community 74"
+Cohesion: 0.19
+Nodes (11): canonical_entity_kind_as_str(), external_object_kind_as_str(), ExternalObservationDocument, map_canonical_entity_kind(), map_document_to_observation(), map_external_object_kind(), map_observation_to_document(), map_provider() (+3 more)
 
-### Community 64 - "Community 64"
-Cohesion: 0.12
-Nodes (9): AuthSettings, AuthSettingsParts, DevAuthSettings, GoogleOAuthSettings, MongoSettings, ServerSettings, SessionSettings, Settings (+1 more)
+### Community 75 - "Community 75"
+Cohesion: 0.16
+Nodes (14): AuthMeResponse, build_session_cookie(), buildAuthUrl(), buildGoogleLoginUrl(), clear_session_cookie(), current_user(), CurrentUserDto, finish_google_login() (+6 more)
 
-### Community 65 - "Community 65"
-Cohesion: 0.12
-Nodes (7): CreateRace, Race, RaceDiscipline, RaceError, RacePriority, RaceResult, UpdateRace
+### Community 76 - "Community 76"
+Cohesion: 0.22
+Nodes (15): build_projected_calendar_event(), build_update_event(), format_projected_step_duration(), format_projected_step_target(), merge_event_description(), projected_day_payload_hash(), projected_day_sync_status(), projected_event_payload_hash() (+7 more)
 
-### Community 66 - "Community 66"
+### Community 77 - "Community 77"
+Cohesion: 0.16
+Nodes (9): compute_session_expiry(), GoogleLoginStart, GoogleLoginSuccess, IdentityService, IdentityService<Users, Sessions, LoginStates, GoogleOAuth, Time, Ids>, IdentityServiceConfig, IdentityUseCases, sanitize_return_to() (+1 more)
+
+### Community 78 - "Community 78"
+Cohesion: 0.14
+Nodes (9): AppUser, assign_roles(), authorize_admin_access(), AuthSession, GoogleIdentity, IdentityError, LoginState, normalize_email() (+1 more)
+
+### Community 79 - "Community 79"
 Cohesion: 0.18
-Nodes (1): WorkoutSummaryService<Repo, Ops, Time, Ids>
+Nodes (13): compress_encoded_runs(), compress_power_stream(), compress_stream_chunks(), encode_power_level(), EncodedPowerRun, extract_and_average_stream(), extract_raw_stream(), format_encoded_runs() (+5 more)
 
-### Community 67 - "Community 67"
+### Community 80 - "Community 80"
 Cohesion: 0.15
 Nodes (2): AdminIdentityErrorService, TestIdentityServiceWithSession
 
-### Community 68 - "Community 68"
+### Community 81 - "Community 81"
 Cohesion: 0.29
 Nodes (16): add_days(), date_epoch(), plan_with_invalid_day(), single_invalid_day(), single_rest_day(), snapshot_for_first_day(), snapshot_projected_days_for_first_day(), stale_pending_operation_with_checkpoints() (+8 more)
 
-### Community 69 - "Community 69"
+### Community 82 - "Community 82"
 Cohesion: 0.12
-Nodes (1): TestWorkoutSummaryService
+Nodes (9): AuthSettings, AuthSettingsParts, DevAuthSettings, GoogleOAuthSettings, MongoSettings, ServerSettings, SessionSettings, Settings (+1 more)
 
-### Community 70 - "Community 70"
-Cohesion: 0.22
-Nodes (11): canonical_entity_kind_as_str(), external_object_kind_as_str(), ExternalObservationDocument, map_canonical_entity_kind(), map_document_to_observation(), map_external_object_kind(), map_observation_to_document(), map_provider() (+3 more)
+### Community 83 - "Community 83"
+Cohesion: 0.13
+Nodes (10): map_legacy_projection_to_document(), map_record_to_document(), map_summary_to_document(), MongoPestParserPocWorkoutRepository, ParsedWorkoutDocDocument, PestParserPocParsedPayloadDocument, PestParserPocWorkoutDocument, WorkoutIntervalDefinitionDocument (+2 more)
 
-### Community 71 - "Community 71"
-Cohesion: 0.17
-Nodes (7): ExternalSyncStateDocument, map_discipline(), map_document_to_race(), map_priority(), map_sync_status(), MongoRaceCalendarSource, RaceDocument
-
-### Community 72 - "Community 72"
-Cohesion: 0.23
-Nodes (3): map_user_document(), MongoUserRepository, UserDocument
-
-### Community 73 - "Community 73"
+### Community 84 - "Community 84"
 Cohesion: 0.12
-Nodes (11): NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation, PestParserPocParsedPayload, PestParserPocRecordContext, PestParserPocRepositoryPort, PestParserPocSource, PestParserPocStatus (+3 more)
+Nodes (8): CalendarError, CalendarEvent, CalendarEventCategory, CalendarEventSource, CalendarProjectedWorkout, PlannedWorkoutSyncRecord, PlannedWorkoutSyncStatus, SyncPlannedWorkout
 
-### Community 74 - "Community 74"
+### Community 85 - "Community 85"
 Cohesion: 0.14
-Nodes (2): SessionMappedIdentityService, TestIdentityServiceWithSession
+Nodes (6): CalendarEntryViewService, CalendarEntryViewService<
+        Repository,
+        NoopPlannedWorkoutSyncRepository,
+        NoopExternalSyncStateRepository,
+    >, CalendarEntryViewService<Repository, PlannedSyncs, SyncStates>, linked_intervals_event_id(), map_external_sync_state(), map_planned_sync_record_to_calendar_entry_sync()
 
-### Community 75 - "Community 75"
-Cohesion: 0.23
-Nodes (14): api_error_propagated_to_caller(), create_event_passes_event_to_api(), create_event_stores_failed_poc_record_for_malformed_workout(), create_event_stores_poc_record_for_outbound_push(), delete_event_calls_api_and_returns_ok(), download_fit_returns_bytes(), FixedClock, get_enriched_event_propagates_activity_lookup_failure() (+6 more)
+### Community 86 - "Community 86"
+Cohesion: 0.12
+Nodes (7): CreateRace, Race, RaceDiscipline, RaceError, RacePriority, RaceResult, UpdateRace
 
-### Community 76 - "Community 76"
+### Community 87 - "Community 87"
+Cohesion: 0.12
+Nodes (6): ExternalObservationRepository, ExternalSyncStateRepository, NoopExternalObservationRepository, NoopExternalSyncStateRepository, NoopProviderPollStateRepository, ProviderPollStateRepository
+
+### Community 88 - "Community 88"
 Cohesion: 0.12
 Nodes (2): InMemoryCoachReplyOperationRepository, InMemoryWorkoutSummaryRepository
 
-### Community 77 - "Community 77"
+### Community 89 - "Community 89"
+Cohesion: 0.12
+Nodes (3): InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutRepository, InMemorySpecialDayRepository
+
+### Community 90 - "Community 90"
+Cohesion: 0.12
+Nodes (0): 
+
+### Community 91 - "Community 91"
 Cohesion: 0.14
 Nodes (3): claim_pending_reclaims_stale_pending_operations(), InMemoryCoachReplyOperationRepository, InMemoryWorkoutSummaryRepository
 
-### Community 78 - "Community 78"
+### Community 92 - "Community 92"
+Cohesion: 0.14
+Nodes (2): SessionMappedIdentityService, TestIdentityServiceWithSession
+
+### Community 93 - "Community 93"
+Cohesion: 0.23
+Nodes (14): api_error_propagated_to_caller(), create_event_passes_event_to_api(), create_event_stores_failed_poc_record_for_malformed_workout(), create_event_stores_poc_record_for_outbound_push(), delete_event_calls_api_and_returns_ok(), download_fit_returns_bytes(), FixedClock, get_enriched_event_propagates_activity_lookup_failure() (+6 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.23
+Nodes (3): map_user_document(), MongoUserRepository, UserDocument
+
+### Community 95 - "Community 95"
+Cohesion: 0.2
+Nodes (9): CalendarEntryRaceDocument, CalendarEntrySummaryDocument, CalendarEntrySyncDocument, CalendarEntryViewDocument, map_document_to_entry(), map_entry_to_document(), map_kind_from_str(), MongoCalendarEntryViewRepository (+1 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.18
+Nodes (11): category_to_string(), map_actual_workout_to_dto(), map_calendar_event_to_dto(), map_calendar_label_payload_to_dto(), map_calendar_label_to_dto(), map_calendar_labels_to_dto(), map_category(), map_enriched_event_to_dto() (+3 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.12
+Nodes (11): NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation, PestParserPocParsedPayload, PestParserPocRecordContext, PestParserPocRepositoryPort, PestParserPocSource, PestParserPocStatus (+3 more)
+
+### Community 98 - "Community 98"
 Cohesion: 0.18
 Nodes (7): makeActivity(), makeActivityDetails(), makeActivityMetrics(), makeActualWorkout(), makeEvent(), makeEventDefinition(), makeWorkoutSummary()
 
-### Community 79 - "Community 79"
+### Community 99 - "Community 99"
 Cohesion: 0.16
 Nodes (4): listActivities(), listCalendarEvents(), listEvents(), toQueryString()
 
-### Community 80 - "Community 80"
-Cohesion: 0.13
-Nodes (1): DevIntervalsClient
-
-### Community 81 - "Community 81"
-Cohesion: 0.23
-Nodes (9): map_document_to_poll_state(), map_poll_state_to_document(), map_provider(), map_stream(), MongoProviderPollStateRepository, poll_state_document_round_trip_preserves_fields(), provider_as_str(), ProviderPollStateDocument (+1 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.16
-Nodes (6): map_discipline(), map_document_to_race(), map_priority(), map_race_to_document(), MongoRaceRepository, RaceDocument
-
-### Community 83 - "Community 83"
-Cohesion: 0.28
-Nodes (1): AthleteSummaryService<Repo, Ops, Generator, Time>
-
-### Community 84 - "Community 84"
-Cohesion: 0.13
-Nodes (7): CalendarError, CalendarEvent, CalendarEventSource, CalendarProjectedWorkout, PlannedWorkoutSyncRecord, PlannedWorkoutSyncStatus, SyncPlannedWorkout
-
-### Community 85 - "Community 85"
-Cohesion: 0.13
-Nodes (6): ExternalObservationRepository, ExternalSyncStateRepository, NoopExternalObservationRepository, NoopExternalSyncStateRepository, NoopProviderPollStateRepository, ProviderPollStateRepository
-
-### Community 86 - "Community 86"
-Cohesion: 0.15
-Nodes (2): RecapSnapshot, WorkoutSummaryService<Repo, Ops, Time, Ids>
-
-### Community 87 - "Community 87"
+### Community 100 - "Community 100"
 Cohesion: 0.13
 Nodes (0): 
 
-### Community 88 - "Community 88"
+### Community 101 - "Community 101"
 Cohesion: 0.13
 Nodes (0): 
 
-### Community 89 - "Community 89"
+### Community 102 - "Community 102"
 Cohesion: 0.14
 Nodes (1): ScopedIntervalsService
 
-### Community 90 - "Community 90"
-Cohesion: 0.18
-Nodes (5): get_activity_returns_requested_seeded_activity(), InMemoryIntervalsService, list_and_get_activity_scope_results_by_user_id(), sample_activity(), sample_activity_uses_current_date_for_recent_window()
+### Community 103 - "Community 103"
+Cohesion: 0.13
+Nodes (2): FailingCalendarRefresh, RecordingCalendarRefresh
 
-### Community 91 - "Community 91"
+### Community 104 - "Community 104"
+Cohesion: 0.13
+Nodes (1): DevIntervalsClient
+
+### Community 105 - "Community 105"
 Cohesion: 0.16
-Nodes (3): buildCalendarWeek(), roundMetric(), sumMetric()
+Nodes (6): map_discipline(), map_document_to_race(), map_priority(), map_race_to_document(), MongoRaceRepository, RaceDocument
 
-### Community 92 - "Community 92"
+### Community 106 - "Community 106"
+Cohesion: 0.28
+Nodes (1): AthleteSummaryService<Repo, Ops, Generator, Time>
+
+### Community 107 - "Community 107"
+Cohesion: 0.15
+Nodes (2): RecapSnapshot, WorkoutSummaryService<Repo, Ops, Time, Ids>
+
+### Community 108 - "Community 108"
+Cohesion: 0.14
+Nodes (4): CalendarEntryViewRefreshPort, CalendarEntryViewRefreshService, CalendarEntryViewRefreshService<
+        Views,
+        Planned,
+        PlannedSyncs,
+        Completed,
+        Races,
+        SpecialDays,
+        SyncStates,
+    >, NoopCalendarEntryViewRefresh
+
+### Community 109 - "Community 109"
+Cohesion: 0.13
+Nodes (0): 
+
+### Community 110 - "Community 110"
 Cohesion: 0.23
 Nodes (8): addDays(), addWeeks(), formatDateRange(), getMondayOfWeek(), isSameDay(), isToday(), startOfLocalDay(), toDateKey()
 
-### Community 93 - "Community 93"
-Cohesion: 0.14
-Nodes (1): IntervalsApiAdapter
+### Community 111 - "Community 111"
+Cohesion: 0.16
+Nodes (3): buildCalendarWeek(), roundMetric(), sumMetric()
 
-### Community 94 - "Community 94"
-Cohesion: 0.21
-Nodes (7): training_plan_correction_system_prompt(), training_plan_initial_window_system_prompt(), training_plan_prompts_adjust_availability_guidance_when_not_configured(), training_plan_prompts_include_durability_guidelines(), training_plan_recap_system_prompt(), TrainingPlanLlmGenerator, TrainingPlanLlmGenerator<Time>
-
-### Community 95 - "Community 95"
-Cohesion: 0.14
-Nodes (13): OpenRouterCacheControl, OpenRouterChatRequest, OpenRouterChatResponse, OpenRouterChoice, OpenRouterContentPart, OpenRouterMessage, OpenRouterMessageContent, OpenRouterMessageResponse (+5 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.22
-Nodes (11): binary_body_preview_format(), body_preview_truncates(), format_binary_body_preview(), format_body_preview(), header_redaction(), is_sensitive_header(), redact_headers(), redact_sensitive_child_value() (+3 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.14
-Nodes (1): AppState
-
-### Community 98 - "Community 98"
+### Community 112 - "Community 112"
 Cohesion: 0.16
 Nodes (2): LargeContextTrainingContextBuilder, UnconfiguredAvailabilityTrainingContextBuilder
 
-### Community 99 - "Community 99"
+### Community 113 - "Community 113"
 Cohesion: 0.14
 Nodes (0): 
 
-### Community 100 - "Community 100"
-Cohesion: 0.19
-Nodes (5): buildWorkoutItems(), chooseMatchedActivity(), inferEventIdHint(), namesLookRelated(), normalizeName()
-
-### Community 101 - "Community 101"
-Cohesion: 0.26
-Nodes (8): getAiAgentsFieldValue(), getOptionalStringFieldValue(), normalizeAiAgentsPayload(), testAiAgentsConnection(), trimToUndefined(), updateAiAgents(), updateCycling(), updateIntervals()
-
-### Community 102 - "Community 102"
-Cohesion: 0.23
-Nodes (7): ActivityFileIdentityExtractor, enum_u8_field(), extract_fit_identity(), float_field(), int_field(), map_fit_activity_type(), timestamp_field()
-
-### Community 103 - "Community 103"
-Cohesion: 0.32
-Nodes (1): DefaultTrainingContextBuilder<Time>
-
-### Community 104 - "Community 104"
-Cohesion: 0.15
-Nodes (0): 
-
-### Community 105 - "Community 105"
-Cohesion: 0.15
-Nodes (0): 
-
-### Community 106 - "Community 106"
-Cohesion: 0.15
-Nodes (1): InMemoryWorkoutSummaryRepository
-
-### Community 107 - "Community 107"
-Cohesion: 0.26
-Nodes (9): AuthenticationError, buildUrl(), del(), get(), HttpError, patch(), post(), put() (+1 more)
-
-### Community 108 - "Community 108"
-Cohesion: 0.17
-Nodes (1): IntervalsIcuClient
-
-### Community 109 - "Community 109"
-Cohesion: 0.21
-Nodes (4): chat_times_out_when_model_exceeds_deadline(), is_thinking_model(), LlmAdapter, with_timeout()
-
-### Community 110 - "Community 110"
-Cohesion: 0.21
-Nodes (2): CoachReplyOperationDocument, MongoCoachReplyOperationRepository
-
-### Community 111 - "Community 111"
-Cohesion: 0.23
-Nodes (4): LoginStateDocument, map_login_state_document(), MongoLoginStateRepository, rejects_login_state_expiry_that_cannot_be_converted_to_bson_datetime()
-
-### Community 112 - "Community 112"
-Cohesion: 0.21
-Nodes (3): MongoTrainingPlanProjectionRepository, TrainingPlanProjectedDayDocument, validate_replacement_scope()
-
-### Community 113 - "Community 113"
-Cohesion: 0.18
-Nodes (3): MongoTrainingPlanSnapshotRepository, TrainingPlanDayDocument, TrainingPlanSnapshotDocument
-
 ### Community 114 - "Community 114"
-Cohesion: 0.17
-Nodes (11): CalendarActivityLabelDto, CalendarCustomLabelDto, CalendarEventDto, CalendarHealthLabelDto, CalendarLabelDto, CalendarLabelPayloadDto, CalendarLabelsResponseDto, CalendarRaceLabelDto (+3 more)
+Cohesion: 0.14
+Nodes (1): AppState
 
 ### Community 115 - "Community 115"
-Cohesion: 0.24
-Nodes (6): optional_bool_setting(), optional_string_setting(), parse_bool_setting(), parse_dev_auth_settings(), parse_google_oauth_settings(), required()
+Cohesion: 0.21
+Nodes (7): training_plan_correction_system_prompt(), training_plan_initial_window_system_prompt(), training_plan_prompts_adjust_availability_guidance_when_not_configured(), training_plan_prompts_include_durability_guidelines(), training_plan_recap_system_prompt(), TrainingPlanLlmGenerator, TrainingPlanLlmGenerator<Time>
 
 ### Community 116 - "Community 116"
-Cohesion: 0.18
-Nodes (8): CalendarActivityLabel, CalendarCustomLabel, CalendarHealthLabel, CalendarLabel, CalendarLabelError, CalendarLabelPayload, CalendarLabelsResponse, CalendarRaceLabel
+Cohesion: 0.14
+Nodes (13): OpenRouterCacheControl, OpenRouterChatRequest, OpenRouterChatResponse, OpenRouterChoice, OpenRouterContentPart, OpenRouterMessage, OpenRouterMessageContent, OpenRouterMessageResponse (+5 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.17
-Nodes (10): CompactAvailabilityDay, CompactFuturePlannedEvent, CompactHistoricalLoadTrend, CompactHistoricalWorkout, CompactHistory, CompactIntervalsStatus, CompactPlannedWorkoutBlock, CompactProfile (+2 more)
+Cohesion: 0.14
+Nodes (1): IntervalsApiAdapter
 
 ### Community 118 - "Community 118"
-Cohesion: 0.24
-Nodes (7): build_load_trend(), build_load_trend_point(), build_recent_interval_blocks(), build_recent_interval_blocks_by_activity_id(), ewma_at_index(), ewma_latest(), rolling_average_at_index()
+Cohesion: 0.19
+Nodes (7): CalendarEntryRaceDocument, CalendarEntrySyncDocument, CalendarEntryViewDocument, map_race_label(), MongoCalendarEntryViewCalendarSource, parse_race_description(), strip_race_title_prefix()
 
 ### Community 119 - "Community 119"
-Cohesion: 0.17
-Nodes (0): 
+Cohesion: 0.22
+Nodes (11): binary_body_preview_format(), body_preview_truncates(), format_binary_body_preview(), format_body_preview(), header_redaction(), is_sensitive_header(), redact_headers(), redact_sensitive_child_value() (+3 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.33
-Nodes (1): TrainingPlanGenerationService<
-        Snapshots,
-        Projections,
-        Operations,
-        Generator,
-        WorkoutSummary,
-        Time,
+Cohesion: 0.25
+Nodes (2): TrainingPlanGenerationService<
+        Snapshots,
+        Projections,
+        Operations,
+        Generator,
+        WorkoutSummary,
+        Time,
+    >, TrainingPlanGenerationService<
+        Snapshots,
+        Projections,
+        Operations,
+        Generator,
+        WorkoutSummary,
+        Time,
+        Refresh,
     >
 
 ### Community 121 - "Community 121"
+Cohesion: 0.26
+Nodes (8): getAiAgentsFieldValue(), getOptionalStringFieldValue(), normalizeAiAgentsPayload(), testAiAgentsConnection(), trimToUndefined(), updateAiAgents(), updateCycling(), updateIntervals()
+
+### Community 122 - "Community 122"
+Cohesion: 0.49
+Nodes (10): calendar_entry_view_repository_creates_expected_indexes(), calendar_entry_view_repository_lists_mixed_entries_by_date_range(), calendar_entry_view_repository_rejects_replace_range_entries_outside_requested_dates(), calendar_entry_view_repository_replace_all_overwrites_stale_user_rows(), calendar_entry_view_repository_replaces_all_entries_for_user(), calendar_entry_view_repository_replaces_only_target_range_and_handles_date_moves(), mongo_fixture_or_skip(), MongoFixture (+2 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.15
+Nodes (1): InMemoryWorkoutSummaryRepository
+
+### Community 124 - "Community 124"
+Cohesion: 0.15
+Nodes (0): 
+
+### Community 125 - "Community 125"
+Cohesion: 0.15
+Nodes (0): 
+
+### Community 126 - "Community 126"
+Cohesion: 0.23
+Nodes (7): ActivityFileIdentityExtractor, enum_u8_field(), extract_fit_identity(), float_field(), int_field(), map_fit_activity_type(), timestamp_field()
+
+### Community 127 - "Community 127"
+Cohesion: 0.15
+Nodes (9): PlannedWorkout, PlannedWorkoutContent, PlannedWorkoutError, PlannedWorkoutLine, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind, PlannedWorkoutTarget (+1 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.27
+Nodes (12): completed_workout_dedup_key(), completed_workout_distance_bucket(), completed_workout_duration_seconds(), completed_workout_stream_bucket(), completed_workout_stream_distance_bucket(), completed_workout_stream_sample_count(), last_numeric_value(), merge_completed_workout() (+4 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.21
+Nodes (5): buildWorkoutItems(), chooseMatchedActivity(), inferEventIdHint(), namesLookRelated(), normalizeName()
+
+### Community 130 - "Community 130"
+Cohesion: 0.26
+Nodes (9): AuthenticationError, buildUrl(), del(), get(), HttpError, patch(), post(), put() (+1 more)
+
+### Community 131 - "Community 131"
 Cohesion: 0.17
 Nodes (1): InMemoryUserSettingsRepository
 
-### Community 122 - "Community 122"
+### Community 132 - "Community 132"
 Cohesion: 0.17
 Nodes (0): 
 
-### Community 123 - "Community 123"
+### Community 133 - "Community 133"
 Cohesion: 0.2
 Nodes (2): configured_availability(), TestAvailabilitySettingsService
 
-### Community 124 - "Community 124"
-Cohesion: 0.27
-Nodes (8): buildTestStatusMessage(), clearDraftApiKeys(), clearTestStatusIfNeeded(), handleSave(), handleTest(), setStatusFromTest(), updateDraft(), updateProvider()
-
-### Community 125 - "Community 125"
-Cohesion: 0.29
-Nodes (7): finish_server_shutdown(), main(), shutdown_signal(), TrainingPlanWorkoutSummaryAdapter, TrainingPlanWorkoutSummaryAdapter<Service>, wait_for_ctrl_c(), wait_for_sigterm()
-
-### Community 126 - "Community 126"
-Cohesion: 0.22
-Nodes (3): ctrl_c_registration_error_logs_and_does_not_finish_shutdown_future(), SharedLogBuffer, sigterm_registration_error_logs_and_does_not_finish_shutdown_future()
-
-### Community 127 - "Community 127"
-Cohesion: 0.25
-Nodes (7): approximate_token_usage(), build_conversation(), build_stable_context(), build_volatile_context(), LlmWorkoutCoach, LlmWorkoutCoach<Time>, workout_coach_system_prompt()
-
-### Community 128 - "Community 128"
-Cohesion: 0.35
-Nodes (10): activity_document_bson_round_trip_preserves_enriched_completed_fields(), enriched_activity(), infer_event_id_hint_checks_description_after_non_matching_external_id(), merge_activity_for_storage_drops_time_streams(), merge_equal_richness_payloads_preserves_complementary_detail_buckets(), merge_richer_incoming_activity_replaces_existing_payload(), merge_sparse_activity_payload_preserves_existing_enriched_fields(), normalize_activity_document_drops_time_streams_and_refreshes_dedupe_fields() (+2 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.25
-Nodes (4): AthleteSummaryGenerationOperationDocument, map_document_to_domain(), map_domain_to_document(), MongoAthleteSummaryGenerationOperationRepository
-
-### Community 130 - "Community 130"
-Cohesion: 0.22
-Nodes (5): map_document_to_record(), map_record_to_document(), map_status(), MongoPlannedWorkoutSyncRepository, PlannedWorkoutSyncDocument
-
-### Community 131 - "Community 131"
-Cohesion: 0.25
-Nodes (4): map_session_document(), MongoSessionRepository, rejects_session_expiry_that_cannot_be_converted_to_bson_datetime(), SessionDocument
-
-### Community 132 - "Community 132"
-Cohesion: 0.35
-Nodes (9): detect_intervals_from_power_stream(), detected_interval_candidates(), evaluate_activity_match(), extract_float_stream(), extract_integer_stream(), find_best_activity_match(), IntervalCandidate, matching_segments() (+1 more)
-
-### Community 133 - "Community 133"
-Cohesion: 0.18
-Nodes (10): CompactFocus, CompactPlannedWorkout, CompactPlannedWorkoutRef, CompactProjectedDay, CompactProjectedWorkout, CompactRecentDay, CompactRecentWorkout, CompactSpecialDay (+2 more)
-
 ### Community 134 - "Community 134"
-Cohesion: 0.35
-Nodes (4): mongo_fixture_or_skip(), MongoFixture, pest_parser_poc_repository_creates_expected_indexes(), pest_parser_poc_repository_inserts_failed_record_document()
+Cohesion: 0.24
+Nodes (8): finish_server_shutdown(), reconcile_intervals_poll_states(), should_reset_poll_state(), shutdown_signal(), TrainingPlanWorkoutSummaryAdapter, TrainingPlanWorkoutSummaryAdapter<Service>, wait_for_ctrl_c(), wait_for_sigterm()
 
 ### Community 135 - "Community 135"
-Cohesion: 0.22
-Nodes (3): find_best_activity_match_prefers_detected_intervals_and_extracts_streams(), ignores_invalid_stream_samples_when_extracting_actual_workout_data(), sample_activity()
+Cohesion: 0.24
+Nodes (6): optional_bool_setting(), optional_string_setting(), parse_bool_setting(), parse_dev_auth_settings(), parse_google_oauth_settings(), required()
 
 ### Community 136 - "Community 136"
-Cohesion: 0.18
-Nodes (1): FakeSettingsUseCases
+Cohesion: 0.21
+Nodes (4): chat_times_out_when_model_exceeds_deadline(), is_thinking_model(), LlmAdapter, with_timeout()
 
 ### Community 137 - "Community 137"
-Cohesion: 0.18
-Nodes (0): 
+Cohesion: 0.17
+Nodes (1): IntervalsIcuClient
 
 ### Community 138 - "Community 138"
-Cohesion: 0.22
-Nodes (1): InMemoryCoachReplyOperationRepository
+Cohesion: 0.23
+Nodes (4): LoginStateDocument, map_login_state_document(), MongoLoginStateRepository, rejects_login_state_expiry_that_cannot_be_converted_to_bson_datetime()
 
 ### Community 139 - "Community 139"
-Cohesion: 0.38
-Nodes (8): createWorkoutSummary(), ensureWorkoutSummary(), getWorkoutSummary(), normalizeWorkoutTargetId(), reopenWorkoutSummary(), saveWorkoutSummary(), sendWorkoutSummaryMessage(), updateWorkoutSummaryRpe()
+Cohesion: 0.21
+Nodes (2): CoachReplyOperationDocument, MongoCoachReplyOperationRepository
 
 ### Community 140 - "Community 140"
-Cohesion: 0.22
-Nodes (2): formatRaceDate(), parseRaceDate()
+Cohesion: 0.18
+Nodes (3): MongoTrainingPlanSnapshotRepository, TrainingPlanDayDocument, TrainingPlanSnapshotDocument
 
 ### Community 141 - "Community 141"
-Cohesion: 0.29
-Nodes (4): extract_message_text(), map_message(), map_request(), map_response()
+Cohesion: 0.23
+Nodes (6): map_document_to_special_day(), map_kind_from_str(), map_kind_to_str(), map_special_day_to_document(), MongoSpecialDayRepository, SpecialDayDocument
 
 ### Community 142 - "Community 142"
-Cohesion: 0.22
-Nodes (3): database_needs_bootstrap(), ensure_database_exists(), MongoConnectionError
+Cohesion: 0.21
+Nodes (3): MongoTrainingPlanProjectionRepository, TrainingPlanProjectedDayDocument, validate_replacement_scope()
 
 ### Community 143 - "Community 143"
-Cohesion: 0.22
-Nodes (3): LlmContextCacheDocument, map_domain_to_document(), MongoLlmContextCacheRepository
+Cohesion: 0.23
+Nodes (6): map_document_to_domain(), map_domain_to_document(), match_source_as_str(), match_source_from_str(), MongoPlannedCompletedWorkoutLinkRepository, PlannedCompletedWorkoutLinkDocument
 
 ### Community 144 - "Community 144"
-Cohesion: 0.29
-Nodes (5): category_to_string(), map_enriched_event_to_dto(), map_event_to_dto(), map_event_to_dto_with_parsed(), map_event_to_dto_with_parsed_workout_doc()
+Cohesion: 0.17
+Nodes (11): CalendarActivityLabelDto, CalendarCustomLabelDto, CalendarEventDto, CalendarHealthLabelDto, CalendarLabelDto, CalendarLabelPayloadDto, CalendarLabelsResponseDto, CalendarRaceLabelDto (+3 more)
 
 ### Community 145 - "Community 145"
-Cohesion: 0.4
-Nodes (9): auth_and_get_race_service(), create_race(), delete_race(), get_race(), list_races(), map_request(), parse_discipline(), parse_priority() (+1 more)
+Cohesion: 0.18
+Nodes (8): CalendarActivityLabel, CalendarCustomLabel, CalendarHealthLabel, CalendarLabel, CalendarLabelError, CalendarLabelPayload, CalendarLabelsResponse, CalendarRaceLabel
 
 ### Community 146 - "Community 146"
-Cohesion: 0.38
-Nodes (9): client_error_message(), close_ws(), handle_socket(), handle_socket_message(), process_send_message(), send_ws_json(), should_close_worker(), SocketMessageAction (+1 more)
+Cohesion: 0.24
+Nodes (8): CalendarService<
+        Intervals,
+        Entries,
+        Projections,
+        Syncs,
+        Time,
+        Tokens,
+        PollStates,
+        Refresh,
+        Completed,
+    >, float_stream_values(), integer_stream_values(), legacy_activity_id(), map_calendar_entry_to_event(), map_calendar_sync_status(), map_completed_workout_to_actual_workout_match(), parse_projected_workout()
 
 ### Community 147 - "Community 147"
-Cohesion: 0.38
-Nodes (9): base_values(), client_log_ingestion_can_be_enabled_explicitly(), client_log_ingestion_defaults_to_disabled(), dev_auth_can_supply_google_oauth_defaults(), dev_intervals_can_be_enabled_explicitly(), dev_llm_coach_can_be_enabled_explicitly(), dev_llm_coach_defaults_to_disabled(), legacy_time_stream_cleanup_can_be_enabled_explicitly() (+1 more)
+Cohesion: 0.27
+Nodes (10): date_prefix(), linked_intervals_event_id(), map_sync_state(), planned_workout_title(), project_completed_workout_entry(), project_planned_workout_entry(), project_race_entry(), project_special_day_entry() (+2 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.2
-Nodes (8): PlannedWorkout, PlannedWorkoutContent, PlannedWorkoutLine, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind, PlannedWorkoutTarget, PlannedWorkoutText
+Nodes (3): completed_workout_repository_lists_by_user_and_date_range(), planned_workout_repository_lists_by_user_and_date_range(), sample_workout()
 
 ### Community 149 - "Community 149"
-Cohesion: 0.2
-Nodes (0): 
+Cohesion: 0.17
+Nodes (9): CompletedWorkout, CompletedWorkoutDetails, CompletedWorkoutError, CompletedWorkoutInterval, CompletedWorkoutIntervalGroup, CompletedWorkoutMetrics, CompletedWorkoutSeries, CompletedWorkoutStream (+1 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.51
-Nodes (6): mongo_fixture_or_skip(), MongoFixture, sample_summary(), workout_summary_repository_creates_legacy_event_id_index(), workout_summary_repository_list_uses_legacy_fallback_when_current_match_is_absent(), workout_summary_repository_prefers_current_workout_id_over_legacy_event_id()
+Cohesion: 0.24
+Nodes (7): build_load_trend(), build_load_trend_point(), build_recent_interval_blocks(), build_recent_interval_blocks_by_activity_id(), ewma_at_index(), ewma_latest(), rolling_average_at_index()
 
 ### Community 151 - "Community 151"
-Cohesion: 0.2
+Cohesion: 0.17
 Nodes (0): 
 
 ### Community 152 - "Community 152"
-Cohesion: 0.2
-Nodes (0): 
+Cohesion: 0.17
+Nodes (10): CompactAvailabilityDay, CompactFuturePlannedEvent, CompactHistoricalLoadTrend, CompactHistoricalWorkout, CompactHistory, CompactIntervalsStatus, CompactPlannedWorkoutBlock, CompactProfile (+2 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.2
+Cohesion: 0.17
 Nodes (0): 
 
 ### Community 154 - "Community 154"
-Cohesion: 0.2
-Nodes (0): 
+Cohesion: 0.27
+Nodes (8): buildTestStatusMessage(), clearDraftApiKeys(), clearTestStatusIfNeeded(), handleSave(), handleTest(), setStatusFromTest(), updateDraft(), updateProvider()
 
 ### Community 155 - "Community 155"
-Cohesion: 0.36
-Nodes (5): buildDayItems(), buildGenericEventItem(), formatMinutes(), summarizeCompletedActivity(), summarizePlannedEvent()
+Cohesion: 0.22
+Nodes (3): find_best_activity_match_prefers_detected_intervals_and_extracts_streams(), ignores_invalid_stream_samples_when_extracting_actual_workout_data(), sample_activity()
 
 ### Community 156 - "Community 156"
-Cohesion: 0.25
-Nodes (3): buildProtocol(), buildWorkoutSummaryWebSocketUrl(), StaleWorkoutSelectionError
+Cohesion: 0.35
+Nodes (4): mongo_fixture_or_skip(), MongoFixture, pest_parser_poc_repository_creates_expected_indexes(), pest_parser_poc_repository_inserts_failed_record_document()
 
 ### Community 157 - "Community 157"
-Cohesion: 0.39
-Nodes (6): formatLogMessage(), generateTraceparent(), getFrontendTraceparent(), getTraceId(), randomHex(), sendFrontendLog()
+Cohesion: 0.18
+Nodes (0): 
 
 ### Community 158 - "Community 158"
-Cohesion: 0.28
-Nodes (3): map_activity_response(), should_persist_stream(), should_persist_stream_type()
+Cohesion: 0.18
+Nodes (1): FakeSettingsUseCases
 
 ### Community 159 - "Community 159"
 Cohesion: 0.22
-Nodes (8): GeminiCachedContentResponse, GeminiCandidate, GeminiContent, GeminiCreateCacheRequest, GeminiGenerateContentRequest, GeminiGenerateContentResponse, GeminiTextPart, GeminiUsageMetadata
+Nodes (1): InMemoryCoachReplyOperationRepository
 
 ### Community 160 - "Community 160"
-Cohesion: 0.25
-Nodes (3): AthleteSummaryDocument, map_domain_to_document(), MongoAthleteSummaryRepository
-
-### Community 161 - "Community 161"
-Cohesion: 0.22
+Cohesion: 0.18
 Nodes (0): 
 
+### Community 161 - "Community 161"
+Cohesion: 0.25
+Nodes (7): approximate_token_usage(), build_conversation(), build_stable_context(), build_volatile_context(), LlmWorkoutCoach, LlmWorkoutCoach<Time>, workout_coach_system_prompt()
+
 ### Community 162 - "Community 162"
-Cohesion: 0.22
-Nodes (7): AthleteSummary, AthleteSummaryError, AthleteSummaryGenerationClaimResult, AthleteSummaryGenerationOperation, AthleteSummaryGenerationOperationStatus, AthleteSummaryState, EnsuredAthleteSummary
+Cohesion: 0.35
+Nodes (10): activity_document_bson_round_trip_preserves_enriched_completed_fields(), enriched_activity(), infer_event_id_hint_checks_description_after_non_matching_external_id(), merge_activity_for_storage_drops_time_streams(), merge_equal_richness_payloads_preserves_complementary_detail_buckets(), merge_richer_incoming_activity_replaces_existing_payload(), merge_sparse_activity_payload_preserves_existing_enriched_fields(), normalize_activity_document_drops_time_streams_and_refreshes_dedupe_fields() (+2 more)
 
 ### Community 163 - "Community 163"
-Cohesion: 0.22
-Nodes (7): CompletedWorkout, CompletedWorkoutDetails, CompletedWorkoutInterval, CompletedWorkoutIntervalGroup, CompletedWorkoutMetrics, CompletedWorkoutStream, CompletedWorkoutZoneTime
+Cohesion: 0.25
+Nodes (4): map_session_document(), MongoSessionRepository, rejects_session_expiry_that_cannot_be_converted_to_bson_datetime(), SessionDocument
 
 ### Community 164 - "Community 164"
 Cohesion: 0.22
-Nodes (0): 
+Nodes (5): map_document_to_record(), map_record_to_document(), map_status(), MongoPlannedWorkoutSyncRepository, PlannedWorkoutSyncDocument
 
 ### Community 165 - "Community 165"
-Cohesion: 0.22
-Nodes (8): CadenceRange, ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst
+Cohesion: 0.25
+Nodes (4): AthleteSummaryGenerationOperationDocument, map_document_to_domain(), map_domain_to_document(), MongoAthleteSummaryGenerationOperationRepository
 
 ### Community 166 - "Community 166"
-Cohesion: 0.33
-Nodes (4): activity_date(), date_key(), event_date(), parse_date()
+Cohesion: 0.35
+Nodes (9): detect_intervals_from_power_stream(), detected_interval_candidates(), evaluate_activity_match(), extract_float_stream(), extract_integer_stream(), find_best_activity_match(), IntervalCandidate, matching_segments() (+1 more)
 
 ### Community 167 - "Community 167"
-Cohesion: 0.58
-Nodes (6): external_observation_repository_round_trips_by_provider_and_external_id(), external_sync_repositories_create_expected_indexes(), external_sync_state_repository_round_trips_by_provider_and_canonical_entity(), mongo_fixture_or_skip(), MongoFixture, provider_poll_state_repository_lists_due_items_and_round_trips_by_stream()
-
-### Community 168 - "Community 168"
-Cohesion: 0.22
+Cohesion: 0.18
 Nodes (0): 
 
+### Community 168 - "Community 168"
+Cohesion: 0.18
+Nodes (10): CompactFocus, CompactPlannedWorkout, CompactPlannedWorkoutRef, CompactProjectedDay, CompactProjectedWorkout, CompactRecentDay, CompactRecentWorkout, CompactSpecialDay (+2 more)
+
 ### Community 169 - "Community 169"
-Cohesion: 0.56
-Nodes (6): mongo_fixture_or_skip(), MongoFixture, race_repository_creates_expected_indexes(), race_repository_exposes_races_as_calendar_labels(), race_repository_round_trips_race_and_lists_by_date_range(), sample_race()
+Cohesion: 0.38
+Nodes (8): createWorkoutSummary(), ensureWorkoutSummary(), getWorkoutSummary(), normalizeWorkoutTargetId(), reopenWorkoutSummary(), saveWorkoutSummary(), sendWorkoutSummaryMessage(), updateWorkoutSummaryRpe()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.22
-Nodes (0): 
+Nodes (2): formatRaceDate(), parseRaceDate()
 
 ### Community 171 - "Community 171"
-Cohesion: 0.31
-Nodes (1): InMemoryAthleteSummaryService
+Cohesion: 0.51
+Nodes (6): mongo_fixture_or_skip(), MongoFixture, sample_summary(), workout_summary_repository_creates_legacy_event_id_index(), workout_summary_repository_list_uses_legacy_fallback_when_current_match_is_absent(), workout_summary_repository_prefers_current_workout_id_over_legacy_event_id()
 
 ### Community 172 - "Community 172"
-Cohesion: 0.22
-Nodes (0): 
+Cohesion: 0.56
+Nodes (7): calendar_entry_view_calendar_source_reads_race_labels_from_persisted_view(), mongo_fixture_or_skip(), MongoFixture, race_calendar_hides_only_intervals_events_linked_to_races_in_requested_range(), race_repository_creates_expected_indexes(), race_repository_round_trips_race_and_lists_by_date_range(), sample_race()
 
 ### Community 173 - "Community 173"
-Cohesion: 0.5
-Nodes (4): builds_same_origin_callback_redirect(), DevGoogleOAuthClient, rejects_invalid_dev_code_as_unauthenticated(), returns_configured_identity_for_dev_code()
+Cohesion: 0.2
+Nodes (0): 
 
 ### Community 174 - "Community 174"
-Cohesion: 0.25
-Nodes (2): IntervalsSettingsAdapter, SettingsIntervalsProvider
+Cohesion: 0.2
+Nodes (0): 
 
 ### Community 175 - "Community 175"
-Cohesion: 0.25
-Nodes (7): OpenAiChatRequest, OpenAiChatResponse, OpenAiChoice, OpenAiMessage, OpenAiMessageResponse, OpenAiPromptTokenDetails, OpenAiUsage
+Cohesion: 0.38
+Nodes (9): base_values(), client_log_ingestion_can_be_enabled_explicitly(), client_log_ingestion_defaults_to_disabled(), dev_auth_can_supply_google_oauth_defaults(), dev_intervals_can_be_enabled_explicitly(), dev_llm_coach_can_be_enabled_explicitly(), dev_llm_coach_defaults_to_disabled(), legacy_time_stream_cleanup_can_be_enabled_explicitly() (+1 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.25
-Nodes (2): ActivityUploadOperationDocument, MongoActivityUploadOperationRepository
+Cohesion: 0.29
+Nodes (4): extract_message_text(), map_message(), map_request(), map_response()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.25
-Nodes (2): EventFileUpload, normalize_optional_upload_field()
+Cohesion: 0.22
+Nodes (3): LlmContextCacheDocument, map_domain_to_document(), MongoLlmContextCacheRepository
 
 ### Community 178 - "Community 178"
-Cohesion: 0.36
-Nodes (5): current_api_key_is_saved(), map_validation_error_to_response(), merge_ai_connection_config(), MergedAiConnectionConfig, selected_key_was_not_provided()
+Cohesion: 0.22
+Nodes (3): database_needs_bootstrap(), ensure_database_exists(), MongoConnectionError
 
 ### Community 179 - "Community 179"
-Cohesion: 0.32
-Nodes (4): merge_connection_credentials(), merge_credentials(), MergedCredentials, normalize_optional_input()
+Cohesion: 0.38
+Nodes (9): client_error_message(), close_ws(), handle_socket(), handle_socket_message(), process_send_message(), send_ws_json(), should_close_worker(), SocketMessageAction (+1 more)
 
 ### Community 180 - "Community 180"
-Cohesion: 0.25
-Nodes (4): CompactHistory<'a>, CompactIntervalsStatus<'a>, CompactProfile<'a>, StablePayload<'a>
+Cohesion: 0.4
+Nodes (9): auth_and_get_race_service(), create_race(), delete_race(), get_race(), list_races(), map_request(), parse_discipline(), parse_priority() (+1 more)
 
 ### Community 181 - "Community 181"
-Cohesion: 0.25
-Nodes (6): LatestCompletedActivityUseCases, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus, WorkoutSummaryService, WorkoutSummaryUseCases
+Cohesion: 0.38
+Nodes (9): build_standalone_completed_entries(), group_completed_workouts_by_planned_id(), index_planned_entry_positions(), merge_completed_workout_into_planned_entry(), merge_single_completed_match_into_planned_entries(), merge_workout_entries(), rebuild_calendar_entries(), should_keep_completed_workout_as_standalone_entry() (+1 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.25
-Nodes (0): 
+Cohesion: 0.36
+Nodes (5): buildDayItems(), buildGenericEventItem(), formatMinutes(), summarizeCompletedActivity(), summarizePlannedEvent()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.25
-Nodes (0): 
+Nodes (3): buildProtocol(), buildWorkoutSummaryWebSocketUrl(), StaleWorkoutSelectionError
 
 ### Community 184 - "Community 184"
-Cohesion: 0.25
-Nodes (0): 
+Cohesion: 0.39
+Nodes (6): formatLogMessage(), generateTraceparent(), getFrontendTraceparent(), getTraceId(), randomHex(), sendFrontendLog()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (0): 
 
 ### Community 186 - "Community 186"
-Cohesion: 0.25
-Nodes (0): 
+Cohesion: 0.58
+Nodes (6): external_observation_repository_round_trips_by_provider_and_external_id(), external_sync_repositories_create_expected_indexes(), external_sync_state_repository_round_trips_by_provider_and_canonical_entity(), mongo_fixture_or_skip(), MongoFixture, provider_poll_state_repository_lists_due_items_and_round_trips_by_stream()
 
 ### Community 187 - "Community 187"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (0): 
 
 ### Community 188 - "Community 188"
-Cohesion: 0.36
-Nodes (1): TestAthleteSummaryService
+Cohesion: 0.31
+Nodes (1): InMemoryAthleteSummaryService
 
 ### Community 189 - "Community 189"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (0): 
 
 ### Community 190 - "Community 190"
-Cohesion: 0.33
-Nodes (2): countRangeCalls(), hasRangeCall()
+Cohesion: 0.22
+Nodes (8): GeminiCachedContentResponse, GeminiCandidate, GeminiContent, GeminiCreateCacheRequest, GeminiGenerateContentRequest, GeminiGenerateContentResponse, GeminiTextPart, GeminiUsageMetadata
 
 ### Community 191 - "Community 191"
-Cohesion: 0.33
-Nodes (2): listRaces(), toQueryString()
+Cohesion: 0.28
+Nodes (3): map_activity_response(), should_persist_stream(), should_persist_stream_type()
 
 ### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (2): handleSave(), normalizeDays()
+Cohesion: 0.25
+Nodes (3): AthleteSummaryDocument, map_domain_to_document(), MongoAthleteSummaryRepository
 
 ### Community 193 - "Community 193"
-Cohesion: 0.29
+Cohesion: 0.22
 Nodes (0): 
 
 ### Community 194 - "Community 194"
-Cohesion: 0.29
-Nodes (2): PlannedWorkoutDocument, PlannedWorkoutLineDocument
+Cohesion: 0.22
+Nodes (7): AthleteSummary, AthleteSummaryError, AthleteSummaryGenerationClaimResult, AthleteSummaryGenerationOperation, AthleteSummaryGenerationOperationStatus, AthleteSummaryState, EnsuredAthleteSummary
 
 ### Community 195 - "Community 195"
-Cohesion: 0.38
-Nodes (6): ErrorResponse, header_value(), ingest_logs(), LogIngestionRequest, request_has_same_origin(), StatusResponse
+Cohesion: 0.22
+Nodes (7): CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus, WorkoutSummaryService, WorkoutSummaryUseCases
 
 ### Community 196 - "Community 196"
-Cohesion: 0.43
-Nodes (6): log_connection_error(), log_identity_error(), log_settings_error(), map_admin_identity_error(), map_connection_error_to_response(), map_settings_error()
+Cohesion: 0.22
+Nodes (8): CadenceRange, ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst
 
 ### Community 197 - "Community 197"
-Cohesion: 0.38
-Nodes (4): FieldUpdate, normalize_string_input(), parse_provider_input(), parse_provider_settings_input()
+Cohesion: 0.22
+Nodes (6): CalendarEntryKind, CalendarEntryRace, CalendarEntrySummary, CalendarEntrySync, CalendarEntryView, CalendarEntryViewError
 
 ### Community 198 - "Community 198"
-Cohesion: 0.29
-Nodes (0): 
+Cohesion: 0.36
+Nodes (1): TestAthleteSummaryService
 
 ### Community 199 - "Community 199"
-Cohesion: 0.48
-Nodes (5): map_message_to_dto(), map_save_summary_result_to_dto(), map_send_message_result_to_dto(), map_summary_to_dto(), map_workflow_status_to_dto()
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 200 - "Community 200"
-Cohesion: 0.29
-Nodes (6): Clock, GoogleOAuthPort, IdGenerator, LoginStateRepository, SessionRepository, UserRepository
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 201 - "Community 201"
-Cohesion: 0.29
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 202 - "Community 202"
-Cohesion: 0.38
-Nodes (1): TrainingPlanGenerationService<
-        Snapshots,
-        Projections,
-        Operations,
-        Generator,
-        WorkoutSummary,
-        Time,
-    >
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 203 - "Community 203"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (0): 
 
 ### Community 204 - "Community 204"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (0): 
 
 ### Community 205 - "Community 205"
-Cohesion: 0.29
-Nodes (2): FakeActivityUploadOperationRepository, UploadOperationRepoCall
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 206 - "Community 206"
-Cohesion: 0.29
-Nodes (0): 
+Cohesion: 0.5
+Nodes (4): builds_same_origin_callback_redirect(), DevGoogleOAuthClient, rejects_invalid_dev_code_as_unauthenticated(), returns_configured_identity_for_dev_code()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.29
-Nodes (2): MockLlmChatService, TestLlmConfigProvider
+Cohesion: 0.25
+Nodes (7): OpenAiChatRequest, OpenAiChatResponse, OpenAiChoice, OpenAiMessage, OpenAiMessageResponse, OpenAiPromptTokenDetails, OpenAiUsage
 
 ### Community 208 - "Community 208"
-Cohesion: 0.29
-Nodes (0): 
+Cohesion: 0.25
+Nodes (2): IntervalsSettingsAdapter, SettingsIntervalsProvider
 
 ### Community 209 - "Community 209"
-Cohesion: 0.4
-Nodes (1): FakeWebSocket
+Cohesion: 0.25
+Nodes (2): ActivityUploadOperationDocument, MongoActivityUploadOperationRepository
 
 ### Community 210 - "Community 210"
-Cohesion: 0.4
-Nodes (2): InspectableBlob, readBlobText()
+Cohesion: 0.36
+Nodes (5): current_api_key_is_saved(), map_validation_error_to_response(), merge_ai_connection_config(), MergedAiConnectionConfig, selected_key_was_not_provided()
 
 ### Community 211 - "Community 211"
-Cohesion: 0.47
-Nodes (3): map_error_response_from_logged_response(), sanitize_error_url(), summarize_log_body()
+Cohesion: 0.32
+Nodes (4): merge_connection_credentials(), merge_credentials(), MergedCredentials, normalize_optional_input()
 
 ### Community 212 - "Community 212"
-Cohesion: 0.4
-Nodes (3): ErrorResponse, log_workout_summary_error(), map_workout_summary_error()
+Cohesion: 0.25
+Nodes (2): EventFileUpload, normalize_optional_upload_field()
 
 ### Community 213 - "Community 213"
-Cohesion: 0.53
-Nodes (4): map_calendar_label_payload_to_dto(), map_calendar_label_to_dto(), map_calendar_labels_to_dto(), map_race_label_to_dto()
+Cohesion: 0.25
+Nodes (4): CalendarUseCases, HiddenCalendarEventSource, NoopPlannedWorkoutSyncRepository, PlannedWorkoutSyncRepository
 
 ### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (2): load_env_values(), Settings
+Cohesion: 0.39
+Nodes (4): activity_date(), date_key(), event_date(), parse_date()
 
 ### Community 215 - "Community 215"
-Cohesion: 0.33
-Nodes (5): TrainingPlanGenerationOperationRepository, TrainingPlanGenerator, TrainingPlanProjectionRepository, TrainingPlanSnapshotRepository, TrainingPlanWorkoutSummaryPort
+Cohesion: 0.25
+Nodes (4): CompactHistory<'a>, CompactIntervalsStatus<'a>, CompactProfile<'a>, StablePayload<'a>
 
 ### Community 216 - "Community 216"
-Cohesion: 0.53
-Nodes (1): TrainingPlanGenerationService<
-        Snapshots,
-        Projections,
-        Operations,
-        Generator,
-        WorkoutSummary,
-        Time,
-    >
+Cohesion: 0.33
+Nodes (2): handleSave(), normalizeDays()
 
 ### Community 217 - "Community 217"
-Cohesion: 0.67
-Nodes (5): lock_telemetry_env(), restore_env_var(), setup_telemetry_accepts_service_name_override_without_otlp_endpoint(), setup_telemetry_rejects_malformed_otlp_endpoint(), telemetry_env_lock()
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
-Nodes (0): 
+Nodes (2): countRangeCalls(), hasRangeCall()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.33
-Nodes (0): 
+Nodes (2): listRaces(), toQueryString()
 
 ### Community 220 - "Community 220"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (0): 
 
 ### Community 221 - "Community 221"
-Cohesion: 0.33
-Nodes (0): 
+Cohesion: 0.29
+Nodes (2): MockLlmChatService, TestLlmConfigProvider
 
 ### Community 222 - "Community 222"
-Cohesion: 0.47
-Nodes (1): MockIntervalsConnectionTester
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 223 - "Community 223"
-Cohesion: 0.6
-Nodes (4): getApiBaseUrl(), isDevAuthEnabled(), normalizeApiBaseUrl(), normalizeBooleanFlag()
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 224 - "Community 224"
-Cohesion: 0.5
-Nodes (2): handleTest(), setStatusFromTest()
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 225 - "Community 225"
-Cohesion: 0.4
-Nodes (2): SystemClock, UuidIdGenerator
+Cohesion: 0.29
+Nodes (2): FakeActivityUploadOperationRepository, UploadOperationRepoCall
 
 ### Community 226 - "Community 226"
-Cohesion: 0.5
-Nodes (1): GoogleOAuthClient
+Cohesion: 0.29
+Nodes (2): PlannedWorkoutDocument, PlannedWorkoutLineDocument
 
 ### Community 227 - "Community 227"
-Cohesion: 0.8
-Nodes (1): IntervalsIcuClient
+Cohesion: 0.38
+Nodes (6): ErrorResponse, header_value(), ingest_logs(), LogIngestionRequest, request_has_same_origin(), StatusResponse
 
 ### Community 228 - "Community 228"
-Cohesion: 0.4
-Nodes (2): HealthResponse, ReadinessResponse
+Cohesion: 0.43
+Nodes (6): log_connection_error(), log_identity_error(), log_settings_error(), map_admin_identity_error(), map_connection_error_to_response(), map_settings_error()
 
 ### Community 229 - "Community 229"
-Cohesion: 0.6
-Nodes (4): log_calendar_error(), log_calendar_label_error(), map_calendar_error(), map_calendar_label_error()
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 230 - "Community 230"
-Cohesion: 0.4
-Nodes (4): ListRacesQuery, RaceDto, RacePath, UpsertRaceRequest
+Cohesion: 0.38
+Nodes (4): FieldUpdate, normalize_string_input(), parse_provider_input(), parse_provider_settings_input()
 
 ### Community 231 - "Community 231"
-Cohesion: 0.4
-Nodes (4): AttemptRecord, ValidationIssue, WorkflowPhase, WorkflowStatus
+Cohesion: 0.48
+Nodes (5): map_message_to_dto(), map_save_summary_result_to_dto(), map_send_message_result_to_dto(), map_summary_to_dto(), map_workflow_status_to_dto()
 
 ### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+Cohesion: 0.43
+Nodes (4): build_create_event(), CalendarService<
+        Intervals,
+        Entries,
+        Projections,
+        Syncs,
+        Time,
+        Tokens,
+        PollStates,
+        Refresh,
+        Completed,
+    >, ensure_planned_workout_marker(), find_existing_remote_event()
 
 ### Community 233 - "Community 233"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.29
+Nodes (1): CalendarService<
+        Intervals,
+        Entries,
+        Projections,
+        Syncs,
+        Time,
+        Tokens,
+        PollStates,
+        Refresh,
+        Completed,
+    >
 
 ### Community 234 - "Community 234"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.29
+Nodes (6): Clock, GoogleOAuthPort, IdGenerator, LoginStateRepository, SessionRepository, UserRepository
 
 ### Community 235 - "Community 235"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.33
+Nodes (4): SpecialDay, SpecialDayError, SpecialDayKind, validate_date()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.29
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
 ### Community 237 - "Community 237"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.38
+Nodes (1): TrainingPlanGenerationService<
+        Snapshots,
+        Projections,
+        Operations,
+        Generator,
+        WorkoutSummary,
+        Time,
+        Refresh,
+    >
 
 ### Community 238 - "Community 238"
-Cohesion: 0.4
-Nodes (1): FakeSettingsPort
+Cohesion: 0.29
+Nodes (2): CalendarEntryViewRepository, InMemoryCalendarEntryViewRepository
 
 ### Community 239 - "Community 239"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): FakeWebSocket
 
 ### Community 240 - "Community 240"
 Cohesion: 0.4
-Nodes (1): InMemoryLlmContextCacheRepository
+Nodes (2): InspectableBlob, readBlobText()
 
 ### Community 241 - "Community 241"
-Cohesion: 0.7
-Nodes (4): existing_summary(), sample_summary(), sample_summary_for_user(), sample_summary_with_updated_at()
+Cohesion: 0.67
+Nodes (5): lock_telemetry_env(), restore_env_var(), setup_telemetry_accepts_service_name_override_without_otlp_endpoint(), setup_telemetry_rejects_malformed_otlp_endpoint(), telemetry_env_lock()
 
 ### Community 242 - "Community 242"
-Cohesion: 0.4
-Nodes (2): TestClock, TestIdGenerator
+Cohesion: 0.47
+Nodes (1): MockIntervalsConnectionTester
 
 ### Community 243 - "Community 243"
-Cohesion: 1.0
-Nodes (3): buildHookState(), buildRenderedWeeks(), buildWeek()
+Cohesion: 0.33
+Nodes (0): 
 
 ### Community 244 - "Community 244"
-Cohesion: 0.5
+Cohesion: 0.33
 Nodes (0): 
 
 ### Community 245 - "Community 245"
-Cohesion: 0.5
+Cohesion: 0.33
 Nodes (0): 
 
 ### Community 246 - "Community 246"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.4
+Nodes (2): load_env_values(), Settings
 
 ### Community 247 - "Community 247"
-Cohesion: 0.67
-Nodes (2): hasExplicitAvailabilityWeek(), isAvailabilityConfigured()
+Cohesion: 0.33
+Nodes (0): 
 
 ### Community 248 - "Community 248"
-Cohesion: 0.83
-Nodes (3): handleGenerate(), load(), refreshSummary()
+Cohesion: 0.47
+Nodes (3): map_error_response_from_logged_response(), sanitize_error_url(), summarize_log_body()
 
 ### Community 249 - "Community 249"
-Cohesion: 0.67
-Nodes (2): getStatusPanelClass(), getStatusToneClass()
+Cohesion: 0.4
+Nodes (3): ErrorResponse, log_workout_summary_error(), map_workout_summary_error()
 
 ### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (1): ApiError
+Cohesion: 0.33
+Nodes (0): 
 
 ### Community 251 - "Community 251"
-Cohesion: 0.83
-Nodes (3): buildApiUrl(), formatCheckedAtLabel(), loadBackendStatus()
+Cohesion: 0.33
+Nodes (2): NoopPlannedWorkoutRepository, PlannedWorkoutRepository
 
 ### Community 252 - "Community 252"
-Cohesion: 0.5
-Nodes (1): GoogleOAuthAdapter
+Cohesion: 0.33
+Nodes (2): NoopSpecialDayRepository, SpecialDayRepository
 
 ### Community 253 - "Community 253"
-Cohesion: 0.5
-Nodes (1): AthleteSummaryLlmGenerator
+Cohesion: 0.47
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
 ### Community 254 - "Community 254"
-Cohesion: 0.5
-Nodes (1): SettingsLlmConfigProvider
+Cohesion: 0.33
+Nodes (5): TrainingPlanGenerationOperationRepository, TrainingPlanGenerator, TrainingPlanProjectionRepository, TrainingPlanSnapshotRepository, TrainingPlanWorkoutSummaryPort
 
 ### Community 255 - "Community 255"
-Cohesion: 0.83
-Nodes (3): converts_epoch_seconds_to_bson_datetime(), epoch_seconds_to_bson_datetime(), rejects_epoch_seconds_that_overflow_bson_millis()
+Cohesion: 0.53
+Nodes (1): TrainingPlanGenerationService<
+        Snapshots,
+        Projections,
+        Operations,
+        Generator,
+        WorkoutSummary,
+        Time,
+        Refresh,
+    >
 
 ### Community 256 - "Community 256"
-Cohesion: 0.5
-Nodes (1): SettingsError
+Cohesion: 0.4
+Nodes (4): CalendarEntryIntegrityIssue, CalendarEntryIntegrityReport, issue_sort_key(), verify_calendar_entry_integrity()
 
 ### Community 257 - "Community 257"
-Cohesion: 0.5
-Nodes (3): AthleteSummaryGenerationOperationRepository, AthleteSummaryGenerator, AthleteSummaryRepository
+Cohesion: 0.33
+Nodes (2): CompletedWorkoutRepository, NoopCompletedWorkoutRepository
 
 ### Community 258 - "Community 258"
-Cohesion: 0.5
-Nodes (3): AthleteSummaryService, AthleteSummaryUseCases, SummaryRecord
+Cohesion: 0.33
+Nodes (3): PlannedCompletedWorkoutLink, PlannedCompletedWorkoutLinkError, PlannedCompletedWorkoutLinkMatchSource
 
 ### Community 259 - "Community 259"
-Cohesion: 0.5
-Nodes (3): CalendarUseCases, HiddenCalendarEventSource, PlannedWorkoutSyncRepository
+Cohesion: 0.47
+Nodes (3): finalize_import(), refresh_imported_range(), refresh_range_bounds()
 
 ### Community 260 - "Community 260"
-Cohesion: 0.83
-Nodes (1): CalendarLabelsService<Source>
+Cohesion: 0.6
+Nodes (4): getApiBaseUrl(), isDevAuthEnabled(), normalizeApiBaseUrl(), normalizeBooleanFlag()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.5
-Nodes (2): CompletedWorkoutRepository, NoopCompletedWorkoutRepository
+Nodes (2): handleTest(), setStatusFromTest()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0): 
 
 ### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (1): WorkoutPestParseError
+Cohesion: 0.4
+Nodes (1): InMemoryLlmContextCacheRepository
 
 ### Community 264 - "Community 264"
-Cohesion: 0.5
-Nodes (1): LlmError
+Cohesion: 0.7
+Nodes (4): existing_summary(), sample_summary(), sample_summary_for_user(), sample_summary_with_updated_at()
 
 ### Community 265 - "Community 265"
-Cohesion: 0.5
-Nodes (3): LlmChatPort, LlmContextCacheRepository, UserLlmConfigProvider
+Cohesion: 0.4
+Nodes (2): TestClock, TestIdGenerator
 
 ### Community 266 - "Community 266"
-Cohesion: 0.5
-Nodes (2): NoopPlannedWorkoutRepository, PlannedWorkoutRepository
-
-### Community 267 - "Community 267"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0): 
 
+### Community 267 - "Community 267"
+Cohesion: 0.4
+Nodes (1): FakeSettingsPort
+
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (2): SpecialDay, SpecialDayKind
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 269 - "Community 269"
-Cohesion: 0.5
-Nodes (2): NoopSpecialDayRepository, SpecialDayRepository
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 270 - "Community 270"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0): 
 
 ### Community 271 - "Community 271"
-Cohesion: 0.67
-Nodes (2): approximate_token_count(), render_training_context()
+Cohesion: 0.4
+Nodes (2): SystemClock, UuidIdGenerator
 
 ### Community 272 - "Community 272"
 Cohesion: 0.5
-Nodes (3): ParsedPlanWindow, TrainingPlanGenerationService, TrainingPlanUseCases
+Nodes (1): GoogleOAuthClient
 
 ### Community 273 - "Community 273"
-Cohesion: 0.5
-Nodes (2): MockWorkoutCoach, WorkoutCoach
+Cohesion: 0.8
+Nodes (1): IntervalsIcuClient
 
 ### Community 274 - "Community 274"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.4
+Nodes (2): HealthResponse, ReadinessResponse
 
 ### Community 275 - "Community 275"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.6
+Nodes (4): log_calendar_error(), log_calendar_label_error(), map_calendar_error(), map_calendar_label_error()
 
 ### Community 276 - "Community 276"
-Cohesion: 0.5
-Nodes (1): FakeActivityIdentityExtractor
+Cohesion: 0.4
+Nodes (4): ListRacesQuery, RaceDto, RacePath, UpsertRaceRequest
 
 ### Community 277 - "Community 277"
-Cohesion: 0.5
-Nodes (1): BuiltService
+Cohesion: 0.4
+Nodes (4): AttemptRecord, ValidationIssue, WorkflowPhase, WorkflowStatus
 
 ### Community 278 - "Community 278"
-Cohesion: 0.5
-Nodes (1): TestIdGenerator
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (2): hasExplicitAvailabilityWeek(), isAvailabilityConfigured()
 
 ### Community 280 - "Community 280"
-Cohesion: 1.0
-Nodes (2): listCalendarLabels(), toQueryString()
+Cohesion: 0.83
+Nodes (3): handleGenerate(), load(), refreshSummary()
 
 ### Community 281 - "Community 281"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 282 - "Community 282"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 283 - "Community 283"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (3): buildHookState(), buildRenderedWeeks(), buildWeek()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (2): getStatusPanelClass(), getStatusToneClass()
 
 ### Community 286 - "Community 286"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): ApiError
 
 ### Community 287 - "Community 287"
-Cohesion: 1.0
-Nodes (2): handleSave(), handleSaveClick()
+Cohesion: 0.83
+Nodes (3): buildApiUrl(), formatCheckedAtLabel(), loadBackendStatus()
 
 ### Community 288 - "Community 288"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): TestIdGenerator
 
 ### Community 289 - "Community 289"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): BuiltService
 
 ### Community 290 - "Community 290"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 291 - "Community 291"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): RecordingCalendarRefresh
 
 ### Community 292 - "Community 292"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 293 - "Community 293"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): FakeActivityIdentityExtractor
 
 ### Community 294 - "Community 294"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): SettingsError
 
 ### Community 295 - "Community 295"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): GoogleOAuthAdapter
 
 ### Community 297 - "Community 297"
-Cohesion: 0.67
-Nodes (1): LatestCompletedActivityAdapter<Repo>
+Cohesion: 0.5
+Nodes (1): AthleteSummaryLlmGenerator
 
 ### Community 298 - "Community 298"
-Cohesion: 0.67
-Nodes (2): GoogleTokenResponse, GoogleUserInfoResponse
+Cohesion: 0.5
+Nodes (1): SettingsLlmConfigProvider
 
 ### Community 299 - "Community 299"
-Cohesion: 0.67
-Nodes (1): DevIntervalsSettingsProvider
+Cohesion: 0.83
+Nodes (3): converts_epoch_seconds_to_bson_datetime(), epoch_seconds_to_bson_datetime(), rejects_epoch_seconds_that_overflow_bson_millis()
 
 ### Community 300 - "Community 300"
-Cohesion: 0.67
-Nodes (1): DevLlmCoachAdapter
+Cohesion: 0.83
+Nodes (1): CalendarLabelsService<Source>
 
 ### Community 301 - "Community 301"
-Cohesion: 0.67
-Nodes (1): SystemInfoResponse
+Cohesion: 0.5
+Nodes (3): AthleteSummaryGenerationOperationRepository, AthleteSummaryGenerator, AthleteSummaryRepository
 
 ### Community 302 - "Community 302"
-Cohesion: 1.0
-Nodes (2): pseudonymize_user_id(), resolve_user_id()
+Cohesion: 0.5
+Nodes (3): AthleteSummaryService, AthleteSummaryUseCases, SummaryRecord
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): log_intervals_error(), map_intervals_error()
+Cohesion: 0.5
+Nodes (2): MockWorkoutCoach, WorkoutCoach
 
 ### Community 304 - "Community 304"
-Cohesion: 1.0
-Nodes (2): log_race_error(), map_race_error()
+Cohesion: 0.5
+Nodes (3): LlmChatPort, LlmContextCacheRepository, UserLlmConfigProvider
 
 ### Community 305 - "Community 305"
-Cohesion: 1.0
-Nodes (2): build_app(), build_app_with_frontend_dist()
+Cohesion: 0.5
+Nodes (1): LlmError
 
 ### Community 306 - "Community 306"
-Cohesion: 0.67
-Nodes (2): CalendarLabelSource, CalendarLabelsUseCases
+Cohesion: 0.5
+Nodes (1): SpecialDayService<Repository, Refresh>
 
 ### Community 307 - "Community 307"
-Cohesion: 1.0
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+Cohesion: 0.5
+Nodes (1): WorkoutPestParseError
 
 ### Community 308 - "Community 308"
-Cohesion: 0.67
-Nodes (2): RaceRepository, RaceUseCases
+Cohesion: 0.5
+Nodes (3): ParsedPlanWindow, TrainingPlanGenerationService, TrainingPlanUseCases
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
-Nodes (2): DefaultTrainingContextBuilder, TrainingContextBuilder
+Nodes (2): approximate_token_count(), render_training_context()
 
 ### Community 310 - "Community 310"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 311 - "Community 311"
@@ -1955,7 +2036,7 @@ Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
-Nodes (2): CoachReplyOperationRepository, WorkoutSummaryRepository
+Nodes (0): 
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
@@ -1975,7 +2056,7 @@ Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (1): FakePestParserPocRepository
+Nodes (0): 
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
@@ -1986,143 +2067,143 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 320 - "Community 320"
-Cohesion: 0.67
-Nodes (1): TestClock
+Cohesion: 1.0
+Nodes (2): listCalendarLabels(), toQueryString()
 
 ### Community 321 - "Community 321"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): handleSave(), handleSaveClick()
 
 ### Community 323 - "Community 323"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 324 - "Community 324"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 325 - "Community 325"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 326 - "Community 326"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 327 - "Community 327"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 328 - "Community 328"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 329 - "Community 329"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 330 - "Community 330"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 331 - "Community 331"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 332 - "Community 332"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 333 - "Community 333"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): TestClock
 
 ### Community 334 - "Community 334"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 335 - "Community 335"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 336 - "Community 336"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 337 - "Community 337"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): FakePestParserPocRepository
 
 ### Community 338 - "Community 338"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): build_app(), build_app_with_frontend_dist()
 
 ### Community 339 - "Community 339"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): CompletedWorkoutTargetAdapter<Repo>
 
 ### Community 340 - "Community 340"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): LatestCompletedActivityAdapter<Repo>
 
 ### Community 341 - "Community 341"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): GoogleTokenResponse, GoogleUserInfoResponse
 
 ### Community 342 - "Community 342"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): DevLlmCoachAdapter
 
 ### Community 343 - "Community 343"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): DevIntervalsSettingsProvider
 
 ### Community 344 - "Community 344"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): pseudonymize_user_id(), resolve_user_id()
 
 ### Community 345 - "Community 345"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): SystemInfoResponse
 
 ### Community 346 - "Community 346"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): log_intervals_error(), map_intervals_error()
 
 ### Community 347 - "Community 347"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): log_race_error(), map_race_error()
 
 ### Community 348 - "Community 348"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): CalendarLabelSource, CalendarLabelsUseCases
 
 ### Community 349 - "Community 349"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): CoachReplyOperationRepository, WorkoutSummaryRepository
 
 ### Community 350 - "Community 350"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
 ### Community 351 - "Community 351"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 352 - "Community 352"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): RaceRepository, RaceUseCases
 
 ### Community 353 - "Community 353"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 354 - "Community 354"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 355 - "Community 355"
@@ -2143,11 +2224,11 @@ Nodes (0):
 
 ### Community 359 - "Community 359"
 Cohesion: 1.0
-Nodes (1): LatestCompletedActivityAdapter
+Nodes (0): 
 
 ### Community 360 - "Community 360"
 Cohesion: 1.0
-Nodes (1): IntervalsIcuClient
+Nodes (0): 
 
 ### Community 361 - "Community 361"
 Cohesion: 1.0
@@ -2167,7 +2248,7 @@ Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 1.0
-Nodes (1): AthleteSummaryDto
+Nodes (0): 
 
 ### Community 366 - "Community 366"
 Cohesion: 1.0
@@ -2179,7 +2260,7 @@ Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 1.0
-Nodes (1): CreateRace
+Nodes (0): 
 
 ### Community 369 - "Community 369"
 Cohesion: 1.0
@@ -2187,83 +2268,75 @@ Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 1.0
-Nodes (1): CalendarLabelsService
+Nodes (0): 
 
 ### Community 371 - "Community 371"
 Cohesion: 1.0
-Nodes (1): IntervalsService<
-        Api,
-        Settings,
-        Activities,
-        UploadOperations,
-        Extractor,
-        NoopPestParserPocRepository,
-        LiveClock,
-    >
+Nodes (0): 
 
 ### Community 372 - "Community 372"
 Cohesion: 1.0
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>
+Nodes (0): 
 
 ### Community 373 - "Community 373"
 Cohesion: 1.0
-Nodes (1): UserSettingsRepository
+Nodes (0): 
 
 ### Community 374 - "Community 374"
 Cohesion: 1.0
-Nodes (1): CompactRace<'a>
+Nodes (0): 
 
 ### Community 375 - "Community 375"
 Cohesion: 1.0
-Nodes (1): CompactFuturePlannedEvent<'a>
+Nodes (0): 
 
 ### Community 376 - "Community 376"
 Cohesion: 1.0
-Nodes (1): CompactAvailabilityDay<'a>
+Nodes (0): 
 
 ### Community 377 - "Community 377"
 Cohesion: 1.0
-Nodes (1): CompactHistoricalLoadTrend<'a>
+Nodes (0): 
 
 ### Community 378 - "Community 378"
 Cohesion: 1.0
-Nodes (1): CompactHistoricalWorkout<'a>
+Nodes (0): 
 
 ### Community 379 - "Community 379"
 Cohesion: 1.0
-Nodes (1): VolatilePayload<'a>
+Nodes (0): 
 
 ### Community 380 - "Community 380"
 Cohesion: 1.0
-Nodes (1): CompactRecentDay<'a>
+Nodes (0): 
 
 ### Community 381 - "Community 381"
 Cohesion: 1.0
-Nodes (1): CompactRecentWorkout<'a>
+Nodes (0): 
 
 ### Community 382 - "Community 382"
 Cohesion: 1.0
-Nodes (1): CompactPlannedWorkoutRef<'a>
+Nodes (0): 
 
 ### Community 383 - "Community 383"
 Cohesion: 1.0
-Nodes (1): CompactPlannedWorkout<'a>
+Nodes (0): 
 
 ### Community 384 - "Community 384"
 Cohesion: 1.0
-Nodes (1): CompactSpecialDay<'a>
+Nodes (0): 
 
 ### Community 385 - "Community 385"
 Cohesion: 1.0
-Nodes (1): CompactUpcomingDay<'a>
+Nodes (0): 
 
 ### Community 386 - "Community 386"
 Cohesion: 1.0
-Nodes (1): CompactProjectedDay<'a>
+Nodes (0): 
 
 ### Community 387 - "Community 387"
 Cohesion: 1.0
-Nodes (1): CompactProjectedWorkout<'a>
+Nodes (0): 
 
 ### Community 388 - "Community 388"
 Cohesion: 1.0
@@ -2311,7 +2384,15 @@ Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): ProviderPollingService<
+        Api,
+        Settings,
+        PollStates,
+        Imports,
+        Time,
+        Ids,
+        NoopCalendarEntryViewRefresh,
+    >
 
 ### Community 400 - "Community 400"
 Cohesion: 1.0
@@ -2319,11 +2400,11 @@ Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompletedWorkoutTargetAdapter
 
 ### Community 402 - "Community 402"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): LatestCompletedActivityAdapter
 
 ### Community 403 - "Community 403"
 Cohesion: 1.0
@@ -2335,7 +2416,7 @@ Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): IntervalsIcuClient
 
 ### Community 406 - "Community 406"
 Cohesion: 1.0
@@ -2351,11 +2432,11 @@ Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): AthleteSummaryDto
 
 ### Community 410 - "Community 410"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CreateRace
 
 ### Community 411 - "Community 411"
 Cohesion: 1.0
@@ -2367,95 +2448,114 @@ Nodes (0):
 
 ### Community 413 - "Community 413"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): UserSettingsRepository
 
 ### Community 414 - "Community 414"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CalendarLabelsService
 
 ### Community 415 - "Community 415"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CalendarService
 
 ### Community 416 - "Community 416"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CalendarService<
+        Intervals,
+        Entries,
+        Projections,
+        Syncs,
+        Time,
+        NoopPlannedWorkoutTokenRepository,
+        NoopProviderPollStateRepository,
+        NoopCalendarEntryViewRefresh,
+        (),
+    >
 
 ### Community 417 - "Community 417"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): SpecialDayService
 
 ### Community 418 - "Community 418"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): SpecialDayService<Repository>
 
 ### Community 419 - "Community 419"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): IntervalsService<
+        Api,
+        Settings,
+        Activities,
+        UploadOperations,
+        Extractor,
+        NoopPestParserPocRepository,
+        LiveClock,
+        NoopCalendarEntryViewRefresh,
+    >
 
 ### Community 420 - "Community 420"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
 ### Community 421 - "Community 421"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): PlannedCompletedWorkoutLinkRepository
 
 ### Community 422 - "Community 422"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): VolatilePayload<'a>
 
 ### Community 423 - "Community 423"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactRecentDay<'a>
 
 ### Community 424 - "Community 424"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactRecentWorkout<'a>
 
 ### Community 425 - "Community 425"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactPlannedWorkoutRef<'a>
 
 ### Community 426 - "Community 426"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactPlannedWorkout<'a>
 
 ### Community 427 - "Community 427"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactSpecialDay<'a>
 
 ### Community 428 - "Community 428"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactUpcomingDay<'a>
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactProjectedDay<'a>
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactProjectedWorkout<'a>
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactRace<'a>
 
 ### Community 432 - "Community 432"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactFuturePlannedEvent<'a>
 
 ### Community 433 - "Community 433"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactAvailabilityDay<'a>
 
 ### Community 434 - "Community 434"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactHistoricalLoadTrend<'a>
 
 ### Community 435 - "Community 435"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactHistoricalWorkout<'a>
 
 ### Community 436 - "Community 436"
 Cohesion: 1.0
@@ -2827,860 +2927,927 @@ Nodes (0):
 
 ### Community 528 - "Community 528"
 Cohesion: 1.0
-Nodes (1): Hexagonal Architecture Rules
+Nodes (0): 
 
 ### Community 529 - "Community 529"
 Cohesion: 1.0
-Nodes (1): Persist Local State Before Side Effects
+Nodes (0): 
 
 ### Community 530 - "Community 530"
 Cohesion: 1.0
-Nodes (1): Single Container API And SPA Deployment
+Nodes (0): 
 
 ### Community 531 - "Community 531"
 Cohesion: 1.0
-Nodes (1): Operational Health And Readiness Endpoints
+Nodes (0): 
 
 ### Community 532 - "Community 532"
 Cohesion: 1.0
-Nodes (1): Coach Reply Operation
+Nodes (0): 
 
 ### Community 533 - "Community 533"
 Cohesion: 1.0
-Nodes (1): Pending Durable Coach Reply State
+Nodes (0): 
 
 ### Community 534 - "Community 534"
 Cohesion: 1.0
-Nodes (1): Coach Reply Recovery Rules
+Nodes (0): 
 
 ### Community 535 - "Community 535"
 Cohesion: 1.0
-Nodes (1): Same Request Local Write Retries
+Nodes (0): 
 
 ### Community 536 - "Community 536"
 Cohesion: 1.0
-Nodes (1): Compare And Swap Pending Operation Reclaim
+Nodes (0): 
 
 ### Community 537 - "Community 537"
 Cohesion: 1.0
-Nodes (1): Bootstrap Architecture
+Nodes (0): 
 
 ### Community 538 - "Community 538"
 Cohesion: 1.0
-Nodes (1): REST Adapter
+Nodes (0): 
 
 ### Community 539 - "Community 539"
 Cohesion: 1.0
-Nodes (1): Mongo Adapter
+Nodes (0): 
 
 ### Community 540 - "Community 540"
 Cohesion: 1.0
-Nodes (1): Planned Mongo Collections
+Nodes (0): 
 
 ### Community 541 - "Community 541"
 Cohesion: 1.0
-Nodes (1): Backend Bootstrap Foundation
+Nodes (0): 
 
 ### Community 542 - "Community 542"
 Cohesion: 1.0
-Nodes (1): Project Obsidian Handbook
+Nodes (0): 
 
 ### Community 543 - "Community 543"
 Cohesion: 1.0
-Nodes (1): Manual Tag Based Release Flow
+Nodes (0): 
 
 ### Community 544 - "Community 544"
 Cohesion: 1.0
-Nodes (1): Manual Coolify Deployment Path
+Nodes (0): 
 
 ### Community 545 - "Community 545"
 Cohesion: 1.0
-Nodes (1): Frontend Application Shell
+Nodes (0): 
 
 ### Community 546 - "Community 546"
 Cohesion: 1.0
-Nodes (1): Frontend Backend Connectivity
+Nodes (0): 
 
 ### Community 547 - "Community 547"
 Cohesion: 1.0
-Nodes (1): Identity Domain
+Nodes (0): 
 
 ### Community 548 - "Community 548"
 Cohesion: 1.0
-Nodes (1): Google OAuth Login Flow
+Nodes (0): 
 
 ### Community 549 - "Community 549"
 Cohesion: 1.0
-Nodes (1): Server Side Sessions
+Nodes (0): 
 
 ### Community 550 - "Community 550"
 Cohesion: 1.0
-Nodes (1): RBAC Policy
+Nodes (0): 
 
 ### Community 551 - "Community 551"
 Cohesion: 1.0
-Nodes (1): Draft Driven Intervals Settings Actions
+Nodes (0): 
 
 ### Community 552 - "Community 552"
 Cohesion: 1.0
-Nodes (1): Synthetic Trace Parent Fix
+Nodes (0): 
 
 ### Community 553 - "Community 553"
 Cohesion: 1.0
-Nodes (1): Atomic Tracing Capture Writes
+Nodes (0): 
 
 ### Community 554 - "Community 554"
 Cohesion: 1.0
-Nodes (1): Structured Mini Chart Bars
+Nodes (0): 
 
 ### Community 555 - "Community 555"
 Cohesion: 1.0
-Nodes (1): Completed Activity Enrichment
+Nodes (0): 
 
 ### Community 556 - "Community 556"
 Cohesion: 1.0
-Nodes (1): Partial Enrichment Fail Open
+Nodes (0): 
 
 ### Community 557 - "Community 557"
 Cohesion: 1.0
-Nodes (1): Workout Detail Modal Flow
+Nodes (1): Hexagonal Architecture Rules
 
 ### Community 558 - "Community 558"
 Cohesion: 1.0
-Nodes (1): Event FIT Download Action
+Nodes (1): Persist Local State Before Side Effects
 
 ### Community 559 - "Community 559"
 Cohesion: 1.0
-Nodes (1): Intervals Service Enrichment Placement
+Nodes (1): Single Container API And SPA Deployment
 
 ### Community 560 - "Community 560"
 Cohesion: 1.0
-Nodes (1): Partial Modal Resilience
+Nodes (1): Operational Health And Readiness Endpoints
 
 ### Community 561 - "Community 561"
 Cohesion: 1.0
-Nodes (1): Intervals Service Workout Enrichment
+Nodes (1): Coach Reply Operation
 
 ### Community 562 - "Community 562"
 Cohesion: 1.0
-Nodes (1): Partial Workout Detail Failure Resilience
+Nodes (1): Pending Durable Coach Reply State
 
 ### Community 563 - "Community 563"
 Cohesion: 1.0
-Nodes (1): Completed Workout Mode UI Cleanup
+Nodes (1): Coach Reply Recovery Rules
 
 ### Community 564 - "Community 564"
 Cohesion: 1.0
-Nodes (1): Remove Workout Detail Auto Scroll Side Effect
+Nodes (1): Same Request Local Write Retries
 
 ### Community 565 - "Community 565"
 Cohesion: 1.0
-Nodes (1): Preserve Workout Detail Selection Synchronization
+Nodes (1): Compare And Swap Pending Operation Reclaim
 
 ### Community 566 - "Community 566"
 Cohesion: 1.0
-Nodes (1): Workout Detail ScrollIntoView Removal
+Nodes (1): Bootstrap Architecture
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (1): Workout Detail Interaction Test Updates
+Nodes (1): REST Adapter
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
-Nodes (1): Durable Recoverable Coach Replies
+Nodes (1): Mongo Adapter
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (1): LLM Context Cache Invalidation
+Nodes (1): Planned Mongo Collections
 
 ### Community 570 - "Community 570"
 Cohesion: 1.0
-Nodes (1): Provider Observability And Cost Tracing
+Nodes (1): Backend Bootstrap Foundation
 
 ### Community 571 - "Community 571"
 Cohesion: 1.0
-Nodes (1): AI Settings UX Hardening
+Nodes (1): Project Obsidian Handbook
 
 ### Community 572 - "Community 572"
 Cohesion: 1.0
-Nodes (1): Coach Reply Operation As Durable Workflow Record
+Nodes (1): Manual Tag Based Release Flow
 
 ### Community 573 - "Community 573"
 Cohesion: 1.0
-Nodes (1): Idempotent Coach Reply Finalization
+Nodes (1): Manual Coolify Deployment Path
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
-Nodes (1): Partial Persistence Failure Recovery For Finalization
+Nodes (1): Frontend Application Shell
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (1): Coach Reply State Machine Documentation Update
+Nodes (1): Frontend Backend Connectivity
 
 ### Community 576 - "Community 576"
 Cohesion: 1.0
-Nodes (1): Debug Level Successful Health Logs
+Nodes (1): Identity Domain
 
 ### Community 577 - "Community 577"
 Cohesion: 1.0
-Nodes (1): Preserve Health Failure Visibility
+Nodes (1): Google OAuth Login Flow
 
 ### Community 578 - "Community 578"
 Cohesion: 1.0
-Nodes (1): Reduce Health Endpoint Success Log Noise
+Nodes (1): Server Side Sessions
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
-Nodes (1): Curated Provider Model Suggestion Refresh
+Nodes (1): RBAC Policy
 
 ### Community 580 - "Community 580"
 Cohesion: 1.0
-Nodes (1): Preserve Freeform Model Input
+Nodes (1): Draft Driven Intervals Settings Actions
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
-Nodes (1): Refresh AI Agent Model Suggestions
+Nodes (1): Synthetic Trace Parent Fix
 
 ### Community 582 - "Community 582"
 Cohesion: 1.0
-Nodes (1): Lower Mongo Local Development Verbosity
+Nodes (1): Atomic Tracing Capture Writes
 
 ### Community 583 - "Community 583"
 Cohesion: 1.0
-Nodes (1): Quiet Docker Compose Mongo Startup Logs
+Nodes (1): Structured Mini Chart Bars
 
 ### Community 584 - "Community 584"
 Cohesion: 1.0
-Nodes (1): Safe Structured OpenRouter Diagnostics
+Nodes (1): Completed Activity Enrichment
 
 ### Community 585 - "Community 585"
 Cohesion: 1.0
-Nodes (1): Redacted Provider Request Metadata Logging
+Nodes (1): Partial Enrichment Fail Open
 
 ### Community 586 - "Community 586"
 Cohesion: 1.0
-Nodes (1): OpenRouter Transport And Response Diagnostics
+Nodes (1): Workout Detail Modal Flow
 
 ### Community 587 - "Community 587"
 Cohesion: 1.0
-Nodes (1): Multi Provider Logging Pattern Rollout
+Nodes (1): Event FIT Download Action
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (1): OpenAI And Gemini Diagnostic Logging
+Nodes (1): Intervals Service Enrichment Placement
 
 ### Community 589 - "Community 589"
 Cohesion: 1.0
-Nodes (1): Persisted Athlete Summary Feature
+Nodes (1): Partial Modal Resilience
 
 ### Community 590 - "Community 590"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Prompt Context Integration
+Nodes (1): Intervals Service Workout Enrichment
 
 ### Community 591 - "Community 591"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Generation System Message
+Nodes (1): Partial Workout Detail Failure Resilience
 
 ### Community 592 - "Community 592"
 Cohesion: 1.0
-Nodes (1): OpenRouter Stable Prefix Prompt Caching
+Nodes (1): Completed Workout Mode UI Cleanup
 
 ### Community 593 - "Community 593"
 Cohesion: 1.0
-Nodes (1): Uncached Conversation Tail
+Nodes (1): Remove Workout Detail Auto Scroll Side Effect
 
 ### Community 594 - "Community 594"
 Cohesion: 1.0
-Nodes (1): Single WebSocket Control Loop
+Nodes (1): Preserve Workout Detail Selection Synchronization
 
 ### Community 595 - "Community 595"
 Cohesion: 1.0
-Nodes (1): Drop Queued Messages After Disconnect
+Nodes (1): Workout Detail ScrollIntoView Removal
 
 ### Community 596 - "Community 596"
 Cohesion: 1.0
-Nodes (1): Full Workout Summary Builder Request Logging
+Nodes (1): Workout Detail Interaction Test Updates
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Durable Generation Operation
+Nodes (1): Durable Recoverable Coach Replies
 
 ### Community 598 - "Community 598"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Stale Work Reclaim
+Nodes (1): LLM Context Cache Invalidation
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (1): Distinct Athlete Summary System Message Rendering
+Nodes (1): Provider Observability And Cost Tracing
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (1): Compressed Raw Power Segments
+Nodes (1): AI Settings UX Hardening
 
 ### Community 601 - "Community 601"
 Cohesion: 1.0
-Nodes (1): Compact Training Context Power Field
+Nodes (1): Coach Reply Operation As Durable Workflow Record
 
 ### Community 602 - "Community 602"
 Cohesion: 1.0
-Nodes (1): Power Compression Prompt Encoding Legend
+Nodes (1): Idempotent Coach Reply Finalization
 
 ### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Partial Persistence Failure Recovery For Finalization
 
 ### Community 604 - "Community 604"
 Cohesion: 1.0
-Nodes (1): Replace LLM workout power arrays with compressed raw-power segments
+Nodes (1): Coach Reply State Machine Documentation Update
 
 ### Community 605 - "Community 605"
 Cohesion: 1.0
-Nodes (1): Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly
+Nodes (1): Debug Level Successful Health Logs
 
 ### Community 606 - "Community 606"
 Cohesion: 1.0
-Nodes (1): RecentWorkoutContext.compressed_power_levels: Vec<String>
+Nodes (1): Preserve Health Failure Visibility
 
 ### Community 607 - "Community 607"
 Cohesion: 1.0
-Nodes (1): Add power compression tests and implementation in training_context service
+Nodes (1): Reduce Health Endpoint Success Log Noise
 
 ### Community 608 - "Community 608"
 Cohesion: 1.0
-Nodes (1): Pack pc instead of p5
+Nodes (1): Curated Provider Model Suggestion Refresh
 
 ### Community 609 - "Community 609"
 Cohesion: 1.0
-Nodes (1): Update the workout coach prompt with power-compression semantics
+Nodes (1): Preserve Freeform Model Input
 
 ### Community 610 - "Community 610"
 Cohesion: 1.0
-Nodes (1): Update LLM flow assertions to expect pc in live requests
+Nodes (1): Refresh AI Agent Model Suggestions
 
 ### Community 611 - "Community 611"
 Cohesion: 1.0
-Nodes (1): Run full formatting, lint, Rust tests, and repo verification
+Nodes (1): Lower Mongo Local Development Verbosity
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Quiet Docker Compose Mongo Startup Logs
 
 ### Community 613 - "Community 613"
 Cohesion: 1.0
-Nodes (1): Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior
+Nodes (1): Safe Structured OpenRouter Diagnostics
 
 ### Community 614 - "Community 614"
 Cohesion: 1.0
-Nodes (1): Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged
+Nodes (1): Redacted Provider Request Metadata Logging
 
 ### Community 615 - "Community 615"
 Cohesion: 1.0
-Nodes (1): Split training_context service into focused service/ siblings
+Nodes (1): OpenRouter Transport And Response Diagnostics
 
 ### Community 616 - "Community 616"
 Cohesion: 1.0
-Nodes (1): Split workout_summary service into focused service/ siblings
+Nodes (1): Multi Provider Logging Pattern Rollout
 
 ### Community 617 - "Community 617"
 Cohesion: 1.0
-Nodes (1): Split training_context packing into focused packing/ siblings
+Nodes (1): OpenAI And Gemini Diagnostic Logging
 
 ### Community 618 - "Community 618"
 Cohesion: 1.0
-Nodes (1): Split Mongo workout-summary adapter tests first and helper concerns only if still oversized
+Nodes (1): Persisted Athlete Summary Feature
 
 ### Community 619 - "Community 619"
 Cohesion: 1.0
-Nodes (1): Split bulky current-slice shared helpers and integration suites into directory-based test modules
+Nodes (1): Athlete Summary Prompt Context Integration
 
 ### Community 620 - "Community 620"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Athlete Summary Generation System Message
 
 ### Community 621 - "Community 621"
 Cohesion: 1.0
-Nodes (1): Split training_context service into focused directory modules
+Nodes (1): OpenRouter Stable Prefix Prompt Caching
 
 ### Community 622 - "Community 622"
 Cohesion: 1.0
-Nodes (1): Split workout_summary service while keeping WorkoutSummaryService as the entrypoint
+Nodes (1): Uncached Conversation Tail
 
 ### Community 623 - "Community 623"
 Cohesion: 1.0
-Nodes (1): Split training_context packing into focused payload and rendering modules
+Nodes (1): Single WebSocket Control Loop
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (1): Split the Mongo workout-summary adapter by moving tests first and helpers only if needed
+Nodes (1): Drop Queued Messages After Disconnect
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (1): Split bulky workout-summary shared helpers and remaining oversized current-slice tests
+Nodes (1): Full Workout Summary Builder Request Logging
 
 ### Community 626 - "Community 626"
 Cohesion: 1.0
-Nodes (1): Run broader backend verification after the refactor
+Nodes (1): Athlete Summary Durable Generation Operation
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Athlete Summary Stale Work Reclaim
 
 ### Community 628 - "Community 628"
 Cohesion: 1.0
-Nodes (1): Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits
+Nodes (1): Distinct Athlete Summary System Message Rendering
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (1): Make projection replay heal partial same-operation inserts
+Nodes (1): Compressed Raw Power Segments
 
 ### Community 630 - "Community 630"
 Cohesion: 1.0
-Nodes (1): Make workout-summary legacy fallback deterministic
+Nodes (1): Compact Training Context Power Field
 
 ### Community 631 - "Community 631"
 Cohesion: 1.0
-Nodes (1): Preserve correction retry budget across reclaim
+Nodes (1): Power Compression Prompt Encoding Legend
 
 ### Community 632 - "Community 632"
 Cohesion: 1.0
-Nodes (1): Close low-level test and docs nits
+Nodes (1): 2026-04-04-power-compression-llm.md
 
 ### Community 633 - "Community 633"
 Cohesion: 1.0
-Nodes (1): Run targeted tests, fmt, and clippy for the follow-up batch
+Nodes (1): Replace LLM workout power arrays with compressed raw-power segments
 
 ### Community 634 - "Community 634"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly
 
 ### Community 635 - "Community 635"
 Cohesion: 1.0
-Nodes (1): Cyclist athlete
+Nodes (1): RecentWorkoutContext.compressed_power_levels: Vec<String>
 
 ### Community 636 - "Community 636"
 Cohesion: 1.0
-Nodes (1): Endurance cycling performance
+Nodes (1): Add power compression tests and implementation in training_context service
 
 ### Community 637 - "Community 637"
 Cohesion: 1.0
-Nodes (1): Hero background imagery
+Nodes (1): Pack pc instead of p5
 
 ### Community 638 - "Community 638"
 Cohesion: 1.0
-Nodes (1): Performance coaching brand tone
+Nodes (1): Update the workout coach prompt with power-compression semantics
 
 ### Community 639 - "Community 639"
+Cohesion: 1.0
+Nodes (1): Update LLM flow assertions to expect pc in live requests
+
+### Community 640 - "Community 640"
+Cohesion: 1.0
+Nodes (1): Run full formatting, lint, Rust tests, and repo verification
+
+### Community 641 - "Community 641"
+Cohesion: 1.0
+Nodes (1): 2026-04-06-backend-slice-size-refactor-design.md
+
+### Community 642 - "Community 642"
+Cohesion: 1.0
+Nodes (1): Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior
+
+### Community 643 - "Community 643"
+Cohesion: 1.0
+Nodes (1): Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged
+
+### Community 644 - "Community 644"
+Cohesion: 1.0
+Nodes (1): Split training_context service into focused service/ siblings
+
+### Community 645 - "Community 645"
+Cohesion: 1.0
+Nodes (1): Split workout_summary service into focused service/ siblings
+
+### Community 646 - "Community 646"
+Cohesion: 1.0
+Nodes (1): Split training_context packing into focused packing/ siblings
+
+### Community 647 - "Community 647"
+Cohesion: 1.0
+Nodes (1): Split Mongo workout-summary adapter tests first and helper concerns only if still oversized
+
+### Community 648 - "Community 648"
+Cohesion: 1.0
+Nodes (1): Split bulky current-slice shared helpers and integration suites into directory-based test modules
+
+### Community 649 - "Community 649"
+Cohesion: 1.0
+Nodes (1): 2026-04-06-backend-slice-size-refactor.md
+
+### Community 650 - "Community 650"
+Cohesion: 1.0
+Nodes (1): Split training_context service into focused directory modules
+
+### Community 651 - "Community 651"
+Cohesion: 1.0
+Nodes (1): Split workout_summary service while keeping WorkoutSummaryService as the entrypoint
+
+### Community 652 - "Community 652"
+Cohesion: 1.0
+Nodes (1): Split training_context packing into focused payload and rendering modules
+
+### Community 653 - "Community 653"
+Cohesion: 1.0
+Nodes (1): Split the Mongo workout-summary adapter by moving tests first and helpers only if needed
+
+### Community 654 - "Community 654"
+Cohesion: 1.0
+Nodes (1): Split bulky workout-summary shared helpers and remaining oversized current-slice tests
+
+### Community 655 - "Community 655"
+Cohesion: 1.0
+Nodes (1): Run broader backend verification after the refactor
+
+### Community 656 - "Community 656"
+Cohesion: 1.0
+Nodes (1): 2026-04-06-review-followups.md
+
+### Community 657 - "Community 657"
+Cohesion: 1.0
+Nodes (1): Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits
+
+### Community 658 - "Community 658"
+Cohesion: 1.0
+Nodes (1): Make projection replay heal partial same-operation inserts
+
+### Community 659 - "Community 659"
+Cohesion: 1.0
+Nodes (1): Make workout-summary legacy fallback deterministic
+
+### Community 660 - "Community 660"
+Cohesion: 1.0
+Nodes (1): Preserve correction retry budget across reclaim
+
+### Community 661 - "Community 661"
+Cohesion: 1.0
+Nodes (1): Close low-level test and docs nits
+
+### Community 662 - "Community 662"
+Cohesion: 1.0
+Nodes (1): Run targeted tests, fmt, and clippy for the follow-up batch
+
+### Community 663 - "Community 663"
+Cohesion: 1.0
+Nodes (1): cyclist-bg.jpg
+
+### Community 664 - "Community 664"
+Cohesion: 1.0
+Nodes (1): Cyclist athlete
+
+### Community 665 - "Community 665"
+Cohesion: 1.0
+Nodes (1): Endurance cycling performance
+
+### Community 666 - "Community 666"
+Cohesion: 1.0
+Nodes (1): Hero background imagery
+
+### Community 667 - "Community 667"
+Cohesion: 1.0
+Nodes (1): Performance coaching brand tone
+
+### Community 668 - "Community 668"
 Cohesion: 1.0
 Nodes (1): Outdoor road training context
 
 ## Knowledge Gaps
-- **535 isolated node(s):** `TrainingPlanWorkoutSummaryAdapter`, `LatestCompletedActivityAdapter`, `GoogleTokenResponse`, `GoogleUserInfoResponse`, `EventResponse` (+530 more)
+- **602 isolated node(s):** `EventQuery`, `EventPath`, `AthletePath`, `ActivityPath`, `ResponseUpload` (+597 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 321`** (2 nodes): `PublicLayout.tsx`, `PublicLayout()`
+- **Thin community `Community 355`** (2 nodes): `PublicLayout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `ApiConfigCard()`, `ApiConfigCard.tsx`
+- **Thin community `Community 356`** (2 nodes): `cycling()`, `AuthenticatedLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `BackendStatusCard()`, `BackendStatusCard.tsx`
+- **Thin community `Community 357`** (2 nodes): `buildSettings()`, `AvailabilityCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `ProtectedSystemInfoCard.tsx`, `ProtectedSystemInfoCard()`
+- **Thin community `Community 358`** (2 nodes): `OptionsCard.tsx`, `handleToggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `SystemStatusHero.tsx`, `SystemStatusHero()`
+- **Thin community `Community 359`** (2 nodes): `IntervalsCard.test.tsx`, `buildSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `UserMenu.tsx`, `UserMenu()`
+- **Thin community `Community 360`** (2 nodes): `buildSettings()`, `AiAgentsCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `AuthProbe()`, `AuthProvider.test.tsx`
+- **Thin community `Community 361`** (2 nodes): `buildSettings()`, `AthleteSummaryCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `AuthProvider()`, `AuthProvider.tsx`
+- **Thin community `Community 362`** (2 nodes): `ApiKeyInput()`, `ApiKeyInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `RequireAuth.tsx`, `RequireAuth()`
+- **Thin community `Community 363`** (2 nodes): `BackgroundGlow()`, `BackgroundGlow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `RequireRole.tsx`, `RequireRole()`
+- **Thin community `Community 364`** (2 nodes): `CalendarWeekDayHeader()`, `CalendarWeekDayHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `CalendarLoadingRow()`, `CalendarLoadingRow.tsx`
+- **Thin community `Community 365`** (2 nodes): `WorkoutDetailModal.interaction.test.tsx`, `renderActivityModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `CalendarWeekDayHeader()`, `CalendarWeekDayHeader.tsx`
+- **Thin community `Community 366`** (2 nodes): `CalendarLoadingRow()`, `CalendarLoadingRow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `handleToggleSelectedInterval()`, `CompletedWorkoutDetailModal.tsx`
+- **Thin community `Community 367`** (2 nodes): `handleToggleSelectedInterval()`, `CompletedWorkoutDetailModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `handleKeyDown()`, `DayItemsModal.tsx`
+- **Thin community `Community 368`** (2 nodes): `handleKeyDown()`, `DayItemsModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `RaceDayDetailModal.tsx`, `handleKeyDown()`
+- **Thin community `Community 369`** (2 nodes): `AuthProbe()`, `AuthProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `WorkoutDetailModal.interaction.test.tsx`, `renderActivityModal()`
+- **Thin community `Community 370`** (2 nodes): `AuthProvider()`, `AuthProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `ChatHeader()`, `ChatHeader.tsx`
+- **Thin community `Community 371`** (2 nodes): `UserMenu.tsx`, `UserMenu()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `handleSend()`, `ChatInput.tsx`
+- **Thin community `Community 372`** (2 nodes): `RequireRole.tsx`, `RequireRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `handleKeyDown()`, `ConfirmWithoutChatModal.tsx`
+- **Thin community `Community 373`** (2 nodes): `RequireAuth.tsx`, `RequireAuth()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `RpeButton.tsx`, `RpeButton()`
+- **Thin community `Community 374`** (2 nodes): `WorkoutActionButtons.tsx`, `WorkoutActionButtons()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `WorkoutActionButtons.tsx`, `WorkoutActionButtons()`
+- **Thin community `Community 375`** (2 nodes): `WorkoutCategoryTag.tsx`, `WorkoutCategoryTag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `WorkoutCategoryTag.tsx`, `WorkoutCategoryTag()`
+- **Thin community `Community 376`** (2 nodes): `handleSend()`, `ChatInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `useWorkoutList.test.tsx`, `formatWeekLabel()`
+- **Thin community `Community 377`** (2 nodes): `RpeButton.tsx`, `RpeButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `BackgroundGlow()`, `BackgroundGlow.tsx`
+- **Thin community `Community 378`** (2 nodes): `handleKeyDown()`, `ConfirmWithoutChatModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `RaceCard.tsx`, `switch()`
+- **Thin community `Community 379`** (2 nodes): `useWorkoutList.test.tsx`, `formatWeekLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `RacesPageLayout.test.tsx`, `makeRace()`
+- **Thin community `Community 380`** (2 nodes): `BackendStatusCard()`, `BackendStatusCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `buildSettings()`, `AiAgentsCard.test.tsx`
+- **Thin community `Community 381`** (2 nodes): `ApiConfigCard()`, `ApiConfigCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `ApiKeyInput()`, `ApiKeyInput.tsx`
+- **Thin community `Community 382`** (2 nodes): `SystemStatusHero.tsx`, `SystemStatusHero()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `buildSettings()`, `AthleteSummaryCard.test.tsx`
+- **Thin community `Community 383`** (2 nodes): `ProtectedSystemInfoCard.tsx`, `ProtectedSystemInfoCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `buildSettings()`, `AvailabilityCard.test.tsx`
+- **Thin community `Community 384`** (2 nodes): `RacesPageLayout.test.tsx`, `makeRace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `IntervalsCard.test.tsx`, `buildSettings()`
+- **Thin community `Community 385`** (2 nodes): `RaceCard.tsx`, `switch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `OptionsCard.tsx`, `handleToggle()`
+- **Thin community `Community 386`** (2 nodes): `CalendarPage()`, `CalendarPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `AdminSystemInfoPage()`, `AdminSystemInfoPage.tsx`
+- **Thin community `Community 387`** (2 nodes): `AdminSystemInfoPage()`, `AdminSystemInfoPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `AICoachPage()`, `AICoachPage.tsx`
+- **Thin community `Community 388`** (2 nodes): `AppHomePage()`, `AppHomePage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `AppHomePage()`, `AppHomePage.tsx`
+- **Thin community `Community 389`** (2 nodes): `LandingPage.tsx`, `LandingPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `CalendarPage()`, `CalendarPage.tsx`
+- **Thin community `Community 390`** (2 nodes): `RacesPage.tsx`, `RacesPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `LandingPage.tsx`, `LandingPage()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `RacesPage.tsx`, `RacesPage()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `workout_summary_latest_activity.rs`, `LatestCompletedActivityAdapter`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `IntervalsIcuClient`, `.test_connection()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `non_empty_context_parts()`, `context_prelude.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `context_hash()`, `cache.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `is_duplicate_key_error()`, `error.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `read_cookie()`, `cookies.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `AthleteSummaryDto`, `dto.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `map_summary_state_to_dto()`, `mapping.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `status_class.rs`, `status_class()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `CreateRace`, `.from()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `map_race_to_dto()`, `mapping.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `CalendarLabelsService`, `service.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `IntervalsService<
-        Api,
-        Settings,
-        Activities,
-        UploadOperations,
-        Extractor,
-        NoopPestParserPocRepository,
-        LiveClock,
-    >`, `.new()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time>`, `.get_enriched_event_impl()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `UserSettingsRepository`, `ports.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `CompactRace<'a>`, `.from_race()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `CompactFuturePlannedEvent<'a>`, `.from_event()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `CompactAvailabilityDay<'a>`, `.from_day()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `CompactHistoricalLoadTrend<'a>`, `.from_point()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `CompactHistoricalWorkout<'a>`, `.from_workout()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `VolatilePayload<'a>`, `.from_context()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `CompactRecentDay<'a>`, `.from_recent_day()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `CompactRecentWorkout<'a>`, `.from_workout()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `CompactPlannedWorkoutRef<'a>`, `.from_reference()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `CompactPlannedWorkout<'a>`, `.from_planned()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `CompactSpecialDay<'a>`, `.from_special()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `CompactUpcomingDay<'a>`, `.from_upcoming_day()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `CompactProjectedDay<'a>`, `.from_projected_day()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `CompactProjectedWorkout<'a>`, `.from_projected_workout()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `settings_request_logs_authenticated_user_id_on_request_span()`, `observability.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `ttl_validation.rs`, `validate_session_ttl_against_current_time_rejects_bson_overflowing_ttl()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `assert_valid_traceparent()`, `assertions.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `assert_log_entry_contains()`, `test_support.rs`
+- **Thin community `Community 391`** (2 nodes): `AICoachPage()`, `AICoachPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 392`** (2 nodes): `assert_log_entry_contains()`, `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `assert_event_order()`, `assertions.rs`
+- **Thin community `Community 393`** (2 nodes): `assert_valid_traceparent()`, `assertions.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (1 nodes): `vite.config.ts`
+- **Thin community `Community 394`** (2 nodes): `assert_log_entry_contains()`, `test_support.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (1 nodes): `App.test.tsx`
+- **Thin community `Community 395`** (2 nodes): `assert_event_order()`, `assertions.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (1 nodes): `App.tsx`
+- **Thin community `Community 396`** (2 nodes): `ttl_validation.rs`, `validate_session_ttl_against_current_time_rejects_bson_overflowing_ttl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (1 nodes): `i18n.ts`
+- **Thin community `Community 397`** (2 nodes): `settings_request_logs_authenticated_user_id_on_request_span()`, `observability.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (1 nodes): `main.tsx`
+- **Thin community `Community 398`** (2 nodes): `main()`, `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 399`** (2 nodes): `ProviderPollingService<
+        Api,
+        Settings,
+        PollStates,
+        Imports,
+        Time,
+        Ids,
+        NoopCalendarEntryViewRefresh,
+    >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (1 nodes): `AuthenticatedLayout.tsx`
+- **Thin community `Community 400`** (2 nodes): `poll_due_once_persists_attempt_before_calling_intervals()`, `persistence.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (1 nodes): `env.test.ts`
+- **Thin community `Community 401`** (2 nodes): `workout_summary_completed_target.rs`, `CompletedWorkoutTargetAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (1 nodes): `types.ts`
+- **Thin community `Community 402`** (2 nodes): `workout_summary_latest_activity.rs`, `LatestCompletedActivityAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 403`** (2 nodes): `non_empty_context_parts()`, `context_prelude.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (1 nodes): `RequireAuth.test.tsx`
+- **Thin community `Community 404`** (2 nodes): `context_hash()`, `cache.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (1 nodes): `RequireRole.test.tsx`
+- **Thin community `Community 405`** (2 nodes): `IntervalsIcuClient`, `.test_connection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (1 nodes): `constants.ts`
+- **Thin community `Community 406`** (2 nodes): `is_duplicate_key_error()`, `error.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (1 nodes): `types.ts`
+- **Thin community `Community 407`** (2 nodes): `read_cookie()`, `cookies.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (1 nodes): `workoutDetails.test.ts`
+- **Thin community `Community 408`** (2 nodes): `map_summary_state_to_dto()`, `mapping.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (1 nodes): `calendar.test.ts`
+- **Thin community `Community 409`** (2 nodes): `AthleteSummaryDto`, `dto.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (1 nodes): `CalendarDayCell.charts.test.tsx`
+- **Thin community `Community 410`** (2 nodes): `CreateRace`, `.from()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (1 nodes): `CalendarDayCell.content.test.tsx`
+- **Thin community `Community 411`** (2 nodes): `map_race_to_dto()`, `mapping.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (1 nodes): `CalendarErrorRow.test.tsx`
+- **Thin community `Community 412`** (2 nodes): `status_class.rs`, `status_class()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (1 nodes): `CalendarErrorRow.tsx`
+- **Thin community `Community 413`** (2 nodes): `UserSettingsRepository`, `ports.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (1 nodes): `CalendarGrid.tsx`
+- **Thin community `Community 414`** (2 nodes): `CalendarLabelsService`, `service.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (1 nodes): `CalendarLoadingRow.test.tsx`
+- **Thin community `Community 415`** (2 nodes): `CalendarService`, `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (1 nodes): `CalendarMiniChart.tsx`
+- **Thin community `Community 416`** (2 nodes): `CalendarService<
+        Intervals,
+        Entries,
+        Projections,
+        Syncs,
+        Time,
+        NoopPlannedWorkoutTokenRepository,
+        NoopProviderPollStateRepository,
+        NoopCalendarEntryViewRefresh,
+        (),
+    >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (1 nodes): `CalendarPerformanceCards.test.tsx`
+- **Thin community `Community 417`** (2 nodes): `SpecialDayService`, `service.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (1 nodes): `CalendarPerformanceCards.tsx`
+- **Thin community `Community 418`** (2 nodes): `SpecialDayService<Repository>`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (1 nodes): `CalendarWeekSection.tsx`
+- **Thin community `Community 419`** (2 nodes): `IntervalsService<
+        Api,
+        Settings,
+        Activities,
+        UploadOperations,
+        Extractor,
+        NoopPestParserPocRepository,
+        LiveClock,
+        NoopCalendarEntryViewRefresh,
+    >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (1 nodes): `CalendarWeekSummary.tsx`
+- **Thin community `Community 420`** (2 nodes): `IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>`, `.get_enriched_event_impl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (1 nodes): `DayItemsModal.test.tsx`
+- **Thin community `Community 421`** (2 nodes): `PlannedCompletedWorkoutLinkRepository`, `ports.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (1 nodes): `RaceDayDetailModal.test.tsx`
+- **Thin community `Community 422`** (2 nodes): `VolatilePayload<'a>`, `.from_context()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (1 nodes): `WorkoutDetailModal.actions.test.tsx`
+- **Thin community `Community 423`** (2 nodes): `CompactRecentDay<'a>`, `.from_recent_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (1 nodes): `WorkoutDetailModal.charts.test.tsx`
+- **Thin community `Community 424`** (2 nodes): `CompactRecentWorkout<'a>`, `.from_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (1 nodes): `WorkoutDetailModal.completed.test.tsx`
+- **Thin community `Community 425`** (2 nodes): `CompactPlannedWorkoutRef<'a>`, `.from_reference()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (1 nodes): `WorkoutDetailModal.intervals.test.tsx`
+- **Thin community `Community 426`** (2 nodes): `CompactPlannedWorkout<'a>`, `.from_planned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (1 nodes): `WorkoutDetailModal.planned.test.tsx`
+- **Thin community `Community 427`** (2 nodes): `CompactSpecialDay<'a>`, `.from_special()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (1 nodes): `WorkoutDetailModalPanels.tsx`
+- **Thin community `Community 428`** (2 nodes): `CompactUpcomingDay<'a>`, `.from_upcoming_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (1 nodes): `WorkoutDetailPanelPrimitives.tsx`
+- **Thin community `Community 429`** (2 nodes): `CompactProjectedDay<'a>`, `.from_projected_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (1 nodes): `dateUtils.test.ts`
+- **Thin community `Community 430`** (2 nodes): `CompactProjectedWorkout<'a>`, `.from_projected_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (1 nodes): `types.ts`
+- **Thin community `Community 431`** (2 nodes): `CompactRace<'a>`, `.from_race()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (1 nodes): `workoutSummary.test.ts`
+- **Thin community `Community 432`** (2 nodes): `CompactFuturePlannedEvent<'a>`, `.from_event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (1 nodes): `ChatMessageList.tsx`
+- **Thin community `Community 433`** (2 nodes): `CompactAvailabilityDay<'a>`, `.from_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (1 nodes): `ChatTypingIndicator.tsx`
+- **Thin community `Community 434`** (2 nodes): `CompactHistoricalLoadTrend<'a>`, `.from_point()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (1 nodes): `ChatWindow.test.tsx`
+- **Thin community `Community 435`** (2 nodes): `CompactHistoricalWorkout<'a>`, `.from_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (1 nodes): `ChatWindow.tsx`
+- **Thin community `Community 436`** (1 nodes): `vite.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (1 nodes): `ConfirmWithoutChatModal.test.tsx`
+- **Thin community `Community 437`** (1 nodes): `App.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (1 nodes): `EmptyWorkoutState.tsx`
+- **Thin community `Community 438`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (1 nodes): `RpeScaleLabels.tsx`
+- **Thin community `Community 439`** (1 nodes): `App.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (1 nodes): `RpeSelector.test.tsx`
+- **Thin community `Community 440`** (1 nodes): `i18n.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (1 nodes): `RpeSelector.tsx`
+- **Thin community `Community 441`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (1 nodes): `WorkoutActionButtons.test.tsx`
+- **Thin community `Community 442`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (1 nodes): `WorkoutHistoryPagination.tsx`
+- **Thin community `Community 443`** (1 nodes): `env.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (1 nodes): `WorkoutHistorySidebar.test.tsx`
+- **Thin community `Community 444`** (1 nodes): `mockData.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (1 nodes): `WorkoutHistorySidebar.tsx`
+- **Thin community `Community 445`** (1 nodes): `settings.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (1 nodes): `types.ts`
+- **Thin community `Community 446`** (1 nodes): `LoginPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (1 nodes): `intervals.activities.test.ts`
+- **Thin community `Community 447`** (1 nodes): `workoutDetails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (1 nodes): `intervals.events.test.ts`
+- **Thin community `Community 448`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (1 nodes): `LoginPanel.tsx`
+- **Thin community `Community 449`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (1 nodes): `types.ts`
+- **Thin community `Community 450`** (1 nodes): `dateUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (1 nodes): `races.test.ts`
+- **Thin community `Community 451`** (1 nodes): `WorkoutDetailPanelPrimitives.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (1 nodes): `RacesPageLayout.tsx`
+- **Thin community `Community 452`** (1 nodes): `DayItemsModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (1 nodes): `useRaces.test.tsx`
+- **Thin community `Community 453`** (1 nodes): `WorkoutDetailModal.intervals.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (1 nodes): `mockData.ts`
+- **Thin community `Community 454`** (1 nodes): `CalendarWeekSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (1 nodes): `settings.test.ts`
+- **Thin community `Community 455`** (1 nodes): `RaceDayDetailModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (1 nodes): `statusUi.test.ts`
+- **Thin community `Community 456`** (1 nodes): `WorkoutDetailModal.actions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (1 nodes): `system.test.ts`
+- **Thin community `Community 457`** (1 nodes): `CalendarPerformanceCards.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (1 nodes): `AdminSystemInfoPage.test.tsx`
+- **Thin community `Community 458`** (1 nodes): `WorkoutDetailModal.completed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (1 nodes): `LandingPage.test.tsx`
+- **Thin community `Community 459`** (1 nodes): `CalendarGrid.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (1 nodes): `setup.ts`
+- **Thin community `Community 460`** (1 nodes): `CalendarDayCell.charts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (1 nodes): `lib.rs`
+- **Thin community `Community 461`** (1 nodes): `CalendarErrorRow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (1 nodes): `mod.rs`
+- **Thin community `Community 462`** (1 nodes): `CalendarPerformanceCards.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (1 nodes): `mod.rs`
+- **Thin community `Community 463`** (1 nodes): `CalendarLoadingRow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (1 nodes): `mod.rs`
+- **Thin community `Community 464`** (1 nodes): `WorkoutDetailModalPanels.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (1 nodes): `api.rs`
+- **Thin community `Community 465`** (1 nodes): `CalendarDayCell.content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (1 nodes): `connection.rs`
+- **Thin community `Community 466`** (1 nodes): `WorkoutDetailModal.planned.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (1 nodes): `details.rs`
+- **Thin community `Community 467`** (1 nodes): `CalendarMiniChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (1 nodes): `mod.rs`
+- **Thin community `Community 468`** (1 nodes): `CalendarWeekSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (1 nodes): `mod.rs`
+- **Thin community `Community 469`** (1 nodes): `WorkoutDetailModal.charts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (1 nodes): `mod.rs`
+- **Thin community `Community 470`** (1 nodes): `CalendarErrorRow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (1 nodes): `mod.rs`
+- **Thin community `Community 471`** (1 nodes): `calendar.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (1 nodes): `mod.rs`
+- **Thin community `Community 472`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (1 nodes): `calendar.rs`
+- **Thin community `Community 473`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (1 nodes): `intervals.rs`
+- **Thin community `Community 474`** (1 nodes): `RequireRole.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (1 nodes): `races.rs`
+- **Thin community `Community 475`** (1 nodes): `RequireAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (1 nodes): `mod.rs`
+- **Thin community `Community 476`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (1 nodes): `mod.rs`
+- **Thin community `Community 477`** (1 nodes): `intervals.activities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (1 nodes): `mod.rs`
+- **Thin community `Community 478`** (1 nodes): `intervals.events.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (1 nodes): `mod.rs`
+- **Thin community `Community 479`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (1 nodes): `mod.rs`
+- **Thin community `Community 480`** (1 nodes): `RpeSelector.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (1 nodes): `mod.rs`
+- **Thin community `Community 481`** (1 nodes): `WorkoutHistorySidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (1 nodes): `mod.rs`
+- **Thin community `Community 482`** (1 nodes): `WorkoutActionButtons.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (1 nodes): `mod.rs`
+- **Thin community `Community 483`** (1 nodes): `RpeScaleLabels.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (1 nodes): `mod.rs`
+- **Thin community `Community 484`** (1 nodes): `EmptyWorkoutState.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (1 nodes): `mod.rs`
+- **Thin community `Community 485`** (1 nodes): `ChatWindow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (1 nodes): `mod.rs`
+- **Thin community `Community 486`** (1 nodes): `ChatHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (1 nodes): `mod.rs`
+- **Thin community `Community 487`** (1 nodes): `ChatWindow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (1 nodes): `mod.rs`
+- **Thin community `Community 488`** (1 nodes): `ConfirmWithoutChatModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (1 nodes): `activities.rs`
+- **Thin community `Community 489`** (1 nodes): `WorkoutHistorySidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (1 nodes): `enriched.rs`
+- **Thin community `Community 490`** (1 nodes): `ChatMessageList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (1 nodes): `events.rs`
+- **Thin community `Community 491`** (1 nodes): `ChatTypingIndicator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (1 nodes): `upload.rs`
+- **Thin community `Community 492`** (1 nodes): `WorkoutHistoryPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (1 nodes): `mod.rs`
+- **Thin community `Community 493`** (1 nodes): `RpeSelector.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (1 nodes): `mod.rs`
+- **Thin community `Community 494`** (1 nodes): `workoutSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (1 nodes): `mod.rs`
+- **Thin community `Community 495`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (1 nodes): `mod.rs`
+- **Thin community `Community 496`** (1 nodes): `RacesPageLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (1 nodes): `mod.rs`
+- **Thin community `Community 497`** (1 nodes): `useRaces.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (1 nodes): `mod.rs`
+- **Thin community `Community 498`** (1 nodes): `races.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (1 nodes): `mod.rs`
+- **Thin community `Community 499`** (1 nodes): `statusUi.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (1 nodes): `mod.rs`
+- **Thin community `Community 500`** (1 nodes): `system.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (1 nodes): `mod.rs`
+- **Thin community `Community 501`** (1 nodes): `AdminSystemInfoPage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (1 nodes): `mod.rs`
+- **Thin community `Community 502`** (1 nodes): `LandingPage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (1 nodes): `parsing.rs`
+- **Thin community `Community 503`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (1 nodes): `snapshot.rs`
+- **Thin community `Community 504`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 505`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 506`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (1 nodes): `main.rs`
+- **Thin community `Community 507`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 508`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (1 nodes): `main.rs`
+- **Thin community `Community 509`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (1 nodes): `mod.rs`
+- **Thin community `Community 510`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (1 nodes): `event_queries.rs`
+- **Thin community `Community 511`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 512`** (1 nodes): `intervals_fakes.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 513`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (1 nodes): `main.rs`
+- **Thin community `Community 514`** (1 nodes): `event_queries.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (1 nodes): `mod.rs`
+- **Thin community `Community 515`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (1 nodes): `main.rs`
+- **Thin community `Community 516`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 517`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (1 nodes): `mod.rs`
+- **Thin community `Community 518`** (1 nodes): `constants.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (1 nodes): `mod.rs`
+- **Thin community `Community 519`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 520`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -3688,255 +3855,313 @@ Nodes (1): Outdoor road training context
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 522`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (1 nodes): `constants.rs`
+- **Thin community `Community 523`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (1 nodes): `main.rs`
+- **Thin community `Community 524`** (1 nodes): `lib.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 525`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (1 nodes): `main.rs`
+- **Thin community `Community 526`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 527`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (1 nodes): `Hexagonal Architecture Rules`
+- **Thin community `Community 528`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (1 nodes): `Persist Local State Before Side Effects`
+- **Thin community `Community 529`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (1 nodes): `Single Container API And SPA Deployment`
+- **Thin community `Community 530`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (1 nodes): `Operational Health And Readiness Endpoints`
+- **Thin community `Community 531`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (1 nodes): `Coach Reply Operation`
+- **Thin community `Community 532`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (1 nodes): `Pending Durable Coach Reply State`
+- **Thin community `Community 533`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (1 nodes): `Coach Reply Recovery Rules`
+- **Thin community `Community 534`** (1 nodes): `connection.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (1 nodes): `Same Request Local Write Retries`
+- **Thin community `Community 535`** (1 nodes): `api.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (1 nodes): `Compare And Swap Pending Operation Reclaim`
+- **Thin community `Community 536`** (1 nodes): `details.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (1 nodes): `Bootstrap Architecture`
+- **Thin community `Community 537`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (1 nodes): `REST Adapter`
+- **Thin community `Community 538`** (1 nodes): `intervals.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (1 nodes): `Mongo Adapter`
+- **Thin community `Community 539`** (1 nodes): `races.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (1 nodes): `Planned Mongo Collections`
+- **Thin community `Community 540`** (1 nodes): `calendar.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (1 nodes): `Backend Bootstrap Foundation`
+- **Thin community `Community 541`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (1 nodes): `Project Obsidian Handbook`
+- **Thin community `Community 542`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (1 nodes): `Manual Tag Based Release Flow`
+- **Thin community `Community 543`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (1 nodes): `Manual Coolify Deployment Path`
+- **Thin community `Community 544`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (1 nodes): `Frontend Application Shell`
+- **Thin community `Community 545`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (1 nodes): `Frontend Backend Connectivity`
+- **Thin community `Community 546`** (1 nodes): `events.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (1 nodes): `Identity Domain`
+- **Thin community `Community 547`** (1 nodes): `upload.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (1 nodes): `Google OAuth Login Flow`
+- **Thin community `Community 548`** (1 nodes): `activities.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (1 nodes): `Server Side Sessions`
+- **Thin community `Community 549`** (1 nodes): `enriched.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (1 nodes): `RBAC Policy`
+- **Thin community `Community 550`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (1 nodes): `Draft Driven Intervals Settings Actions`
+- **Thin community `Community 551`** (1 nodes): `parsing.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (1 nodes): `Synthetic Trace Parent Fix`
+- **Thin community `Community 552`** (1 nodes): `snapshot.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (1 nodes): `Atomic Tracing Capture Writes`
+- **Thin community `Community 553`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (1 nodes): `Structured Mini Chart Bars`
+- **Thin community `Community 554`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (1 nodes): `Completed Activity Enrichment`
+- **Thin community `Community 555`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (1 nodes): `Partial Enrichment Fail Open`
+- **Thin community `Community 556`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (1 nodes): `Workout Detail Modal Flow`
+- **Thin community `Community 557`** (1 nodes): `Hexagonal Architecture Rules`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (1 nodes): `Event FIT Download Action`
+- **Thin community `Community 558`** (1 nodes): `Persist Local State Before Side Effects`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (1 nodes): `Intervals Service Enrichment Placement`
+- **Thin community `Community 559`** (1 nodes): `Single Container API And SPA Deployment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (1 nodes): `Partial Modal Resilience`
+- **Thin community `Community 560`** (1 nodes): `Operational Health And Readiness Endpoints`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (1 nodes): `Intervals Service Workout Enrichment`
+- **Thin community `Community 561`** (1 nodes): `Coach Reply Operation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (1 nodes): `Partial Workout Detail Failure Resilience`
+- **Thin community `Community 562`** (1 nodes): `Pending Durable Coach Reply State`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (1 nodes): `Completed Workout Mode UI Cleanup`
+- **Thin community `Community 563`** (1 nodes): `Coach Reply Recovery Rules`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (1 nodes): `Remove Workout Detail Auto Scroll Side Effect`
+- **Thin community `Community 564`** (1 nodes): `Same Request Local Write Retries`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (1 nodes): `Preserve Workout Detail Selection Synchronization`
+- **Thin community `Community 565`** (1 nodes): `Compare And Swap Pending Operation Reclaim`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (1 nodes): `Workout Detail ScrollIntoView Removal`
+- **Thin community `Community 566`** (1 nodes): `Bootstrap Architecture`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (1 nodes): `Workout Detail Interaction Test Updates`
+- **Thin community `Community 567`** (1 nodes): `REST Adapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (1 nodes): `Durable Recoverable Coach Replies`
+- **Thin community `Community 568`** (1 nodes): `Mongo Adapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (1 nodes): `LLM Context Cache Invalidation`
+- **Thin community `Community 569`** (1 nodes): `Planned Mongo Collections`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (1 nodes): `Provider Observability And Cost Tracing`
+- **Thin community `Community 570`** (1 nodes): `Backend Bootstrap Foundation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (1 nodes): `AI Settings UX Hardening`
+- **Thin community `Community 571`** (1 nodes): `Project Obsidian Handbook`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (1 nodes): `Coach Reply Operation As Durable Workflow Record`
+- **Thin community `Community 572`** (1 nodes): `Manual Tag Based Release Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (1 nodes): `Idempotent Coach Reply Finalization`
+- **Thin community `Community 573`** (1 nodes): `Manual Coolify Deployment Path`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (1 nodes): `Partial Persistence Failure Recovery For Finalization`
+- **Thin community `Community 574`** (1 nodes): `Frontend Application Shell`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (1 nodes): `Coach Reply State Machine Documentation Update`
+- **Thin community `Community 575`** (1 nodes): `Frontend Backend Connectivity`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (1 nodes): `Debug Level Successful Health Logs`
+- **Thin community `Community 576`** (1 nodes): `Identity Domain`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (1 nodes): `Preserve Health Failure Visibility`
+- **Thin community `Community 577`** (1 nodes): `Google OAuth Login Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (1 nodes): `Reduce Health Endpoint Success Log Noise`
+- **Thin community `Community 578`** (1 nodes): `Server Side Sessions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (1 nodes): `Curated Provider Model Suggestion Refresh`
+- **Thin community `Community 579`** (1 nodes): `RBAC Policy`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (1 nodes): `Preserve Freeform Model Input`
+- **Thin community `Community 580`** (1 nodes): `Draft Driven Intervals Settings Actions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (1 nodes): `Refresh AI Agent Model Suggestions`
+- **Thin community `Community 581`** (1 nodes): `Synthetic Trace Parent Fix`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (1 nodes): `Lower Mongo Local Development Verbosity`
+- **Thin community `Community 582`** (1 nodes): `Atomic Tracing Capture Writes`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (1 nodes): `Quiet Docker Compose Mongo Startup Logs`
+- **Thin community `Community 583`** (1 nodes): `Structured Mini Chart Bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (1 nodes): `Safe Structured OpenRouter Diagnostics`
+- **Thin community `Community 584`** (1 nodes): `Completed Activity Enrichment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `Redacted Provider Request Metadata Logging`
+- **Thin community `Community 585`** (1 nodes): `Partial Enrichment Fail Open`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `OpenRouter Transport And Response Diagnostics`
+- **Thin community `Community 586`** (1 nodes): `Workout Detail Modal Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `Multi Provider Logging Pattern Rollout`
+- **Thin community `Community 587`** (1 nodes): `Event FIT Download Action`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `OpenAI And Gemini Diagnostic Logging`
+- **Thin community `Community 588`** (1 nodes): `Intervals Service Enrichment Placement`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `Persisted Athlete Summary Feature`
+- **Thin community `Community 589`** (1 nodes): `Partial Modal Resilience`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `Athlete Summary Prompt Context Integration`
+- **Thin community `Community 590`** (1 nodes): `Intervals Service Workout Enrichment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `Athlete Summary Generation System Message`
+- **Thin community `Community 591`** (1 nodes): `Partial Workout Detail Failure Resilience`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `OpenRouter Stable Prefix Prompt Caching`
+- **Thin community `Community 592`** (1 nodes): `Completed Workout Mode UI Cleanup`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `Uncached Conversation Tail`
+- **Thin community `Community 593`** (1 nodes): `Remove Workout Detail Auto Scroll Side Effect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `Single WebSocket Control Loop`
+- **Thin community `Community 594`** (1 nodes): `Preserve Workout Detail Selection Synchronization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `Drop Queued Messages After Disconnect`
+- **Thin community `Community 595`** (1 nodes): `Workout Detail ScrollIntoView Removal`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `Full Workout Summary Builder Request Logging`
+- **Thin community `Community 596`** (1 nodes): `Workout Detail Interaction Test Updates`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `Athlete Summary Durable Generation Operation`
+- **Thin community `Community 597`** (1 nodes): `Durable Recoverable Coach Replies`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `Athlete Summary Stale Work Reclaim`
+- **Thin community `Community 598`** (1 nodes): `LLM Context Cache Invalidation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `Distinct Athlete Summary System Message Rendering`
+- **Thin community `Community 599`** (1 nodes): `Provider Observability And Cost Tracing`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `Compressed Raw Power Segments`
+- **Thin community `Community 600`** (1 nodes): `AI Settings UX Hardening`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `Compact Training Context Power Field`
+- **Thin community `Community 601`** (1 nodes): `Coach Reply Operation As Durable Workflow Record`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `Power Compression Prompt Encoding Legend`
+- **Thin community `Community 602`** (1 nodes): `Idempotent Coach Reply Finalization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `2026-04-04-power-compression-llm.md`
+- **Thin community `Community 603`** (1 nodes): `Partial Persistence Failure Recovery For Finalization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `Replace LLM workout power arrays with compressed raw-power segments`
+- **Thin community `Community 604`** (1 nodes): `Coach Reply State Machine Documentation Update`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly`
+- **Thin community `Community 605`** (1 nodes): `Debug Level Successful Health Logs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `RecentWorkoutContext.compressed_power_levels: Vec<String>`
+- **Thin community `Community 606`** (1 nodes): `Preserve Health Failure Visibility`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `Add power compression tests and implementation in training_context service`
+- **Thin community `Community 607`** (1 nodes): `Reduce Health Endpoint Success Log Noise`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `Pack pc instead of p5`
+- **Thin community `Community 608`** (1 nodes): `Curated Provider Model Suggestion Refresh`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `Update the workout coach prompt with power-compression semantics`
+- **Thin community `Community 609`** (1 nodes): `Preserve Freeform Model Input`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `Update LLM flow assertions to expect pc in live requests`
+- **Thin community `Community 610`** (1 nodes): `Refresh AI Agent Model Suggestions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `Run full formatting, lint, Rust tests, and repo verification`
+- **Thin community `Community 611`** (1 nodes): `Lower Mongo Local Development Verbosity`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `2026-04-06-backend-slice-size-refactor-design.md`
+- **Thin community `Community 612`** (1 nodes): `Quiet Docker Compose Mongo Startup Logs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior`
+- **Thin community `Community 613`** (1 nodes): `Safe Structured OpenRouter Diagnostics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged`
+- **Thin community `Community 614`** (1 nodes): `Redacted Provider Request Metadata Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `Split training_context service into focused service/ siblings`
+- **Thin community `Community 615`** (1 nodes): `OpenRouter Transport And Response Diagnostics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `Split workout_summary service into focused service/ siblings`
+- **Thin community `Community 616`** (1 nodes): `Multi Provider Logging Pattern Rollout`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `Split training_context packing into focused packing/ siblings`
+- **Thin community `Community 617`** (1 nodes): `OpenAI And Gemini Diagnostic Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `Split Mongo workout-summary adapter tests first and helper concerns only if still oversized`
+- **Thin community `Community 618`** (1 nodes): `Persisted Athlete Summary Feature`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `Split bulky current-slice shared helpers and integration suites into directory-based test modules`
+- **Thin community `Community 619`** (1 nodes): `Athlete Summary Prompt Context Integration`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `2026-04-06-backend-slice-size-refactor.md`
+- **Thin community `Community 620`** (1 nodes): `Athlete Summary Generation System Message`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `Split training_context service into focused directory modules`
+- **Thin community `Community 621`** (1 nodes): `OpenRouter Stable Prefix Prompt Caching`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `Split workout_summary service while keeping WorkoutSummaryService as the entrypoint`
+- **Thin community `Community 622`** (1 nodes): `Uncached Conversation Tail`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `Split training_context packing into focused payload and rendering modules`
+- **Thin community `Community 623`** (1 nodes): `Single WebSocket Control Loop`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `Split the Mongo workout-summary adapter by moving tests first and helpers only if needed`
+- **Thin community `Community 624`** (1 nodes): `Drop Queued Messages After Disconnect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `Split bulky workout-summary shared helpers and remaining oversized current-slice tests`
+- **Thin community `Community 625`** (1 nodes): `Full Workout Summary Builder Request Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `Run broader backend verification after the refactor`
+- **Thin community `Community 626`** (1 nodes): `Athlete Summary Durable Generation Operation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `2026-04-06-review-followups.md`
+- **Thin community `Community 627`** (1 nodes): `Athlete Summary Stale Work Reclaim`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits`
+- **Thin community `Community 628`** (1 nodes): `Distinct Athlete Summary System Message Rendering`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `Make projection replay heal partial same-operation inserts`
+- **Thin community `Community 629`** (1 nodes): `Compressed Raw Power Segments`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `Make workout-summary legacy fallback deterministic`
+- **Thin community `Community 630`** (1 nodes): `Compact Training Context Power Field`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `Preserve correction retry budget across reclaim`
+- **Thin community `Community 631`** (1 nodes): `Power Compression Prompt Encoding Legend`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `Close low-level test and docs nits`
+- **Thin community `Community 632`** (1 nodes): `2026-04-04-power-compression-llm.md`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `Run targeted tests, fmt, and clippy for the follow-up batch`
+- **Thin community `Community 633`** (1 nodes): `Replace LLM workout power arrays with compressed raw-power segments`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `cyclist-bg.jpg`
+- **Thin community `Community 634`** (1 nodes): `Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `Cyclist athlete`
+- **Thin community `Community 635`** (1 nodes): `RecentWorkoutContext.compressed_power_levels: Vec<String>`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `Endurance cycling performance`
+- **Thin community `Community 636`** (1 nodes): `Add power compression tests and implementation in training_context service`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `Hero background imagery`
+- **Thin community `Community 637`** (1 nodes): `Pack pc instead of p5`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `Performance coaching brand tone`
+- **Thin community `Community 638`** (1 nodes): `Update the workout coach prompt with power-compression semantics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `Outdoor road training context`
+- **Thin community `Community 639`** (1 nodes): `Update LLM flow assertions to expect pc in live requests`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 640`** (1 nodes): `Run full formatting, lint, Rust tests, and repo verification`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 641`** (1 nodes): `2026-04-06-backend-slice-size-refactor-design.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 642`** (1 nodes): `Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 643`** (1 nodes): `Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 644`** (1 nodes): `Split training_context service into focused service/ siblings`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 645`** (1 nodes): `Split workout_summary service into focused service/ siblings`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 646`** (1 nodes): `Split training_context packing into focused packing/ siblings`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 647`** (1 nodes): `Split Mongo workout-summary adapter tests first and helper concerns only if still oversized`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 648`** (1 nodes): `Split bulky current-slice shared helpers and integration suites into directory-based test modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 649`** (1 nodes): `2026-04-06-backend-slice-size-refactor.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 650`** (1 nodes): `Split training_context service into focused directory modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 651`** (1 nodes): `Split workout_summary service while keeping WorkoutSummaryService as the entrypoint`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 652`** (1 nodes): `Split training_context packing into focused payload and rendering modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 653`** (1 nodes): `Split the Mongo workout-summary adapter by moving tests first and helpers only if needed`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 654`** (1 nodes): `Split bulky workout-summary shared helpers and remaining oversized current-slice tests`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 655`** (1 nodes): `Run broader backend verification after the refactor`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 656`** (1 nodes): `2026-04-06-review-followups.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 657`** (1 nodes): `Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 658`** (1 nodes): `Make projection replay heal partial same-operation inserts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 659`** (1 nodes): `Make workout-summary legacy fallback deterministic`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 660`** (1 nodes): `Preserve correction retry budget across reclaim`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 661`** (1 nodes): `Close low-level test and docs nits`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 662`** (1 nodes): `Run targeted tests, fmt, and clippy for the follow-up batch`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 663`** (1 nodes): `cyclist-bg.jpg`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 664`** (1 nodes): `Cyclist athlete`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 665`** (1 nodes): `Endurance cycling performance`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 666`** (1 nodes): `Hero background imagery`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 667`** (1 nodes): `Performance coaching brand tone`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 668`** (1 nodes): `Outdoor road training context`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **What connects `TrainingPlanWorkoutSummaryAdapter`, `LatestCompletedActivityAdapter`, `GoogleTokenResponse` to the rest of the system?**
-  _535 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Why does `FixedClock` connect `Community 0` to `Community 11`?**
+  _High betweenness centrality (0.001) - this node is a cross-community bridge._
+- **Why does `sample_completed_workout()` connect `Community 3` to `Community 1`?**
+  _High betweenness centrality (0.001) - this node is a cross-community bridge._
+- **Why does `RecordingCalendarRefresh` connect `Community 7` to `Community 1`?**
+  _High betweenness centrality (0.000) - this node is a cross-community bridge._
+- **What connects `EventQuery`, `EventPath`, `AthletePath` to the rest of the system?**
+  _602 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.03 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._

--- a/scripts/rebuild_graphify.sh
+++ b/scripts/rebuild_graphify.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+graphify_python_default="$HOME/.local/pipx/venvs/graphifyy/bin/python"
+graphify_python_override_file="$repo_root/graphify-out/.graphify_python"
+
+graphify_python="${GRAPHIFY_PYTHON:-}"
+
+if [ -z "$graphify_python" ] && [ -f "$graphify_python_override_file" ]; then
+  override_python="$(tr -d '\r' < "$graphify_python_override_file")"
+  if [ -n "$override_python" ] && [ -x "$override_python" ]; then
+    graphify_python="$override_python"
+  fi
+fi
+
+if [ -z "$graphify_python" ] && [ -x "$graphify_python_default" ]; then
+  graphify_python="$graphify_python_default"
+fi
+
+if [ -z "$graphify_python" ]; then
+  echo "graphify python not found. Install graphifyy with 'pipx install graphifyy' or set GRAPHIFY_PYTHON." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+"$graphify_python" -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"

--- a/src/adapters/intervals_icu/import_mapping.rs
+++ b/src/adapters/intervals_icu/import_mapping.rs
@@ -93,11 +93,13 @@ fn map_special_day_event_import(user_id: &str, event: &Event) -> ExternalImportC
             map_special_day_kind(&event.category),
             event.name.clone(),
             event.description.clone(),
-        ),
+        )
+        .expect("intervals special day import should always produce canonical YYYY-MM-DD date"),
     })
 }
 
 pub fn map_activity_to_import_command(user_id: &str, activity: &Activity) -> ExternalImportCommand {
+    let workout = map_activity_to_completed_workout(user_id, activity);
     ExternalImportCommand::UpsertCompletedWorkout(Box::new(ExternalCompletedWorkoutImport {
         provider: ExternalProvider::Intervals,
         external_id: activity.id.clone(),
@@ -110,120 +112,124 @@ pub fn map_activity_to_import_command(user_id: &str, activity: &Activity) -> Ext
         .into_iter()
         .flatten()
         .collect(),
-        workout: CompletedWorkout::new(
-            format!("intervals-activity:{}", activity.id),
-            user_id.to_string(),
-            activity.start_date_local.clone(),
-            None,
-            activity.name.clone(),
-            activity.description.clone(),
-            activity.activity_type.clone(),
-            activity
-                .elapsed_time_seconds
-                .or(activity.moving_time_seconds),
-            activity.distance_meters,
-            CompletedWorkoutMetrics {
-                training_stress_score: activity.metrics.training_stress_score,
-                normalized_power_watts: activity.metrics.normalized_power_watts,
-                intensity_factor: activity.metrics.intensity_factor,
-                efficiency_factor: activity.metrics.efficiency_factor,
-                variability_index: activity.metrics.variability_index,
-                average_power_watts: activity.metrics.average_power_watts,
-                ftp_watts: activity.metrics.ftp_watts,
-                total_work_joules: activity.metrics.total_work_joules,
-                calories: activity.metrics.calories,
-                trimp: activity.metrics.trimp,
-                power_load: activity.metrics.power_load,
-                heart_rate_load: activity.metrics.heart_rate_load,
-                pace_load: activity.metrics.pace_load,
-                strain_score: activity.metrics.strain_score,
-            },
-            CompletedWorkoutDetails {
-                intervals: activity
-                    .details
-                    .intervals
-                    .iter()
-                    .cloned()
-                    .map(
-                        |interval| crate::domain::completed_workouts::CompletedWorkoutInterval {
-                            id: interval.id,
-                            label: interval.label,
-                            interval_type: interval.interval_type,
-                            group_id: interval.group_id,
-                            start_index: interval.start_index,
-                            end_index: interval.end_index,
-                            start_time_seconds: interval.start_time_seconds,
-                            end_time_seconds: interval.end_time_seconds,
-                            moving_time_seconds: interval.moving_time_seconds,
-                            elapsed_time_seconds: interval.elapsed_time_seconds,
-                            distance_meters: interval.distance_meters,
-                            average_power_watts: interval.average_power_watts,
-                            normalized_power_watts: interval.normalized_power_watts,
-                            training_stress_score: interval.training_stress_score,
-                            average_heart_rate_bpm: interval.average_heart_rate_bpm,
-                            average_cadence_rpm: interval.average_cadence_rpm,
-                            average_speed_mps: interval.average_speed_mps,
-                            average_stride_meters: interval.average_stride_meters,
-                            zone: interval.zone,
-                        },
-                    )
-                    .collect(),
-                interval_groups: activity
-                    .details
-                    .interval_groups
-                    .iter()
-                    .cloned()
-                    .map(
-                        |group| crate::domain::completed_workouts::CompletedWorkoutIntervalGroup {
-                            id: group.id,
-                            count: group.count,
-                            start_index: group.start_index,
-                            moving_time_seconds: group.moving_time_seconds,
-                            elapsed_time_seconds: group.elapsed_time_seconds,
-                            distance_meters: group.distance_meters,
-                            average_power_watts: group.average_power_watts,
-                            normalized_power_watts: group.normalized_power_watts,
-                            training_stress_score: group.training_stress_score,
-                            average_heart_rate_bpm: group.average_heart_rate_bpm,
-                            average_cadence_rpm: group.average_cadence_rpm,
-                            average_speed_mps: group.average_speed_mps,
-                            average_stride_meters: group.average_stride_meters,
-                        },
-                    )
-                    .collect(),
-                streams: activity
-                    .details
-                    .streams
-                    .iter()
-                    .cloned()
-                    .map(|stream| CompletedWorkoutStream {
-                        stream_type: stream.stream_type,
-                        name: stream.name,
-                        primary_series: map_stream_series(stream.data),
-                        secondary_series: map_stream_series(stream.data2),
-                        value_type_is_array: stream.value_type_is_array,
-                        custom: stream.custom,
-                        all_null: stream.all_null,
-                    })
-                    .collect(),
-                interval_summary: activity.details.interval_summary.clone(),
-                skyline_chart: activity.details.skyline_chart.clone(),
-                power_zone_times: activity
-                    .details
-                    .power_zone_times
-                    .iter()
-                    .cloned()
-                    .map(|zone| CompletedWorkoutZoneTime {
-                        zone_id: zone.zone_id,
-                        seconds: zone.seconds,
-                    })
-                    .collect(),
-                heart_rate_zone_times: activity.details.heart_rate_zone_times.clone(),
-                pace_zone_times: activity.details.pace_zone_times.clone(),
-                gap_zone_times: activity.details.gap_zone_times.clone(),
-            },
-        ),
+        workout,
     }))
+}
+
+fn map_activity_to_completed_workout(user_id: &str, activity: &Activity) -> CompletedWorkout {
+    CompletedWorkout::new(
+        format!("intervals-activity:{}", activity.id),
+        user_id.to_string(),
+        activity.start_date_local.clone(),
+        None,
+        activity.name.clone(),
+        activity.description.clone(),
+        activity.activity_type.clone(),
+        activity
+            .elapsed_time_seconds
+            .or(activity.moving_time_seconds),
+        activity.distance_meters,
+        CompletedWorkoutMetrics {
+            training_stress_score: activity.metrics.training_stress_score,
+            normalized_power_watts: activity.metrics.normalized_power_watts,
+            intensity_factor: activity.metrics.intensity_factor,
+            efficiency_factor: activity.metrics.efficiency_factor,
+            variability_index: activity.metrics.variability_index,
+            average_power_watts: activity.metrics.average_power_watts,
+            ftp_watts: activity.metrics.ftp_watts,
+            total_work_joules: activity.metrics.total_work_joules,
+            calories: activity.metrics.calories,
+            trimp: activity.metrics.trimp,
+            power_load: activity.metrics.power_load,
+            heart_rate_load: activity.metrics.heart_rate_load,
+            pace_load: activity.metrics.pace_load,
+            strain_score: activity.metrics.strain_score,
+        },
+        CompletedWorkoutDetails {
+            intervals: activity
+                .details
+                .intervals
+                .iter()
+                .cloned()
+                .map(
+                    |interval| crate::domain::completed_workouts::CompletedWorkoutInterval {
+                        id: interval.id,
+                        label: interval.label,
+                        interval_type: interval.interval_type,
+                        group_id: interval.group_id,
+                        start_index: interval.start_index,
+                        end_index: interval.end_index,
+                        start_time_seconds: interval.start_time_seconds,
+                        end_time_seconds: interval.end_time_seconds,
+                        moving_time_seconds: interval.moving_time_seconds,
+                        elapsed_time_seconds: interval.elapsed_time_seconds,
+                        distance_meters: interval.distance_meters,
+                        average_power_watts: interval.average_power_watts,
+                        normalized_power_watts: interval.normalized_power_watts,
+                        training_stress_score: interval.training_stress_score,
+                        average_heart_rate_bpm: interval.average_heart_rate_bpm,
+                        average_cadence_rpm: interval.average_cadence_rpm,
+                        average_speed_mps: interval.average_speed_mps,
+                        average_stride_meters: interval.average_stride_meters,
+                        zone: interval.zone,
+                    },
+                )
+                .collect(),
+            interval_groups: activity
+                .details
+                .interval_groups
+                .iter()
+                .cloned()
+                .map(
+                    |group| crate::domain::completed_workouts::CompletedWorkoutIntervalGroup {
+                        id: group.id,
+                        count: group.count,
+                        start_index: group.start_index,
+                        moving_time_seconds: group.moving_time_seconds,
+                        elapsed_time_seconds: group.elapsed_time_seconds,
+                        distance_meters: group.distance_meters,
+                        average_power_watts: group.average_power_watts,
+                        normalized_power_watts: group.normalized_power_watts,
+                        training_stress_score: group.training_stress_score,
+                        average_heart_rate_bpm: group.average_heart_rate_bpm,
+                        average_cadence_rpm: group.average_cadence_rpm,
+                        average_speed_mps: group.average_speed_mps,
+                        average_stride_meters: group.average_stride_meters,
+                    },
+                )
+                .collect(),
+            streams: activity
+                .details
+                .streams
+                .iter()
+                .cloned()
+                .map(|stream| CompletedWorkoutStream {
+                    stream_type: stream.stream_type,
+                    name: stream.name,
+                    primary_series: map_stream_series(stream.data),
+                    secondary_series: map_stream_series(stream.data2),
+                    value_type_is_array: stream.value_type_is_array,
+                    custom: stream.custom,
+                    all_null: stream.all_null,
+                })
+                .collect(),
+            interval_summary: activity.details.interval_summary.clone(),
+            skyline_chart: activity.details.skyline_chart.clone(),
+            power_zone_times: activity
+                .details
+                .power_zone_times
+                .iter()
+                .cloned()
+                .map(|zone| CompletedWorkoutZoneTime {
+                    zone_id: zone.zone_id,
+                    seconds: zone.seconds,
+                })
+                .collect(),
+            heart_rate_zone_times: activity.details.heart_rate_zone_times.clone(),
+            pace_zone_times: activity.details.pace_zone_times.clone(),
+            gap_zone_times: activity.details.gap_zone_times.clone(),
+        },
+    )
 }
 
 fn map_stream_series(value: Option<serde_json::Value>) -> Option<CompletedWorkoutSeries> {
@@ -368,23 +374,57 @@ fn infer_race_distance_meters(description: Option<&str>) -> i32 {
 
 fn parse_first_distance_meters(text: &str) -> Option<i32> {
     let lower = text.to_ascii_lowercase();
-    for token in lower.split(|ch: char| ch.is_ascii_whitespace() || ch == ',' || ch == ';') {
-        if let Some(km) = token.strip_suffix("km") {
-            let kilometers = km.parse::<f64>().ok()?;
-            let meters = (kilometers * 1000.0).round();
-            if meters.is_finite() && meters <= i32::MAX as f64 {
-                return Some(meters as i32);
-            }
+    let tokens = lower
+        .split(|ch: char| ch.is_ascii_whitespace() || ch == ',' || ch == ';')
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    for (index, token) in tokens.iter().enumerate() {
+        if let Some(distance) = parse_distance_token(token) {
+            return Some(distance);
         }
-        if let Some(meters) = token.strip_suffix('m') {
-            let meters = meters.parse::<i32>().ok()?;
-            if meters > 0 {
-                return Some(meters);
-            }
+
+        let Some(next_token) = tokens.get(index + 1) else {
+            continue;
+        };
+        if let Some(distance) = parse_split_distance_tokens(token, next_token) {
+            return Some(distance);
         }
     }
 
     None
+}
+
+fn parse_distance_token(token: &str) -> Option<i32> {
+    if let Some(km) = token.strip_suffix("km") {
+        return kilometers_to_meters(km.parse::<f64>().ok()?);
+    }
+
+    if let Some(meters) = token.strip_suffix('m') {
+        let meters = meters.parse::<i32>().ok()?;
+        return (meters > 0).then_some(meters);
+    }
+
+    None
+}
+
+fn parse_split_distance_tokens(value: &str, unit: &str) -> Option<i32> {
+    match unit {
+        "km" => kilometers_to_meters(value.parse::<f64>().ok()?),
+        "m" => {
+            let meters = value.parse::<i32>().ok()?;
+            (meters > 0).then_some(meters)
+        }
+        _ => None,
+    }
+}
+
+fn kilometers_to_meters(kilometers: f64) -> Option<i32> {
+    let meters = (kilometers * 1000.0).round();
+    if meters.is_finite() && meters > 0.0 && meters <= i32::MAX as f64 {
+        Some(meters as i32)
+    } else {
+        None
+    }
 }
 
 fn map_special_day_kind(category: &EventCategory) -> SpecialDayKind {
@@ -412,16 +452,28 @@ fn hash_event(event: &Event) -> String {
 }
 
 fn hash_activity(activity: &Activity) -> String {
+    let workout = map_activity_to_completed_workout("hash-user", activity);
     let digest = Sha256::digest(format!(
-        "{}\n{}\n{}\n{}\n{}\n{:?}\n{:?}\n{:?}",
-        activity.id,
-        activity.start_date_local,
-        activity.activity_type.as_deref().unwrap_or_default(),
-        activity.name.as_deref().unwrap_or_default(),
-        activity.description.as_deref().unwrap_or_default(),
-        activity.metrics.training_stress_score,
-        activity.metrics.normalized_power_watts,
-        activity.metrics.intensity_factor,
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        workout.completed_workout_id,
+        workout.start_date_local,
+        workout.planned_workout_id.as_deref().unwrap_or_default(),
+        workout.name.as_deref().unwrap_or_default(),
+        workout.description.as_deref().unwrap_or_default(),
+        workout.activity_type.as_deref().unwrap_or_default(),
+        workout
+            .duration_seconds
+            .map(|value| value.to_string())
+            .unwrap_or_default(),
+        workout
+            .distance_meters
+            .map(|value| value.to_string())
+            .unwrap_or_default(),
+        serde_json::to_string(&workout.metrics)
+            .expect("completed workout metrics should serialize into a stable payload hash"),
+        serde_json::to_string(&workout.details)
+            .expect("completed workout details should serialize into a stable payload hash"),
+        activity.external_id.as_deref().unwrap_or_default(),
     ));
     format!("{digest:x}")
 }
@@ -518,6 +570,60 @@ mod tests {
     }
 
     #[test]
+    fn maps_race_event_distance_when_unit_is_split_by_space() {
+        let command = map_event_to_import_command(
+            "user-1",
+            &crate::domain::intervals::Event {
+                id: 56,
+                start_date_local: "2026-09-13T00:00:00".to_string(),
+                event_type: Some("Road".to_string()),
+                name: Some("Big Day".to_string()),
+                category: crate::domain::intervals::EventCategory::Race,
+                description: Some("Target event over 120 km with a fast finish".to_string()),
+                indoor: false,
+                color: None,
+                workout_doc: None,
+            },
+            &FixedIdGenerator,
+        )
+        .unwrap()
+        .expect("expected import command");
+
+        let ExternalImportCommand::UpsertRace(command) = command else {
+            panic!("expected race import");
+        };
+
+        assert_eq!(command.race.distance_meters, 120_000);
+    }
+
+    #[test]
+    fn maps_race_event_distance_when_first_distance_token_is_invalid() {
+        let command = map_event_to_import_command(
+            "user-1",
+            &crate::domain::intervals::Event {
+                id: 57,
+                start_date_local: "2026-09-14T00:00:00".to_string(),
+                event_type: Some("Road".to_string()),
+                name: Some("Circuit".to_string()),
+                category: crate::domain::intervals::EventCategory::Race,
+                description: Some("xkm warmup then 500 m sprint finish".to_string()),
+                indoor: false,
+                color: None,
+                workout_doc: None,
+            },
+            &FixedIdGenerator,
+        )
+        .unwrap()
+        .expect("expected import command");
+
+        let ExternalImportCommand::UpsertRace(command) = command else {
+            panic!("expected race import");
+        };
+
+        assert_eq!(command.race.distance_meters, 500);
+    }
+
+    #[test]
     fn maps_special_event_into_special_day_import() {
         let command = map_event_to_import_command(
             "user-1",
@@ -557,76 +663,7 @@ mod tests {
 
     #[test]
     fn maps_activity_into_completed_workout_import() {
-        let command = map_activity_to_import_command(
-            "user-1",
-            &crate::domain::intervals::Activity {
-                id: "activity-1".to_string(),
-                athlete_id: None,
-                start_date_local: "2026-05-11T08:00:00".to_string(),
-                start_date: None,
-                name: Some("Threshold Ride".to_string()),
-                description: Some("Strong day".to_string()),
-                activity_type: Some("Ride".to_string()),
-                source: Some("intervals".to_string()),
-                external_id: Some("external-1".to_string()),
-                device_name: Some("Trainer".to_string()),
-                distance_meters: Some(35_000.0),
-                moving_time_seconds: Some(3600),
-                elapsed_time_seconds: Some(3700),
-                total_elevation_gain_meters: Some(400.0),
-                total_elevation_loss_meters: Some(400.0),
-                average_speed_mps: Some(9.7),
-                max_speed_mps: Some(15.0),
-                average_heart_rate_bpm: Some(150),
-                max_heart_rate_bpm: Some(175),
-                average_cadence_rpm: Some(88.0),
-                trainer: true,
-                commute: false,
-                race: false,
-                has_heart_rate: true,
-                stream_types: vec!["watts".to_string()],
-                tags: vec!["quality".to_string()],
-                metrics: ActivityMetrics {
-                    training_stress_score: Some(78),
-                    normalized_power_watts: Some(245),
-                    intensity_factor: Some(0.83),
-                    efficiency_factor: None,
-                    variability_index: Some(1.04),
-                    average_power_watts: Some(221),
-                    ftp_watts: Some(295),
-                    total_work_joules: Some(750),
-                    calories: Some(900),
-                    trimp: None,
-                    power_load: None,
-                    heart_rate_load: None,
-                    pace_load: None,
-                    strain_score: None,
-                },
-                details: ActivityDetails {
-                    intervals: Vec::new(),
-                    interval_groups: Vec::new(),
-                    streams: vec![ActivityStream {
-                        stream_type: "watts".to_string(),
-                        name: Some("Power".to_string()),
-                        data: Some(serde_json::json!([180, 240, 310])),
-                        data2: None,
-                        value_type_is_array: false,
-                        custom: false,
-                        all_null: false,
-                    }],
-                    interval_summary: vec!["tempo".to_string()],
-                    skyline_chart: Vec::new(),
-                    power_zone_times: vec![ActivityZoneTime {
-                        zone_id: "z3".to_string(),
-                        seconds: 1200,
-                    }],
-                    heart_rate_zone_times: vec![600],
-                    pace_zone_times: Vec::new(),
-                    gap_zone_times: Vec::new(),
-                },
-                details_unavailable_reason: None,
-            },
-        );
+        let command = map_activity_to_import_command("user-1", &sample_activity());
 
         let ExternalImportCommand::UpsertCompletedWorkout(command) = command else {
             panic!("expected completed workout import");
@@ -645,5 +682,98 @@ mod tests {
         assert_eq!(command.workout.distance_meters, Some(35_000.0));
         assert_eq!(command.workout.metrics.training_stress_score, Some(78));
         assert_eq!(command.workout.details.streams.len(), 1);
+    }
+
+    #[test]
+    fn activity_hash_changes_when_persisted_details_change() {
+        let base = sample_activity();
+        let mut changed = sample_activity();
+        changed.details.interval_summary = vec!["tempo".to_string(), "extra note".to_string()];
+
+        let ExternalImportCommand::UpsertCompletedWorkout(base_command) =
+            map_activity_to_import_command("user-1", &base)
+        else {
+            panic!("expected completed workout import");
+        };
+        let ExternalImportCommand::UpsertCompletedWorkout(changed_command) =
+            map_activity_to_import_command("user-1", &changed)
+        else {
+            panic!("expected completed workout import");
+        };
+
+        assert_ne!(
+            base_command.normalized_payload_hash,
+            changed_command.normalized_payload_hash
+        );
+    }
+
+    fn sample_activity() -> crate::domain::intervals::Activity {
+        crate::domain::intervals::Activity {
+            id: "activity-1".to_string(),
+            athlete_id: None,
+            start_date_local: "2026-05-11T08:00:00".to_string(),
+            start_date: None,
+            name: Some("Threshold Ride".to_string()),
+            description: Some("Strong day".to_string()),
+            activity_type: Some("Ride".to_string()),
+            source: Some("intervals".to_string()),
+            external_id: Some("external-1".to_string()),
+            device_name: Some("Trainer".to_string()),
+            distance_meters: Some(35_000.0),
+            moving_time_seconds: Some(3600),
+            elapsed_time_seconds: Some(3700),
+            total_elevation_gain_meters: Some(400.0),
+            total_elevation_loss_meters: Some(400.0),
+            average_speed_mps: Some(9.7),
+            max_speed_mps: Some(15.0),
+            average_heart_rate_bpm: Some(150),
+            max_heart_rate_bpm: Some(175),
+            average_cadence_rpm: Some(88.0),
+            trainer: true,
+            commute: false,
+            race: false,
+            has_heart_rate: true,
+            stream_types: vec!["watts".to_string()],
+            tags: vec!["quality".to_string()],
+            metrics: ActivityMetrics {
+                training_stress_score: Some(78),
+                normalized_power_watts: Some(245),
+                intensity_factor: Some(0.83),
+                efficiency_factor: None,
+                variability_index: Some(1.04),
+                average_power_watts: Some(221),
+                ftp_watts: Some(295),
+                total_work_joules: Some(750),
+                calories: Some(900),
+                trimp: None,
+                power_load: None,
+                heart_rate_load: None,
+                pace_load: None,
+                strain_score: None,
+            },
+            details: ActivityDetails {
+                intervals: Vec::new(),
+                interval_groups: Vec::new(),
+                streams: vec![ActivityStream {
+                    stream_type: "watts".to_string(),
+                    name: Some("Power".to_string()),
+                    data: Some(serde_json::json!([180, 240, 310])),
+                    data2: None,
+                    value_type_is_array: false,
+                    custom: false,
+                    all_null: false,
+                }],
+                interval_summary: vec!["tempo".to_string()],
+                skyline_chart: Vec::new(),
+                power_zone_times: vec![ActivityZoneTime {
+                    zone_id: "z3".to_string(),
+                    seconds: 1200,
+                }],
+                heart_rate_zone_times: vec![600],
+                pace_zone_times: Vec::new(),
+                gap_zone_times: Vec::new(),
+            },
+            details_unavailable_reason: None,
+        }
     }
 }

--- a/src/adapters/mongo/calendar_entry_views.rs
+++ b/src/adapters/mongo/calendar_entry_views.rs
@@ -235,6 +235,12 @@ impl CalendarEntryViewRepository for MongoCalendarEntryViewRepository {
                         entry.user_id
                     )));
                 }
+                if entry.date < oldest || entry.date > newest {
+                    return Err(CalendarEntryViewError::Repository(format!(
+                        "calendar entry date out of range for replace_range_for_user: expected {oldest}..={newest}, got {}",
+                        entry.date
+                    )));
+                }
                 Ok(map_entry_to_document(entry, &rewrite_gen))
             })
             .collect::<Result<Vec<_>, _>>();

--- a/src/adapters/mongo/external_sync_states.rs
+++ b/src/adapters/mongo/external_sync_states.rs
@@ -105,7 +105,7 @@ impl ExternalSyncStateRepository for MongoExternalSyncStateRepository {
                 .await
                 .map_err(storage_error)?;
 
-            Ok(document.map(map_document_to_sync_state))
+            document.map(map_document_to_sync_state).transpose()
         })
     }
 
@@ -146,10 +146,10 @@ impl ExternalSyncStateRepository for MongoExternalSyncStateRepository {
                 .await
                 .map_err(storage_error)?;
 
-            Ok(documents
+            documents
                 .into_iter()
                 .map(map_document_to_sync_state)
-                .collect())
+                .collect::<Result<Vec<_>, _>>()
         })
     }
 
@@ -202,23 +202,25 @@ fn map_sync_state_to_document(state: &ExternalSyncState) -> ExternalSyncStateDoc
     }
 }
 
-fn map_document_to_sync_state(document: ExternalSyncStateDocument) -> ExternalSyncState {
-    ExternalSyncState {
+fn map_document_to_sync_state(
+    document: ExternalSyncStateDocument,
+) -> Result<ExternalSyncState, ExternalSyncRepositoryError> {
+    Ok(ExternalSyncState {
         user_id: document.user_id,
-        provider: map_provider(&document.provider),
+        provider: map_provider(&document.provider)?,
         canonical_entity: CanonicalEntityRef {
-            entity_kind: map_canonical_entity_kind(&document.canonical_entity_kind),
+            entity_kind: map_canonical_entity_kind(&document.canonical_entity_kind)?,
             entity_id: document.canonical_entity_id,
         },
         external_id: document.external_id,
-        sync_status: map_sync_status(&document.sync_status),
+        sync_status: map_sync_status(&document.sync_status)?,
         last_synced_payload_hash: document.last_synced_payload_hash,
         last_seen_remote_payload_hash: document.last_seen_remote_payload_hash,
         last_error: document.last_error,
         last_synced_at_epoch_seconds: document.last_synced_at_epoch_seconds,
         last_seen_remote_at_epoch_seconds: document.last_seen_remote_at_epoch_seconds,
-        conflict_status: map_conflict_status(&document.conflict_status),
-    }
+        conflict_status: map_conflict_status(&document.conflict_status)?,
+    })
 }
 
 fn provider_as_str(provider: &ExternalProvider) -> &'static str {
@@ -256,38 +258,52 @@ fn sync_status_as_str(status: &ExternalSyncStatus) -> &'static str {
     }
 }
 
-fn map_provider(value: &str) -> ExternalProvider {
+fn map_provider(value: &str) -> Result<ExternalProvider, ExternalSyncRepositoryError> {
     match value {
-        "intervals" => ExternalProvider::Intervals,
-        "wahoo" => ExternalProvider::Wahoo,
-        "strava" => ExternalProvider::Strava,
-        _ => ExternalProvider::Other,
+        "intervals" => Ok(ExternalProvider::Intervals),
+        "wahoo" => Ok(ExternalProvider::Wahoo),
+        "strava" => Ok(ExternalProvider::Strava),
+        "other" => Ok(ExternalProvider::Other),
+        other => Err(ExternalSyncRepositoryError::CorruptData(format!(
+            "unknown external sync provider: {other}"
+        ))),
     }
 }
 
-fn map_canonical_entity_kind(value: &str) -> CanonicalEntityKind {
+fn map_canonical_entity_kind(
+    value: &str,
+) -> Result<CanonicalEntityKind, ExternalSyncRepositoryError> {
     match value {
-        "planned_workout" => CanonicalEntityKind::PlannedWorkout,
-        "completed_workout" => CanonicalEntityKind::CompletedWorkout,
-        "race" => CanonicalEntityKind::Race,
-        _ => CanonicalEntityKind::SpecialDay,
+        "planned_workout" => Ok(CanonicalEntityKind::PlannedWorkout),
+        "completed_workout" => Ok(CanonicalEntityKind::CompletedWorkout),
+        "race" => Ok(CanonicalEntityKind::Race),
+        "special_day" => Ok(CanonicalEntityKind::SpecialDay),
+        other => Err(ExternalSyncRepositoryError::CorruptData(format!(
+            "unknown canonical entity kind: {other}"
+        ))),
     }
 }
 
-fn map_conflict_status(value: &str) -> ConflictStatus {
+fn map_conflict_status(value: &str) -> Result<ConflictStatus, ExternalSyncRepositoryError> {
     match value {
-        "in_sync" => ConflictStatus::InSync,
-        "conflict_detected" => ConflictStatus::ConflictDetected,
-        _ => ConflictStatus::Unknown,
+        "unknown" => Ok(ConflictStatus::Unknown),
+        "in_sync" => Ok(ConflictStatus::InSync),
+        "conflict_detected" => Ok(ConflictStatus::ConflictDetected),
+        other => Err(ExternalSyncRepositoryError::CorruptData(format!(
+            "unknown conflict status: {other}"
+        ))),
     }
 }
 
-fn map_sync_status(value: &str) -> ExternalSyncStatus {
+fn map_sync_status(value: &str) -> Result<ExternalSyncStatus, ExternalSyncRepositoryError> {
     match value {
-        "synced" => ExternalSyncStatus::Synced,
-        "failed" => ExternalSyncStatus::Failed,
-        "pending_delete" => ExternalSyncStatus::PendingDelete,
-        _ => ExternalSyncStatus::Pending,
+        "pending" => Ok(ExternalSyncStatus::Pending),
+        "synced" => Ok(ExternalSyncStatus::Synced),
+        "failed" => Ok(ExternalSyncStatus::Failed),
+        "pending_delete" => Ok(ExternalSyncStatus::PendingDelete),
+        other => Err(ExternalSyncRepositoryError::CorruptData(format!(
+            "unknown external sync status: {other}"
+        ))),
     }
 }
 
@@ -295,10 +311,12 @@ fn map_sync_status(value: &str) -> ExternalSyncStatus {
 mod tests {
     use crate::domain::external_sync::{
         CanonicalEntityKind, CanonicalEntityRef, ConflictStatus, ExternalProvider,
-        ExternalSyncState, ExternalSyncStatus,
+        ExternalSyncRepositoryError, ExternalSyncState, ExternalSyncStatus,
     };
 
-    use super::{map_document_to_sync_state, map_sync_state_to_document};
+    use super::{
+        map_document_to_sync_state, map_sync_state_to_document, ExternalSyncStateDocument,
+    };
 
     #[test]
     fn sync_state_document_round_trip_preserves_fields() {
@@ -310,11 +328,53 @@ mod tests {
         .mark_synced("77".to_string(), "hash-1".to_string(), 1_700_000_000)
         .observe_remote("hash-2".to_string(), 1_700_000_100);
 
-        let mapped = map_document_to_sync_state(map_sync_state_to_document(&state));
+        let mapped = map_document_to_sync_state(map_sync_state_to_document(&state)).unwrap();
 
         assert_eq!(mapped.conflict_status, ConflictStatus::ConflictDetected);
         assert_eq!(mapped.external_id.as_deref(), Some("77"));
         assert_eq!(mapped.sync_status, ExternalSyncStatus::Synced);
         assert_eq!(mapped, state);
+    }
+
+    #[test]
+    fn sync_state_document_rejects_unknown_provider() {
+        let error = map_document_to_sync_state(ExternalSyncStateDocument {
+            user_id: "user-1".to_string(),
+            provider: "mystery".to_string(),
+            canonical_entity_kind: "race".to_string(),
+            canonical_entity_id: "race-1".to_string(),
+            external_id: Some("77".to_string()),
+            sync_status: "synced".to_string(),
+            last_synced_payload_hash: Some("hash-1".to_string()),
+            last_seen_remote_payload_hash: Some("hash-1".to_string()),
+            last_error: None,
+            last_synced_at_epoch_seconds: Some(1_700_000_000),
+            last_seen_remote_at_epoch_seconds: Some(1_700_000_000),
+            conflict_status: "in_sync".to_string(),
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, ExternalSyncRepositoryError::CorruptData(_)));
+    }
+
+    #[test]
+    fn sync_state_document_rejects_unknown_sync_status() {
+        let error = map_document_to_sync_state(ExternalSyncStateDocument {
+            user_id: "user-1".to_string(),
+            provider: "intervals".to_string(),
+            canonical_entity_kind: "race".to_string(),
+            canonical_entity_id: "race-1".to_string(),
+            external_id: Some("77".to_string()),
+            sync_status: "mystery".to_string(),
+            last_synced_payload_hash: Some("hash-1".to_string()),
+            last_seen_remote_payload_hash: Some("hash-1".to_string()),
+            last_error: None,
+            last_synced_at_epoch_seconds: Some(1_700_000_000),
+            last_seen_remote_at_epoch_seconds: Some(1_700_000_000),
+            conflict_status: "in_sync".to_string(),
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, ExternalSyncRepositoryError::CorruptData(_)));
     }
 }

--- a/src/adapters/mongo/settings.rs
+++ b/src/adapters/mongo/settings.rs
@@ -1091,24 +1091,24 @@ mod tests {
                     intervals_updated_at_epoch_seconds: Some(20),
                 },
                 IntervalsPollBootstrapUser {
-                    user_id: "explicitly-disconnected-user".to_string(),
-                    desired_active: false,
-                    intervals_updated_at_epoch_seconds: Some(30),
-                },
-                IntervalsPollBootstrapUser {
                     user_id: "disconnected-user".to_string(),
                     desired_active: false,
                     intervals_updated_at_epoch_seconds: None,
                 },
                 IntervalsPollBootstrapUser {
-                    user_id: "poll-only-user".to_string(),
+                    user_id: "explicitly-disconnected-user".to_string(),
                     desired_active: false,
-                    intervals_updated_at_epoch_seconds: None,
+                    intervals_updated_at_epoch_seconds: Some(30),
                 },
                 IntervalsPollBootstrapUser {
                     user_id: "legacy-missing-connected".to_string(),
                     desired_active: true,
                     intervals_updated_at_epoch_seconds: Some(40),
+                },
+                IntervalsPollBootstrapUser {
+                    user_id: "poll-only-user".to_string(),
+                    desired_active: false,
+                    intervals_updated_at_epoch_seconds: None,
                 },
             ]
         );

--- a/src/adapters/mongo/special_days.rs
+++ b/src/adapters/mongo/special_days.rs
@@ -149,14 +149,14 @@ fn map_special_day_to_document(special_day: &SpecialDay) -> SpecialDayDocument {
 fn map_document_to_special_day(
     document: SpecialDayDocument,
 ) -> Result<SpecialDay, SpecialDayError> {
-    Ok(SpecialDay::new(
+    SpecialDay::new(
         document.special_day_id,
         document.user_id,
         document.date,
         map_kind_from_str(&document.kind)?,
         document.title,
         document.description,
-    ))
+    )
 }
 
 fn map_kind_to_str(kind: &SpecialDayKind) -> &'static str {

--- a/src/config/provider_polling/mod.rs
+++ b/src/config/provider_polling/mod.rs
@@ -446,13 +446,11 @@ fn advance_calendar_cursor(
     events: &[crate::domain::intervals::Event],
     range: &DateRange,
 ) -> Option<String> {
-    let newest_seen = events
-        .iter()
-        .filter_map(|event| event.start_date_local.get(..10).map(ToString::to_string))
-        .max();
-    newest_seen
-        .or_else(|| state.cursor.clone())
-        .or_else(|| Some(range.newest.clone()))
+    if events.is_empty() {
+        return state.cursor.clone().or_else(|| Some(range.newest.clone()));
+    }
+
+    Some(range.newest.clone())
 }
 
 fn advance_completed_workout_cursor(

--- a/src/config/provider_polling/tests/calendar.rs
+++ b/src/config/provider_polling/tests/calendar.rs
@@ -55,7 +55,7 @@ async fn poll_due_once_imports_calendar_events_and_marks_success() {
     assert_eq!(stored.last_successful_at_epoch_seconds, Some(1_700_000_000));
     assert_eq!(stored.last_error, None);
     assert_eq!(stored.backoff_until_epoch_seconds, None);
-    assert_eq!(stored.cursor.as_deref(), Some("2026-05-10"));
+    assert_eq!(stored.cursor.as_deref(), Some("2023-11-28"));
     assert_eq!(stored.next_due_at_epoch_seconds, 1_700_000_300);
 }
 

--- a/src/domain/calendar_view/projection.rs
+++ b/src/domain/calendar_view/projection.rs
@@ -1,6 +1,6 @@
 use crate::domain::{
     completed_workouts::CompletedWorkout,
-    external_sync::ExternalSyncState,
+    external_sync::{ExternalProvider, ExternalSyncState},
     planned_workouts::PlannedWorkout,
     races::Race,
     special_days::{SpecialDay, SpecialDayKind},
@@ -214,11 +214,20 @@ fn special_day_title(kind: &SpecialDayKind) -> String {
 
 fn map_sync_state(sync_state: Option<&ExternalSyncState>) -> Option<CalendarEntrySync> {
     sync_state.map(|state| CalendarEntrySync {
-        linked_intervals_event_id: state
-            .external_id
-            .as_deref()
-            .and_then(|value| value.parse::<i64>().ok()),
+        linked_intervals_event_id: linked_intervals_event_id(state),
         sync_status: Some(state.sync_status.as_str().to_string()),
+    })
+}
+
+fn linked_intervals_event_id(state: &ExternalSyncState) -> Option<i64> {
+    if state.provider != ExternalProvider::Intervals {
+        return None;
+    }
+
+    state.external_id.as_deref().map(|value| {
+        value.parse::<i64>().unwrap_or_else(|error| {
+            panic!("intervals sync state external_id must parse as i64, got '{value}': {error}")
+        })
     })
 }
 

--- a/src/domain/calendar_view/refresh.rs
+++ b/src/domain/calendar_view/refresh.rs
@@ -285,7 +285,8 @@ fn map_special_day_error(
     error: crate::domain::special_days::SpecialDayError,
 ) -> CalendarEntryViewError {
     match error {
-        crate::domain::special_days::SpecialDayError::Repository(message) => {
+        crate::domain::special_days::SpecialDayError::Validation(message)
+        | crate::domain::special_days::SpecialDayError::Repository(message) => {
             CalendarEntryViewError::Repository(message)
         }
     }

--- a/src/domain/calendar_view/service.rs
+++ b/src/domain/calendar_view/service.rs
@@ -288,10 +288,19 @@ fn map_external_sync_state(
     sync_state: Option<&ExternalSyncState>,
 ) -> Option<super::CalendarEntrySync> {
     sync_state.map(|state| super::CalendarEntrySync {
-        linked_intervals_event_id: state
-            .external_id
-            .as_deref()
-            .and_then(|value| value.parse::<i64>().ok()),
+        linked_intervals_event_id: linked_intervals_event_id(state),
         sync_status: Some(state.sync_status.as_str().to_string()),
+    })
+}
+
+fn linked_intervals_event_id(state: &ExternalSyncState) -> Option<i64> {
+    if state.provider != ExternalProvider::Intervals {
+        return None;
+    }
+
+    state.external_id.as_deref().map(|value| {
+        value.parse::<i64>().unwrap_or_else(|error| {
+            panic!("intervals sync state external_id must parse as i64, got '{value}': {error}")
+        })
     })
 }

--- a/src/domain/calendar_view/tests.rs
+++ b/src/domain/calendar_view/tests.rs
@@ -1306,6 +1306,23 @@ fn race_projection_keeps_label_shape_and_sync_metadata() {
 }
 
 #[test]
+#[should_panic(expected = "intervals sync state external_id must parse as i64")]
+fn race_projection_panics_when_intervals_external_id_is_not_numeric() {
+    let sync_state = ExternalSyncState::new(
+        "user-1".to_string(),
+        ExternalProvider::Intervals,
+        CanonicalEntityRef::new(CanonicalEntityKind::Race, "race-1".to_string()),
+    )
+    .mark_synced(
+        "not-a-number".to_string(),
+        "hash-1".to_string(),
+        1_700_000_000,
+    );
+
+    let _ = project_race_entry(&sample_race(), Some(&sync_state));
+}
+
+#[test]
 fn special_day_projection_keeps_meaningful_title() {
     let entry = project_special_day_entry(&sample_special_day());
 
@@ -1446,6 +1463,7 @@ fn sample_special_day() -> SpecialDay {
         Some("Flu".to_string()),
         Some("Stay off the bike".to_string()),
     )
+    .unwrap()
 }
 
 fn sample_other_special_day() -> SpecialDay {
@@ -1457,6 +1475,7 @@ fn sample_other_special_day() -> SpecialDay {
         Some("Travel".to_string()),
         Some("Airport day".to_string()),
     )
+    .unwrap()
 }
 
 fn sample_special_day_for_user(user_id: &str) -> SpecialDay {
@@ -1468,17 +1487,21 @@ fn sample_special_day_for_user(user_id: &str) -> SpecialDay {
         Some("Other".to_string()),
         Some("Other user note".to_string()),
     )
+    .unwrap()
 }
 
 fn sample_orphan_entry() -> super::CalendarEntryView {
-    project_special_day_entry(&SpecialDay::new(
-        "orphan-1".to_string(),
-        "user-1".to_string(),
-        "2026-05-14".to_string(),
-        SpecialDayKind::Other,
-        Some("Maintenance".to_string()),
-        Some("Bike in workshop".to_string()),
-    ))
+    project_special_day_entry(
+        &SpecialDay::new(
+            "orphan-1".to_string(),
+            "user-1".to_string(),
+            "2026-05-14".to_string(),
+            SpecialDayKind::Other,
+            Some("Maintenance".to_string()),
+            Some("Bike in workshop".to_string()),
+        )
+        .unwrap(),
+    )
 }
 
 fn sample_type_mismatch_entry() -> super::CalendarEntryView {

--- a/src/domain/external_sync/import/completed_workout_dedup.rs
+++ b/src/domain/external_sync/import/completed_workout_dedup.rs
@@ -48,7 +48,15 @@ fn completed_workout_duration_seconds(workout: &CompletedWorkout) -> Option<i32>
         .filter_map(completed_workout_stream_sample_count)
         .max();
 
-    group_duration.or(interval_duration).or(stream_duration)
+    [
+        workout.duration_seconds,
+        group_duration,
+        interval_duration,
+        stream_duration,
+    ]
+    .into_iter()
+    .flatten()
+    .max()
 }
 
 fn completed_workout_distance_bucket(workout: &CompletedWorkout) -> Option<i32> {
@@ -65,8 +73,21 @@ fn completed_workout_distance_bucket(workout: &CompletedWorkout) -> Option<i32> 
         .filter_map(|interval| interval.distance_meters)
         .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
     let stream_distance = completed_workout_stream_distance_bucket(workout);
+    let workout_distance = workout
+        .distance_meters
+        .filter(|value| value.is_finite() && *value > 0.0);
 
-    round_distance_bucket(group_distance.or(interval_distance).or(stream_distance))
+    let max_distance = [
+        workout_distance,
+        group_distance,
+        interval_distance,
+        stream_distance,
+    ]
+    .into_iter()
+    .flatten()
+    .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+
+    round_distance_bucket(max_distance)
 }
 
 fn completed_workout_stream_bucket(workout: &CompletedWorkout) -> String {

--- a/src/domain/external_sync/import/import_outcome.rs
+++ b/src/domain/external_sync/import/import_outcome.rs
@@ -13,7 +13,7 @@ pub(super) async fn finalize_import<Refresh, Persist>(
     refresh: &Refresh,
     persist_sync_metadata: Persist,
     user_id: &str,
-    import_date: &str,
+    refresh_dates: &[String],
     provider: ExternalProvider,
     external_id: String,
     canonical_entity: CanonicalEntityRef,
@@ -23,13 +23,30 @@ where
     Persist: std::future::Future<Output = Result<(), ExternalImportError>>,
 {
     persist_sync_metadata.await?;
-    refresh_imported_range(refresh, user_id, import_date, import_date).await;
+    let (oldest, newest) = refresh_range_bounds(refresh_dates);
+    refresh_imported_range(refresh, user_id, &oldest, &newest).await;
 
     Ok(ExternalImportOutcome {
         canonical_entity,
         provider,
         external_id,
     })
+}
+
+fn refresh_range_bounds(refresh_dates: &[String]) -> (String, String) {
+    let mut dates = refresh_dates
+        .iter()
+        .filter(|date| !date.is_empty())
+        .cloned()
+        .collect::<Vec<_>>();
+    dates.sort();
+    dates.dedup();
+
+    match dates.as_slice() {
+        [] => ("1970-01-01".to_string(), "1970-01-01".to_string()),
+        [only] => (only.clone(), only.clone()),
+        [first, .., last] => (first.clone(), last.clone()),
+    }
 }
 
 pub(super) async fn refresh_imported_range<Refresh>(

--- a/src/domain/external_sync/import/mod.rs
+++ b/src/domain/external_sync/import/mod.rs
@@ -35,6 +35,11 @@ struct ResolvedPlannedWorkoutLink {
     match_source: PlannedCompletedWorkoutLinkMatchSource,
 }
 
+struct ResolvedCompletedWorkoutTarget {
+    workout: CompletedWorkout,
+    refresh_dates: Vec<String>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExternalImportCommand {
     UpsertPlannedWorkout(ExternalPlannedWorkoutImport),
@@ -336,7 +341,7 @@ where
             &self.refresh,
             self.persist_sync_metadata(&workout.user_id, metadata),
             &workout.user_id,
-            &workout.date,
+            &[workout.date.clone()],
             command.provider,
             command.external_id,
             canonical_entity,
@@ -356,9 +361,11 @@ where
                 &command.workout,
             )
             .await?;
-        let mut workout = self
+        let resolved_target = self
             .resolve_completed_workout_target(command.workout, dedup_key.as_deref())
             .await?;
+        let mut workout = resolved_target.workout;
+        let refresh_dates = resolved_target.refresh_dates;
         let existing_link = self
             .planned_completed_links
             .find_by_completed_workout_id(&workout.user_id, &workout.completed_workout_id)
@@ -405,7 +412,7 @@ where
             &self.refresh,
             self.persist_sync_metadata(&workout.user_id, metadata),
             &workout.user_id,
-            date_key(&workout.start_date_local),
+            &refresh_dates,
             command.provider,
             command.external_id,
             canonical_entity,
@@ -437,7 +444,7 @@ where
             &self.refresh,
             self.persist_sync_metadata(&race.user_id, metadata),
             &race.user_id,
-            &race.date,
+            &[race.date.clone()],
             command.provider,
             command.external_id,
             canonical_entity,
@@ -471,7 +478,7 @@ where
             &self.refresh,
             self.persist_sync_metadata(&special_day.user_id, metadata),
             &special_day.user_id,
-            &special_day.date,
+            &[special_day.date.clone()],
             command.provider,
             command.external_id,
             canonical_entity,
@@ -531,7 +538,7 @@ where
         &self,
         incoming: CompletedWorkout,
         dedup_key: Option<&str>,
-    ) -> Result<CompletedWorkout, ExternalImportError> {
+    ) -> Result<ResolvedCompletedWorkoutTarget, ExternalImportError> {
         let stored_workouts = self
             .completed_workouts
             .list_by_user_id(&incoming.user_id)
@@ -543,11 +550,17 @@ where
             .find(|existing| existing.completed_workout_id == incoming.completed_workout_id)
             .cloned();
         if let Some(existing) = direct_match {
-            return Ok(merge_completed_workout(existing, incoming));
+            return Ok(ResolvedCompletedWorkoutTarget {
+                refresh_dates: completed_workout_refresh_dates(Some(&existing), &incoming),
+                workout: merge_completed_workout(existing, incoming),
+            });
         }
 
         let Some(dedup_key) = dedup_key else {
-            return Ok(incoming);
+            return Ok(ResolvedCompletedWorkoutTarget {
+                refresh_dates: completed_workout_refresh_dates(None, &incoming),
+                workout: incoming,
+            });
         };
 
         let observations = self
@@ -571,16 +584,24 @@ where
         matches.dedup();
 
         match matches.as_slice() {
-            [] => Ok(incoming),
+            [] => Ok(ResolvedCompletedWorkoutTarget {
+                refresh_dates: completed_workout_refresh_dates(None, &incoming),
+                workout: incoming,
+            }),
             [canonical_id] => {
                 let Some(existing) = stored_workouts
                     .into_iter()
                     .find(|workout| workout.completed_workout_id == *canonical_id)
                 else {
-                    return Ok(incoming);
+                    return Err(ExternalImportError::CompletedWorkout(format!(
+                        "stale completed workout dedup match for key '{dedup_key}' points to missing canonical workout '{canonical_id}'"
+                    )));
                 };
 
-                Ok(merge_completed_workout(existing, incoming))
+                Ok(ResolvedCompletedWorkoutTarget {
+                    refresh_dates: completed_workout_refresh_dates(Some(&existing), &incoming),
+                    workout: merge_completed_workout(existing, incoming),
+                })
             }
             _ => Err(ExternalImportError::CompletedWorkout(format!(
                 "ambiguous completed workout dedup match for key '{dedup_key}'"
@@ -627,6 +648,19 @@ where
             _ => Ok(None),
         }
     }
+}
+
+fn completed_workout_refresh_dates(
+    existing: Option<&CompletedWorkout>,
+    incoming: &CompletedWorkout,
+) -> Vec<String> {
+    let mut dates = vec![date_key(&incoming.start_date_local).to_string()];
+    if let Some(existing) = existing {
+        dates.push(date_key(&existing.start_date_local).to_string());
+    }
+    dates.sort();
+    dates.dedup();
+    dates
 }
 
 fn existing_link_candidate(
@@ -767,7 +801,9 @@ fn map_race_error(error: RaceError) -> ExternalImportError {
 
 fn map_special_day_error(error: SpecialDayError) -> ExternalImportError {
     match error {
-        SpecialDayError::Repository(message) => ExternalImportError::SpecialDay(message),
+        SpecialDayError::Validation(message) | SpecialDayError::Repository(message) => {
+            ExternalImportError::SpecialDay(message)
+        }
     }
 }
 

--- a/src/domain/external_sync/import/tests/completed_workouts.rs
+++ b/src/domain/external_sync/import/tests/completed_workouts.rs
@@ -81,6 +81,60 @@ async fn import_completed_workout_persists_canonical_state_and_refreshes_start_d
 }
 
 #[tokio::test]
+async fn import_completed_workout_returns_error_for_stale_dedup_mapping() {
+    let observations = InMemoryObservationRepository::default();
+    let existing = sample_completed_workout();
+    observations
+        .upsert(ExternalObservation::new(ExternalObservationParams {
+            user_id: "user-1".to_string(),
+            provider: ExternalProvider::Intervals,
+            external_object_kind: ExternalObjectKind::CompletedWorkout,
+            external_id: "intervals-activity-77".to_string(),
+            canonical_entity: CanonicalEntityRef::new(
+                CanonicalEntityKind::CompletedWorkout,
+                existing.completed_workout_id.clone(),
+            ),
+            normalized_payload_hash: Some("hash-existing".to_string()),
+            dedup_key: completed_workout_dedup_key(&existing),
+            observed_at_epoch_seconds: 1_699_999_000,
+        }))
+        .await
+        .unwrap();
+    let service = external_import_service_without_refresh(
+        InMemoryPlannedWorkoutRepository::default(),
+        InMemoryCompletedWorkoutRepository::default(),
+        InMemoryRaceRepository::default(),
+        InMemorySpecialDayRepository::default(),
+        InMemoryPlannedWorkoutTokenRepository::default(),
+        InMemoryPlannedCompletedWorkoutLinkRepository::default(),
+        observations,
+        InMemorySyncStateRepository::default(),
+    );
+
+    let error = service
+        .import(ExternalImportCommand::UpsertCompletedWorkout(Box::new(
+            ExternalCompletedWorkoutImport {
+                provider: ExternalProvider::Wahoo,
+                external_id: "wahoo-activity-1".to_string(),
+                normalized_payload_hash: "hash-wahoo-1".to_string(),
+                marker_sources: Vec::new(),
+                workout: sample_completed_workout_for_provider(
+                    ExternalProvider::Wahoo,
+                    "wahoo-activity-1",
+                    Some(CompletedWorkoutSeries::Integers(vec![180, 240, 310, 330])),
+                ),
+            },
+        )))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ExternalImportError::CompletedWorkout(message) if message.contains("stale completed workout dedup match")
+    ));
+}
+
+#[tokio::test]
 async fn import_completed_workout_reuses_existing_canonical_workout_for_matching_dedup_key() {
     let observations = InMemoryObservationRepository::default();
     let completed_workouts = InMemoryCompletedWorkoutRepository::default();
@@ -142,6 +196,51 @@ async fn import_completed_workout_reuses_existing_canonical_workout_for_matching
         existing.completed_workout_id
     );
     assert_eq!(observations.stored().len(), 2);
+}
+
+#[tokio::test]
+async fn import_completed_workout_refreshes_old_and_new_dates_when_existing_canonical_date_moves() {
+    let completed_workouts = InMemoryCompletedWorkoutRepository::default();
+    let refresh = RecordingRefresh::default();
+    let mut existing = sample_completed_workout();
+    existing.start_date_local = "2026-05-10T08:00:00".to_string();
+    completed_workouts.upsert(existing.clone()).await.unwrap();
+    let service = external_import_service(
+        InMemoryPlannedWorkoutRepository::default(),
+        completed_workouts.clone(),
+        InMemoryRaceRepository::default(),
+        InMemorySpecialDayRepository::default(),
+        InMemoryPlannedWorkoutTokenRepository::default(),
+        InMemoryPlannedCompletedWorkoutLinkRepository::default(),
+        InMemoryObservationRepository::default(),
+        InMemorySyncStateRepository::default(),
+        refresh.clone(),
+    );
+
+    service
+        .import(ExternalImportCommand::UpsertCompletedWorkout(Box::new(
+            ExternalCompletedWorkoutImport {
+                provider: ExternalProvider::Intervals,
+                external_id: "intervals-activity-77".to_string(),
+                normalized_payload_hash: "hash-intervals-2".to_string(),
+                marker_sources: Vec::new(),
+                workout: sample_completed_workout(),
+            },
+        )))
+        .await
+        .unwrap();
+
+    let stored = completed_workouts.list_by_user_id("user-1").await.unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].start_date_local, "2026-05-11T08:00:00");
+    assert_eq!(
+        refresh.calls(),
+        vec![(
+            "user-1".to_string(),
+            "2026-05-10".to_string(),
+            "2026-05-11".to_string(),
+        )]
+    );
 }
 
 #[tokio::test]

--- a/src/domain/external_sync/import/tests/entity_imports.rs
+++ b/src/domain/external_sync/import/tests/entity_imports.rs
@@ -167,7 +167,8 @@ async fn import_special_day_persists_canonical_state_and_refreshes_day() {
                     SpecialDayKind::Note,
                     Some("Recovery Note".to_string()),
                     Some("Keep easy".to_string()),
-                ),
+                )
+                .unwrap(),
             },
         ))
         .await

--- a/src/domain/races/service.rs
+++ b/src/domain/races/service.rs
@@ -266,9 +266,12 @@ where
                 )
                 .await
             {
-                self.refresh_race_date(&existing.user_id, &existing.date)
-                    .await;
-                return Err(map_sync_repository_error(error));
+                warn!(
+                    user_id = %existing.user_id,
+                    race_id = %existing.race_id,
+                    %error,
+                    "race delete succeeded locally but failed to delete sync state"
+                );
             }
         }
 

--- a/src/domain/races/tests.rs
+++ b/src/domain/races/tests.rs
@@ -930,7 +930,7 @@ async fn delete_race_refreshes_calendar_view_when_sync_state_delete_fails_after_
     let intervals = RecordingIntervalsService::default();
     let refresh = RecordingCalendarRefresh::default();
     let service = RaceService::new(
-        repository,
+        repository.clone(),
         intervals.clone(),
         sync_states,
         TestClock,
@@ -938,9 +938,9 @@ async fn delete_race_refreshes_calendar_view_when_sync_state_delete_fails_after_
     )
     .with_calendar_view_refresh(refresh.clone());
 
-    let error = service.delete_race("user-1", "race-1").await.unwrap_err();
+    service.delete_race("user-1", "race-1").await.unwrap();
 
-    assert_eq!(error, RaceError::Internal("sync delete boom".to_string()));
+    assert!(repository.stored().is_empty());
     assert_eq!(*intervals.deleted_event_ids.lock().unwrap(), vec![88]);
     assert_eq!(
         refresh.stored(),

--- a/src/domain/settings/service.rs
+++ b/src/domain/settings/service.rs
@@ -341,12 +341,7 @@ where
                 {
                     state
                 } else {
-                    ProviderPollState {
-                        next_due_at_epoch_seconds: now_epoch_seconds,
-                        backoff_until_epoch_seconds: None,
-                        last_error: None,
-                        ..state
-                    }
+                    ProviderPollState { ..state }
                 }
             }
             None => ProviderPollState::new(
@@ -884,5 +879,59 @@ mod tests {
         assert!(stored
             .iter()
             .all(|state| state.last_successful_at_epoch_seconds.is_none()));
+    }
+
+    #[tokio::test]
+    async fn update_intervals_without_credential_change_keeps_future_poll_schedule() {
+        let mut settings = UserSettings::new_defaults("user-1".to_string(), 1_699_999_000);
+        settings.intervals = IntervalsConfig {
+            api_key: Some("same-key".to_string()),
+            athlete_id: Some("same-athlete".to_string()),
+            connected: true,
+        };
+        let repository = InMemoryUserSettingsRepository::with_settings(settings);
+        let poll_states = InMemoryProviderPollStateRepository::default();
+        poll_states
+            .upsert(ProviderPollState {
+                user_id: "user-1".to_string(),
+                provider: ExternalProvider::Intervals,
+                stream: ProviderPollStream::Calendar,
+                cursor: Some("2026-05-01".to_string()),
+                next_due_at_epoch_seconds: 1_700_099_999,
+                last_attempted_at_epoch_seconds: Some(1_699_999_000),
+                last_successful_at_epoch_seconds: Some(1_699_999_100),
+                last_error: Some("transient".to_string()),
+                backoff_until_epoch_seconds: Some(1_700_100_100),
+            })
+            .await
+            .unwrap();
+        let service = UserSettingsService::new(repository, TestClock)
+            .with_provider_poll_states(poll_states.clone());
+
+        service
+            .update_intervals(
+                "user-1",
+                IntervalsConfig {
+                    api_key: Some("same-key".to_string()),
+                    athlete_id: Some("same-athlete".to_string()),
+                    connected: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        let stored = poll_states.stored();
+        assert!(stored.iter().any(|state| {
+            state.stream == ProviderPollStream::Calendar
+                && state.next_due_at_epoch_seconds == 1_700_099_999
+                && state.backoff_until_epoch_seconds == Some(1_700_100_100)
+                && state.last_error.as_deref() == Some("transient")
+        }));
+        assert!(stored.iter().any(|state| {
+            state.stream == ProviderPollStream::CompletedWorkouts
+                && state.next_due_at_epoch_seconds == 1_700_000_000
+                && state.backoff_until_epoch_seconds.is_none()
+                && state.last_error.is_none()
+        }));
     }
 }

--- a/src/domain/special_days/model.rs
+++ b/src/domain/special_days/model.rs
@@ -1,3 +1,5 @@
+use chrono::NaiveDate;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SpecialDayKind {
     Illness,
@@ -19,13 +21,14 @@ pub struct SpecialDay {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SpecialDayError {
+    Validation(String),
     Repository(String),
 }
 
 impl std::fmt::Display for SpecialDayError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Repository(message) => write!(f, "{message}"),
+            Self::Validation(message) | Self::Repository(message) => write!(f, "{message}"),
         }
     }
 }
@@ -40,14 +43,23 @@ impl SpecialDay {
         kind: SpecialDayKind,
         title: Option<String>,
         description: Option<String>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, SpecialDayError> {
+        validate_date(&date)?;
+
+        Ok(Self {
             special_day_id,
             user_id,
             date,
             kind,
             title,
             description,
-        }
+        })
     }
+}
+
+fn validate_date(date: &str) -> Result<(), SpecialDayError> {
+    NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|error| {
+        SpecialDayError::Validation(format!("invalid special day date '{date}': {error}"))
+    })?;
+    Ok(())
 }

--- a/src/domain/special_days/tests.rs
+++ b/src/domain/special_days/tests.rs
@@ -14,7 +14,8 @@ fn special_day_uses_local_canonical_id_and_kind() {
         SpecialDayKind::Illness,
         Some("Sick day".to_string()),
         Some("Fever and sore throat".to_string()),
-    );
+    )
+    .unwrap();
 
     assert_eq!(day.special_day_id, "special-1");
     assert_eq!(day.user_id, "user-1");
@@ -159,4 +160,23 @@ fn sample_day(special_day_id: &str, user_id: &str, date: &str) -> SpecialDay {
         Some("Illness".to_string()),
         Some("Recovery day".to_string()),
     )
+    .unwrap()
+}
+
+#[test]
+fn special_day_rejects_non_canonical_date() {
+    let error = SpecialDay::new(
+        "special-invalid".to_string(),
+        "user-1".to_string(),
+        "2026/05/02".to_string(),
+        SpecialDayKind::Illness,
+        Some("Sick day".to_string()),
+        Some("Fever and sore throat".to_string()),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        super::SpecialDayError::Validation(message) if message.contains("invalid special day date")
+    ));
 }

--- a/src/domain/training_context/service/tests/support.rs
+++ b/src/domain/training_context/service/tests/support.rs
@@ -324,7 +324,8 @@ impl Default for TestSpecialDayRepository {
                 SpecialDayKind::Note,
                 Some("Sick day".to_string()),
                 Some("Felt unwell with sore throat".to_string()),
-            )],
+            )
+            .unwrap()],
         }
     }
 }

--- a/src/main_support.rs
+++ b/src/main_support.rs
@@ -193,17 +193,33 @@ pub(crate) async fn shutdown_signal() {
     let ctrl_c = wait_for_ctrl_c(tokio::signal::ctrl_c(), shutdown.clone());
 
     #[cfg(unix)]
-    let terminate = wait_for_sigterm(
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()),
-        shutdown,
-    );
+    let terminate = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+    {
+        Ok(signal) => Some(wait_for_sigterm(Ok(signal), shutdown)),
+        Err(error) => {
+            tracing::error!(%error, "Failed to register SIGTERM handler");
+            None
+        }
+    };
 
     #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
+    let _terminate = ();
 
-    tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+    #[cfg(unix)]
+    {
+        if let Some(terminate) = terminate {
+            tokio::select! {
+                _ = ctrl_c => {},
+                _ = terminate => {},
+            }
+        } else {
+            ctrl_c.await;
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await;
     }
 }
 

--- a/tests/calendar_entry_views_mongo.rs
+++ b/tests/calendar_entry_views_mongo.rs
@@ -252,6 +252,36 @@ async fn calendar_entry_view_repository_replaces_only_target_range_and_handles_d
 }
 
 #[tokio::test]
+async fn calendar_entry_view_repository_rejects_replace_range_entries_outside_requested_dates() {
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository =
+        MongoCalendarEntryViewRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    let error = repository
+        .replace_range_for_user(
+            "user-1",
+            "2026-05-10",
+            "2026-05-12",
+            vec![sample_entry(
+                "planned:1",
+                CalendarEntryKind::PlannedWorkout,
+                "2026-05-15",
+            )],
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("calendar entry date out of range"));
+
+    fixture.cleanup().await;
+}
+
+#[tokio::test]
 async fn calendar_entry_view_repository_creates_expected_indexes() {
     let Some(fixture) = mongo_fixture_or_skip().await else {
         return;

--- a/tests/canonical_roots_mongo.rs
+++ b/tests/canonical_roots_mongo.rs
@@ -661,4 +661,5 @@ fn sample_special_day(special_day_id: &str, user_id: &str, date: &str) -> Specia
         Some("Illness".to_string()),
         Some("Recovery day".to_string()),
     )
+    .unwrap()
 }


### PR DESCRIPTION
Refresh both old and new calendar dates when canonical completed workouts move so calendar views stay consistent. Add a repo-local graphify rebuild wrapper that follows the pipx-based local setup used in this repo.