### PR TITLE
feat: add training load dashboard

### DIFF
--- a/docs/plans/2026-04-18-dashboard-i18n-refactor-design.md
+++ b/docs/plans/2026-04-18-dashboard-i18n-refactor-design.md
@@ -1,0 +1,77 @@
+# Dashboard I18n Refactor Design
+
+**Goal:** Refactor the training load dashboard UI into smaller frontend-local pieces, localize dashboard and `/app` shell copy through the existing i18n system, and replace backend TSB threshold magic numbers with named constants without changing the existing API contract or dashboard behavior.
+
+**Architecture:** Keep the current fetch and rendering flow unchanged: `AppHomePage` still loads the dashboard payload and renders `TrainingLoadReport`. Limit frontend work to the existing `/app` shell and dashboard feature files, and limit backend work to the existing training-load use-case module so the change stays behavioral-neutral.
+
+**Tech Stack:** React, TypeScript, react-i18next, Tailwind CSS, inline SVG, Vitest, Testing Library, Rust
+
+---
+
+## Scope
+
+- Keep routing, dashboard API calls, Zod parsing, and response shapes unchanged.
+- Refactor `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx` into smaller dashboard-local pieces.
+- Localize dashboard copy including headings, legends, tooltips, chart labels, empty states, loading/error states, and ARIA narration.
+- Extend the localization pass to the `/app` shell in `AuthenticatedLayout.tsx` for page titles, navigation labels, and the notifications button label.
+- Replace backend TSB threshold literals in `classify_tsb_zone(...)` with named constants while preserving current thresholds and zone mapping.
+
+## Design Direction
+
+### Frontend Structure
+
+- Keep `TrainingLoadCharts.tsx` as the orchestration layer only.
+- Move chart-specific rendering into focused dashboard-local components such as:
+  - a load chart section
+  - a TSB chart section
+  - small presentational pieces such as legend and metric blocks
+- Move reusable chart math and display formatting into local helper files instead of keeping geometry, formatting, rendering, and copy in one component.
+
+### Localization Strategy
+
+- Use the existing `react-i18next` setup and extend the existing `frontend/src/locales/en/translation.json` and `frontend/src/locales/pl/translation.json` files.
+- Localize both visible UI copy and accessibility-facing text:
+  - chart ARIA labels
+  - tooltip labels
+  - insight-card copy
+  - range-switch legend text
+  - loading, error, and empty-state strings
+  - `/app` navigation labels and page titles
+- Replace hardcoded `en-US` date formatting with helpers that format using the active i18n language while preserving the existing invalid-date fallback.
+
+### Data Flow
+
+- Keep dashboard data loading in `AppHomePage` unchanged.
+- In the refactored chart layer, compute shared axis, timeline, and point data once in `TrainingLoadCharts.tsx`, then pass only the required prepared data into the focused chart sections.
+- Keep translation calls at render boundaries:
+  - static labels via `t(...)`
+  - dynamic tooltip and ARIA copy via interpolation
+  - localized date and number formatting through small helpers
+
+### Error Handling and Null Behavior
+
+- Preserve current empty, loading, and error behavior, only localizing the current messages.
+- Preserve existing chart null handling exactly:
+  - gaps remain gaps
+  - latest-point fallback stays intact
+  - hover tooltips render only when both the hovered snapshot and plotted point exist
+- Preserve display fallbacks:
+  - invalid dates render as raw strings
+  - null metrics render as `-`
+- Keep backend threshold extraction as a naming cleanup only, with no logic change.
+
+## Backend Cleanup
+
+- Introduce named constants for TSB zone boundaries in `src/domain/training_load/use_cases.rs`.
+- Keep the current semantics:
+  - greater than `0.0` maps to `FreshnessPeak`
+  - less than `-30.0` maps to `HighRisk`
+  - everything else maps to `OptimalTraining`
+- Do not move this logic across architectural boundaries or change DTO/domain shapes.
+
+## Testing
+
+- Update frontend tests in `frontend/src/pages/AppHomePage.test.tsx` to reflect the localized dashboard and existing regression scenarios under the default English locale.
+- Add focused frontend coverage only if the refactor introduces a real gap.
+- Keep backend training-load tests proving current TSB zone classification behavior; add or adjust coverage only if needed to make the named-threshold intent explicit.
+- After implementation, run the relevant targeted frontend and Rust tests, then the broader verification required by the changed files before calling the work complete.

--- a/docs/plans/2026-04-18-dashboard-i18n-refactor-implementation-plan.md
+++ b/docs/plans/2026-04-18-dashboard-i18n-refactor-implementation-plan.md
@@ -1,0 +1,293 @@
+# Dashboard I18n Refactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor the training load dashboard into smaller pieces, localize dashboard and `/app` shell copy, and replace backend TSB threshold magic numbers with named constants without changing the dashboard API or behavior.
+
+**Architecture:** Keep the current page and API flow intact: `AppHomePage` still loads the dashboard payload and `TrainingLoadReport` still renders the dashboard experience. Implement the frontend work inside the existing dashboard feature and `/app` layout, and keep the backend change limited to the training-load use-case module so the pass remains structurally cleaner but behaviorally neutral.
+
+**Tech Stack:** React, TypeScript, react-i18next, Tailwind CSS, inline SVG, Vitest, Testing Library, Rust
+
+---
+
+## Task 1: Lock the localized dashboard and shell expectations in tests
+
+**Files:**
+- Modify: `frontend/src/pages/AppHomePage.test.tsx`
+- Modify: `frontend/src/App.test.tsx`
+
+**Step 1: Write the failing dashboard assertions**
+
+- Update `frontend/src/pages/AppHomePage.test.tsx` so the existing dashboard tests still cover:
+  - loading state
+  - range switching
+  - keyboard range changes
+  - TSB hover tooltip behavior
+  - latest-load marker fallback when CTL is null
+  - empty state
+- Change the assertions to rely on the localized English copy that the implementation will render instead of current hardcoded strings embedded in component code.
+
+**Step 2: Write the failing `/app` shell assertions**
+
+- Update `frontend/src/App.test.tsx` or the most relevant existing app-shell tests so they assert localized nav/page-title behavior for `/app` paths where appropriate.
+
+**Step 3: Run the focused frontend tests to verify failure**
+
+Run:
+- `bun run --cwd frontend test src/pages/AppHomePage.test.tsx src/App.test.tsx`
+
+Expected: FAIL because the dashboard and `/app` shell do not use translation keys yet.
+
+## Task 2: Add the translation keys needed for dashboard and `/app`
+
+**Files:**
+- Modify: `frontend/src/locales/en/translation.json`
+- Modify: `frontend/src/locales/pl/translation.json`
+
+**Step 1: Add `/app` shell translation keys**
+
+- Add keys for:
+  - dashboard nav label
+  - races nav label if needed for consistency with shell usage
+  - page titles used by `AuthenticatedLayout`
+  - notifications button label
+  - brand subtitle if it is meant to be localized
+
+**Step 2: Add dashboard translation keys**
+
+- Add keys for:
+  - dashboard report header copy
+  - range switch labels and legend
+  - empty, loading, and error states
+  - chart legend labels
+  - tooltip labels
+  - chart zone labels
+  - chart ARIA narration
+  - insight-card headings, descriptions, and metric labels
+  - coach-insight headlines and detail text interpolation
+
+**Step 3: Keep the key shape feature-local and readable**
+
+- Group the new keys under a dedicated top-level namespace such as `dashboard` and extend `nav` only where the shell already uses it.
+
+## Task 3: Localize the `/app` shell and dashboard shell states
+
+**Files:**
+- Modify: `frontend/src/app/AuthenticatedLayout.tsx`
+- Modify: `frontend/src/pages/AppHomePage.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadReport.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadEmptyState.tsx`
+
+**Step 1: Write the minimal implementation for `/app` shell localization**
+
+- Add `useTranslation()` to `AuthenticatedLayout.tsx`.
+- Replace hardcoded page-title and nav-label strings with `t(...)` lookups.
+- Localize the notifications button `aria-label`.
+
+**Step 2: Write the minimal implementation for page-level dashboard states**
+
+- Add `useTranslation()` to `AppHomePage.tsx`.
+- Localize the loading and error states while preserving current fetch and fallback behavior.
+
+**Step 3: Localize dashboard shell components**
+
+- Add `useTranslation()` to `TrainingLoadReport.tsx`, `TrainingLoadRangeSwitch.tsx`, and `TrainingLoadEmptyState.tsx`.
+- Replace the current hardcoded header, segmented-control, and empty-state strings with translation keys.
+- Keep behavior and layout semantics unchanged.
+
+**Step 4: Run focused frontend tests to verify progress**
+
+Run:
+- `bun run --cwd frontend test src/pages/AppHomePage.test.tsx src/App.test.tsx`
+
+Expected: some tests may still fail until chart and insight-card localization is implemented.
+
+## Task 4: Split chart helpers out of `TrainingLoadCharts.tsx`
+
+**Files:**
+- Create: `frontend/src/features/dashboard/components/trainingLoadChartUtils.ts`
+- Create: `frontend/src/features/dashboard/components/trainingLoadFormatters.ts`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx`
+
+**Step 1: Move pure chart math into a helper module**
+
+- Extract pure helpers from `TrainingLoadCharts.tsx` into `trainingLoadChartUtils.ts`, such as:
+  - clamp
+  - point building
+  - line and area path building
+  - latest-point and hover-index helpers
+  - axis/timeline helper builders
+
+**Step 2: Move formatting helpers into a dedicated formatter module**
+
+- Extract formatting logic into `trainingLoadFormatters.ts`, including:
+  - metric fallback formatting
+  - localized short-date formatting
+  - localized window-date formatting if it is reused
+- Make the formatter helpers accept the active language so they no longer hardcode `en-US`.
+
+**Step 3: Keep `TrainingLoadCharts.tsx` compiling with the extracted helpers**
+
+- Update imports and preserve current rendering behavior before any deeper component split.
+
+**Step 4: Run the dashboard test file**
+
+Run:
+- `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
+
+Expected: either FAIL on remaining localization work or PASS on unchanged regressions.
+
+## Task 5: Split the load and TSB chart rendering into focused components
+
+**Files:**
+- Create: `frontend/src/features/dashboard/components/TrainingLoadLoadChart.tsx`
+- Create: `frontend/src/features/dashboard/components/TrainingLoadTsbChart.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx`
+
+**Step 1: Extract the load chart section**
+
+- Move the fitness/fatigue card rendering into `TrainingLoadLoadChart.tsx`.
+- Pass prepared props only:
+  - axis labels
+  - timeline labels
+  - latest and hovered snapshot state
+  - line paths and marker data
+  - handlers and translated copy
+
+**Step 2: Extract the TSB chart section**
+
+- Move the form card rendering into `TrainingLoadTsbChart.tsx`.
+- Pass prepared props only:
+  - axis labels
+  - timeline labels
+  - zone boundary layout values
+  - latest and hovered snapshot state
+  - line and area path data
+  - handlers and translated copy
+
+**Step 3: Reduce `TrainingLoadCharts.tsx` to orchestration**
+
+- Keep it responsible for:
+  - deriving series arrays from `report`
+  - computing shared chart data once
+  - owning hover state
+  - passing props into the two focused chart components
+
+## Task 6: Localize chart and insight-card copy completely
+
+**Files:**
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadLoadChart.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadTsbChart.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx`
+- Modify: `frontend/src/features/dashboard/components/trainingLoadFormatters.ts`
+
+**Step 1: Localize chart labels and tooltips**
+
+- Add `useTranslation()` at the chart render boundary.
+- Replace hardcoded legend labels, snapshot labels, zone labels, and metric labels with translation keys.
+- Build chart ARIA labels with translation interpolation instead of inline English strings.
+
+**Step 2: Localize insight-card copy**
+
+- Replace all hardcoded insight/explainer text with translation keys.
+- Keep the current TSB-zone-dependent headline logic, but drive the actual displayed strings from localized keys.
+- Keep delta-dependent detail text behavior unchanged.
+
+**Step 3: Localize date formatting**
+
+- Make date formatting use the active i18n language while preserving the current raw-string fallback for invalid dates.
+
+**Step 4: Run the focused frontend tests**
+
+Run:
+- `bun run --cwd frontend test src/pages/AppHomePage.test.tsx src/App.test.tsx`
+
+Expected: PASS.
+
+## Task 7: Replace backend TSB magic numbers with named constants
+
+**Files:**
+- Modify: `src/domain/training_load/use_cases.rs`
+- Modify: `src/domain/training_load/tests.rs` if a small assertion update is needed
+
+**Step 1: Write the failing or clarifying backend assertion if needed**
+
+- If the existing tests do not make the threshold intent obvious enough, add a small focused assertion around the current threshold behavior.
+
+**Step 2: Introduce named constants**
+
+- Add private constants near `classify_tsb_zone(...)`, for example:
+  - freshness threshold
+  - high-risk threshold
+- Replace inline `0.0` and `-30.0` with those constants.
+
+**Step 3: Run the focused Rust test**
+
+Run:
+- `cargo test training_load -- --nocapture`
+
+Expected: PASS.
+
+## Task 8: Run targeted verification for touched areas
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run targeted frontend tests**
+
+Run:
+- `bun run --cwd frontend test src/pages/AppHomePage.test.tsx src/App.test.tsx src/features/dashboard/api/dashboard.test.ts`
+
+Expected: PASS.
+
+**Step 2: Run targeted Rust verification**
+
+Run:
+- `cargo fmt --all --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test training_load -- --nocapture`
+
+Expected: PASS.
+
+## Task 9: Run broader verification and graph refresh
+
+**Files:**
+- No code changes expected unless verification or review finds issues
+
+**Step 1: Run broader frontend verification**
+
+Run:
+- `bun run --cwd frontend test`
+- `bun run --cwd frontend build`
+
+Expected: PASS.
+
+**Step 2: Refresh graphify**
+
+Run:
+- `bash ./scripts/rebuild_graphify.sh`
+
+Expected: PASS.
+
+## Task 10: Perform the required review loop and final verification pass
+
+**Files:**
+- No code changes expected unless review finds issues
+
+**Step 1: Perform four review iterations**
+
+- In each iteration, review the changed files in three passes:
+  - strict reviewer
+  - very strict reviewer
+  - nitpicker
+- Convert confirmed findings into minimal fixes.
+
+**Step 2: Rerun the most relevant verification after each fix set**
+
+- Use the smallest command set that proves the affected behavior still works.
+
+**Step 3: Finish with the final required checks**
+
+Run the final relevant verification again after the last review iteration and read the output before claiming the work complete.

--- a/docs/plans/2026-04-18-dashboard-prototype-close-design.md
+++ b/docs/plans/2026-04-18-dashboard-prototype-close-design.md
@@ -1,0 +1,51 @@
+# Dashboard Prototype-Close Design
+
+**Goal:** Polish the existing training load dashboard so the `/app` screen looks materially closer to the approved issue `#103` prototype while keeping the current snapshot-backed data model and explicitly omitting the `Plan Deload Week` CTA.
+
+**Architecture:** Keep the current frontend data flow unchanged: `AppHomePage` still loads the dashboard payload and renders `TrainingLoadReport`. Limit the work to the existing dashboard feature components so the change stays presentation-only, with no REST, domain, or schema changes.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, existing SVG chart rendering, Vitest, Testing Library
+
+---
+
+## Scope
+
+- Keep routing, API calls, and Zod parsing unchanged.
+- Keep the current `90 DAYS`, `SEASON`, and `ALL TIME` controls and behavior unchanged.
+- Make the top section, charts, and right-hand panel visually closer to the issue prototype.
+- Preserve the removed deload CTA by using informational insight content only.
+
+## Design Direction
+
+### Header and Range Controls
+
+- Shift the screen toward the prototype's editorial hierarchy:
+  - tighter uppercase eyebrow
+  - stronger headline treatment
+  - short supporting copy
+- Restyle the range switch as a darker segmented control integrated into the same visual language as the cards.
+
+### Chart Cards
+
+- Keep the current SVG chart approach instead of introducing a charting library.
+- Restyle both cards with:
+  - darker surfaces
+  - stronger legends for CTL, ATL, and TSB
+  - clearer grid framing
+  - y-axis labels
+  - bottom date markers
+  - a visible latest-point or today indicator derived from the newest snapshot
+- For TSB, add clearer zone framing so `freshness_peak`, `optimal_training`, and `high_risk` read more like the prototype.
+
+### Right-Hand Panel
+
+- Replace the current single summary card feel with a prototype-close two-part treatment:
+  - a TSB explainer block with zone descriptions
+  - a coach insight block with stronger headline and current metrics
+- Keep this panel purely informational.
+- Do not add any action button or new workflow.
+
+## Testing
+
+- Update frontend tests to assert the new visible structure and copy that distinguishes the prototype-close layout.
+- Run targeted frontend tests first, then broader frontend verification.

--- a/docs/plans/2026-04-18-dashboard-prototype-close-implementation-plan.md
+++ b/docs/plans/2026-04-18-dashboard-prototype-close-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Lock the expected prototype-close UI in a failing test
+## Task 1: Lock the expected prototype-close UI in a failing test
 
 **Files:**
 - Modify: `frontend/src/pages/AppHomePage.test.tsx`
@@ -28,7 +28,7 @@ Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
 
 Expected: FAIL because the current dashboard UI does not render the new structure yet.
 
-### Task 2: Restyle the dashboard report shell and range switch
+## Task 2: Restyle the dashboard report shell and range switch
 
 **Files:**
 - Modify: `frontend/src/features/dashboard/components/TrainingLoadReport.tsx`
@@ -46,7 +46,7 @@ Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
 
 Expected: still failing until the chart and insight components are updated.
 
-### Task 3: Restyle the chart cards with clearer axes, zones, and latest-point context
+## Task 3: Restyle the chart cards with clearer axes, zones, and latest-point context
 
 **Files:**
 - Modify: `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx`
@@ -64,7 +64,7 @@ Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
 
 Expected: may still fail until the right-hand panel is updated.
 
-### Task 4: Replace the summary card feel with the prototype-close insight/explainer panel
+## Task 4: Replace the summary card feel with the prototype-close insight/explainer panel
 
 **Files:**
 - Modify: `frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx`
@@ -81,7 +81,7 @@ Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
 
 Expected: PASS.
 
-### Task 5: Run targeted and broader verification
+## Task 5: Run targeted and broader verification
 
 **Files:**
 - No code changes expected
@@ -100,7 +100,7 @@ Run:
 
 Expected: PASS.
 
-### Task 6: Run graph refresh and the required review loop
+## Task 6: Run graph refresh and the required review loop
 
 **Files:**
 - No code changes expected unless review finds issues

--- a/docs/plans/2026-04-18-dashboard-prototype-close-implementation-plan.md
+++ b/docs/plans/2026-04-18-dashboard-prototype-close-implementation-plan.md
@@ -1,0 +1,118 @@
+# Dashboard Prototype-Close Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restyle the existing training load dashboard to match issue `#103` more closely without changing its data contract or restoring the removed deload CTA.
+
+**Architecture:** Keep `AppHomePage` and the dashboard API untouched, and implement the approved polish inside the existing `frontend/src/features/dashboard/components/*` files. Treat this as a presentation-only pass backed by the same dashboard response payload and the same route behavior.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, inline SVG, Vitest, Testing Library
+
+---
+
+### Task 1: Lock the expected prototype-close UI in a failing test
+
+**Files:**
+- Modify: `frontend/src/pages/AppHomePage.test.tsx`
+
+**Step 1: Write the failing test**
+
+- Extend the existing happy-path dashboard test so it also expects the prototype-close structure and copy, for example:
+  - `Understanding Form (TSB)`
+  - `Coach Insight`
+  - `Latest snapshot`
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
+
+Expected: FAIL because the current dashboard UI does not render the new structure yet.
+
+### Task 2: Restyle the dashboard report shell and range switch
+
+**Files:**
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadReport.tsx`
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx`
+
+**Step 1: Write minimal implementation**
+
+- Update the header layout and copy to feel closer to the prototype.
+- Keep the same `onRangeChange` behavior.
+- Restyle the segmented control only; do not change labels or state semantics.
+
+**Step 2: Run test to verify progress**
+
+Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
+
+Expected: still failing until the chart and insight components are updated.
+
+### Task 3: Restyle the chart cards with clearer axes, zones, and latest-point context
+
+**Files:**
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadCharts.tsx`
+
+**Step 1: Write minimal implementation**
+
+- Keep the current SVG line rendering.
+- Add helpers for date labels and latest-point context.
+- Add visible y-axis labels, bottom timeline labels, and a highlighted latest snapshot marker.
+- Strengthen TSB zone backgrounds and labels.
+
+**Step 2: Run test to verify progress**
+
+Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
+
+Expected: may still fail until the right-hand panel is updated.
+
+### Task 4: Replace the summary card feel with the prototype-close insight/explainer panel
+
+**Files:**
+- Modify: `frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx`
+
+**Step 1: Write minimal implementation**
+
+- Render a TSB explanation block with three zones.
+- Render a darker coach insight block using existing summary data.
+- Keep the panel informational only and do not add any CTA.
+
+**Step 2: Run test to verify it passes**
+
+Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx`
+
+Expected: PASS.
+
+### Task 5: Run targeted and broader verification
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run targeted frontend tests**
+
+Run: `bun run --cwd frontend test src/pages/AppHomePage.test.tsx src/features/dashboard/api/dashboard.test.ts`
+
+Expected: PASS.
+
+**Step 2: Run broader frontend verification**
+
+Run:
+- `bun run --cwd frontend test`
+- `bun run --cwd frontend build`
+
+Expected: PASS.
+
+### Task 6: Run graph refresh and the required review loop
+
+**Files:**
+- No code changes expected unless review finds issues
+
+**Step 1: Refresh graphify**
+
+Run: `bash ./scripts/rebuild_graphify.sh`
+
+**Step 2: Perform four review iterations**
+
+- In each iteration, review the changed frontend files in three passes:
+  - strict reviewer
+  - very strict reviewer
+  - nitpicker
+- Convert confirmed findings into fixes and rerun the most relevant verification after each iteration.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -337,4 +337,115 @@ describe('App', () => {
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
+
+  it('renders the authenticated /app shell labels for the dashboard route', async () => {
+    window.history.replaceState({}, '', '/app');
+
+    const jsonResponse = (body: unknown) =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const { pathname } = new URL(requestUrl, 'http://localhost');
+
+      switch (pathname) {
+        case '/api/auth/me':
+          return jsonResponse({
+            authenticated: true,
+            user: {
+              id: 'user-1',
+              email: 'athlete@example.com',
+              displayName: 'Test Athlete',
+              avatarUrl: null,
+              roles: ['user']
+            }
+          });
+        case '/health':
+          return jsonResponse({ status: 'ok', service: 'AiWattCoach' });
+        case '/ready':
+          return jsonResponse({ status: 'ok', reason: null });
+        case '/api/settings':
+          return jsonResponse({
+            aiAgents: {
+              openaiApiKey: null,
+              openaiApiKeySet: false,
+              geminiApiKey: null,
+              geminiApiKeySet: false,
+              openrouterApiKey: null,
+              openrouterApiKeySet: false
+            },
+            intervals: {
+              apiKey: null,
+              apiKeySet: false,
+              athleteId: null,
+              connected: false
+            },
+            options: {
+              analyzeWithoutHeartRate: false
+            },
+            availability: {
+              configured: false,
+              days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'].map((weekday) => ({
+                weekday,
+                available: false,
+                maxDurationMinutes: null
+              }))
+            },
+            cycling: {
+              fullName: null,
+              age: null,
+              heightCm: null,
+              weightKg: null,
+              ftpWatts: null,
+              hrMaxBpm: null,
+              vo2Max: null,
+              athletePrompt: null,
+              medications: null,
+              athleteNotes: null,
+              lastZoneUpdateEpochSeconds: null
+            }
+          });
+        case '/api/dashboard/training-load':
+          return jsonResponse({
+            range: '90d',
+            windowStart: '2026-01-19',
+            windowEnd: '2026-04-18',
+            hasTrainingLoad: true,
+            summary: {
+              currentCtl: 29.9,
+              currentAtl: 53.4,
+              currentTsb: -23.5,
+              ftpWatts: null,
+              averageIf28d: null,
+              averageEf28d: null,
+              loadDeltaCtl14d: null,
+              tsbZone: 'optimal_training'
+            },
+            points: [
+              {
+                date: '2026-04-18',
+                dailyTss: 97,
+                currentCtl: 29.9,
+                currentAtl: 53.4,
+                currentTsb: -23.5
+              }
+            ]
+          });
+        default:
+          throw new Error(`Unexpected fetch for ${pathname}`);
+      }
+    });
+
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /training stress and recovery/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,7 +115,7 @@ export function App() {
                 </SettingsProvider>
               }
             >
-              <Route element={<AppHomePage />} path="/app" />
+              <Route element={<AppHomePage apiBaseUrl={API_BASE_URL} />} path="/app" />
               <Route element={<SettingsPage apiBaseUrl={API_BASE_URL} />} path="/settings" />
               <Route element={<CalendarPage apiBaseUrl={API_BASE_URL} />} path="/calendar" />
               <Route element={<RacesPage apiBaseUrl={API_BASE_URL} />} path="/races" />

--- a/frontend/src/app/AuthenticatedLayout.tsx
+++ b/frontend/src/app/AuthenticatedLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   Bell,
   Bot,
@@ -19,22 +20,24 @@ type AuthenticatedLayoutProps = {
   backendStatus?: { state: string; health: { service: string; status: string }; readiness: { status: string } };
 };
 
-const PAGE_TITLES: Record<string, string> = {
-  '/app': 'Dashboard',
-  '/settings': 'Settings',
-  '/calendar': 'Calendar',
-  '/races': 'Races',
-  '/ai-coach': 'AI Coach',
-  '/admin/system-info': 'System Info',
+const PAGE_TITLE_KEYS: Record<string, string> = {
+  '/app': 'appShell.pageTitles.dashboard',
+  '/settings': 'appShell.pageTitles.settings',
+  '/calendar': 'appShell.pageTitles.calendar',
+  '/races': 'appShell.pageTitles.races',
+  '/ai-coach': 'appShell.pageTitles.aiCoach',
+  '/admin/system-info': 'appShell.pageTitles.systemInfo',
 };
 
 export function AuthenticatedLayout({ apiBaseUrl }: AuthenticatedLayoutProps) {
+  const { t } = useTranslation();
   const auth = useAuth();
   const location = useLocation();
   const settingsCtx = useSettings();
   const currentUser = auth.user;
 
-  const pageTitle = PAGE_TITLES[location.pathname] ?? 'WATTLY';
+  const pageTitleKey = PAGE_TITLE_KEYS[location.pathname];
+  const pageTitle = pageTitleKey ? t(pageTitleKey) : 'WATTLY';
   const cycling = settingsCtx.settings?.cycling ?? null;
 
   return (
@@ -43,18 +46,18 @@ export function AuthenticatedLayout({ apiBaseUrl }: AuthenticatedLayoutProps) {
         <div className="p-5">
           <p className="text-lg font-bold text-white tracking-wide">WATTLY</p>
           <p className="text-[10px] uppercase tracking-[0.25em] text-slate-500 mt-0.5">
-            Elite Performance
+            {t('appShell.brand.subtitle')}
           </p>
         </div>
 
         <nav className="mt-4 flex-1 px-3 space-y-1">
-          <NavItem to="/app" icon={LayoutDashboard} label="Dashboard" />
-          <NavItem to="/calendar" icon={Calendar} label="Calendar" />
-          <NavItem to="/races" icon={Flag} label="Races" />
-          <NavItem to="/ai-coach" icon={Bot} label="AI Coach" />
-          <NavItem to="/settings" icon={Settings} label="Settings" />
+          <NavItem to="/app" icon={LayoutDashboard} label={t('nav.dashboard')} />
+          <NavItem to="/calendar" icon={Calendar} label={t('nav.calendar')} />
+          <NavItem to="/races" icon={Flag} label={t('nav.races')} />
+          <NavItem to="/ai-coach" icon={Bot} label={t('nav.aiCoach')} />
+          <NavItem to="/settings" icon={Settings} label={t('nav.settings')} />
           {currentUser && currentUser.roles.includes('admin') && (
-            <NavItem to="/admin/system-info" icon={ShieldCheck} label="System Info" />
+            <NavItem to="/admin/system-info" icon={ShieldCheck} label={t('nav.systemInfo')} />
           )}
         </nav>
       </aside>
@@ -73,7 +76,7 @@ export function AuthenticatedLayout({ apiBaseUrl }: AuthenticatedLayoutProps) {
             <button
               className="text-slate-400 hover:text-slate-200 transition"
               type="button"
-              aria-label="Notifications"
+              aria-label={t('appShell.notifications')}
             >
               <Bell size={18} />
             </button>

--- a/frontend/src/features/dashboard/api/dashboard.test.ts
+++ b/frontend/src/features/dashboard/api/dashboard.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFetchMock, useFetchMock } from '../../intervals/api/testHelpers';
+import { loadTrainingLoadDashboard } from './dashboard';
+
+describe('dashboard api', () => {
+  it('loads training load report for selected range', async () => {
+    const fetchMock = useFetchMock(
+      createFetchMock().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            range: '90d',
+            windowStart: '2026-01-19',
+            windowEnd: '2026-04-18',
+            hasTrainingLoad: true,
+            summary: {
+              currentCtl: 29.9,
+              currentAtl: 53.4,
+              currentTsb: -23.5,
+              ftpWatts: 340,
+              averageIf28d: 72.95,
+              averageEf28d: null,
+              loadDeltaCtl14d: 8.4,
+              tsbZone: 'optimal_training',
+            },
+            points: [
+              {
+                date: '2026-04-18',
+                dailyTss: 97,
+                currentCtl: 29.9,
+                currentAtl: 53.4,
+                currentTsb: -23.5,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const result = await loadTrainingLoadDashboard('', '90d');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/dashboard/training-load?range=90d', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        traceparent: expect.stringMatching(/^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/),
+      },
+      credentials: 'include',
+      body: undefined,
+    });
+    expect(result.summary.currentCtl).toBe(29.9);
+    expect(result.points).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/dashboard/api/dashboard.ts
+++ b/frontend/src/features/dashboard/api/dashboard.ts
@@ -1,0 +1,8 @@
+import { get } from '../../../lib/httpClient';
+import { dashboardRangeSchema, trainingLoadDashboardResponseSchema, type DashboardRange } from '../types';
+
+export async function loadTrainingLoadDashboard(apiBaseUrl: string, range: DashboardRange | unknown) {
+  const validatedRange = dashboardRangeSchema.parse(range);
+  const data = await get(apiBaseUrl, `/api/dashboard/training-load?range=${validatedRange}`);
+  return trainingLoadDashboardResponseSchema.parse(data);
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
@@ -1,159 +1,28 @@
 import { useId, useState, type MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { TrainingLoadDashboardResponse } from '../types';
+import {
+  buildAreaPath,
+  buildLinePath,
+  buildPositionedAxisLabels,
+  buildSeriesPoints,
+  clamp,
+  latestSeriesPoint,
+  resolveHoveredIndex,
+  seriesPointAtIndex,
+} from './trainingLoadChartUtils';
+import { buildTimelineLabels, formatMetricValue, formatShortDate } from './trainingLoadFormatters';
+import { TrainingLoadLoadChart } from './TrainingLoadLoadChart';
+import { TrainingLoadTsbChart } from './TrainingLoadTsbChart';
 
 type TrainingLoadChartsProps = {
   report: TrainingLoadDashboardResponse;
 };
 
-type SeriesPoint = {
-  index: number;
-  value: number;
-  x: number;
-  y: number;
-};
-
-const CHART_X_INSET = 2;
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function buildPointX(index: number, total: number, width: number) {
-  return total === 1 ? width / 2 : CHART_X_INSET + (index / (total - 1)) * (width - (CHART_X_INSET * 2));
-}
-
-function buildSeriesPoints(values: Array<number | null>, min: number, max: number, height: number, width: number): SeriesPoint[] {
-  const denominator = Math.max(max - min, 1);
-
-  return values.flatMap((value, index) => {
-    if (value === null) {
-      return [];
-    }
-
-    const x = buildPointX(index, values.length, width);
-    const y = height - ((value - min) / denominator) * height;
-    return [{ index, value, x, y }];
-  });
-}
-
-function buildLinePath(values: Array<number | null>, min: number, max: number, height: number, width: number) {
-  const denominator = Math.max(max - min, 1);
-  let segmentOpen = false;
-
-  return values.reduce((path, value, index) => {
-    if (value === null) {
-      segmentOpen = false;
-      return path;
-    }
-
-    const x = buildPointX(index, values.length, width);
-    const y = height - ((value - min) / denominator) * height;
-    const command = `${segmentOpen ? 'L' : 'M'}${x.toFixed(2)},${y.toFixed(2)}`;
-    segmentOpen = true;
-    return path ? `${path} ${command}` : command;
-  }, '');
-}
-
-function buildAreaPath(points: SeriesPoint[], height: number) {
-  if (points.length < 2) {
-    return '';
-  }
-
-  const line = points.map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(' ');
-  return `${line} L${points[points.length - 1].x.toFixed(2)},${height.toFixed(2)} L${points[0].x.toFixed(2)},${height.toFixed(2)} Z`;
-}
-
-function formatAxisLabel(value: number) {
-  return Number.isInteger(value) ? value.toString() : value.toFixed(0);
-}
-
-function formatMetricValue(value: number | null) {
-  return value === null ? '-' : value.toFixed(1);
-}
-
-function formatShortDate(date: string) {
-  const parsed = new Date(`${date}T00:00:00Z`);
-  return Number.isNaN(parsed.getTime())
-    ? date
-    : new Intl.DateTimeFormat('en-US', { month: 'short', day: '2-digit', timeZone: 'UTC' }).format(parsed);
-}
-
-function buildPositionedAxisLabels(values: number[], min: number, max: number) {
-  const range = Math.max(max - min, 1);
-  const seen = new Set<string>();
-
-  return values.flatMap((value) => {
-    if (value < min || value > max) {
-      return [];
-    }
-
-    const key = value.toFixed(3);
-    if (seen.has(key)) {
-      return [];
-    }
-    seen.add(key);
-
-    return [{
-      key,
-      label: formatAxisLabel(value),
-      top: clamp(((max - value) / range) * 100, 0, 100),
-    }];
-  });
-}
-
-function buildTimelineLabels(dates: string[]) {
-  if (dates.length === 0) {
-    return [] as Array<{ key: string; label: string }>;
-  }
-
-  const candidateIndexes = Array.from(new Set([
-    0,
-    Math.floor((dates.length - 1) * 0.33),
-    Math.floor((dates.length - 1) * 0.66),
-    dates.length - 1,
-  ]));
-
-  return candidateIndexes.map((index) => ({ key: `${dates[index]}-${index}`, label: formatShortDate(dates[index]) }));
-}
-
-function latestSeriesPoint(...seriesCollections: SeriesPoint[][]) {
-  return seriesCollections.flat().reduce<SeriesPoint | null>((latest, point) => {
-    if (!latest || point.index > latest.index) {
-      return point;
-    }
-
-    return latest;
-  }, null);
-}
-
-function seriesPointAtIndex(points: SeriesPoint[], index: number | null) {
-  if (index === null) {
-    return null;
-  }
-
-  return points.find((point) => point.index === index) ?? null;
-}
-
-function resolveHoveredIndex(event: MouseEvent<SVGSVGElement>, totalPoints: number) {
-  if (totalPoints === 0) {
-    return null;
-  }
-
-  if (totalPoints === 1) {
-    return 0;
-  }
-
-  const bounds = event.currentTarget.getBoundingClientRect();
-  if (bounds.width <= 0) {
-    return totalPoints - 1;
-  }
-
-  const ratio = clamp((event.clientX - bounds.left) / bounds.width, 0, 1);
-  return Math.round(ratio * (totalPoints - 1));
-}
-
 export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
+  const { i18n, t } = useTranslation();
+  const language = i18n.resolvedLanguage ?? i18n.language ?? 'en';
   const gradientId = useId().replace(/:/g, '');
   const [activeLoadIndex, setActiveLoadIndex] = useState<number | null>(null);
   const [activeTsbIndex, setActiveTsbIndex] = useState<number | null>(null);
@@ -172,7 +41,7 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
     loadMin + (loadMax - loadMin) / 3,
     loadMin,
   ], loadMin, loadMax);
-  const timelineLabels = buildTimelineLabels(report.points.map((point) => point.date));
+  const timelineLabels = buildTimelineLabels(report.points.map((point) => point.date), language);
   const tsbAxisLabels = buildPositionedAxisLabels([tsbMax, 0, -30, tsbMin], tsbMin, tsbMax);
   const ctlPoints = buildSeriesPoints(ctlValues, loadMin, loadMax, 100, 100);
   const atlPoints = buildSeriesPoints(atlValues, loadMin, loadMax, 100, 100);
@@ -182,6 +51,7 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
   const latestLoadSnapshot = latestLoadPoint ? report.points[latestLoadPoint.index] : null;
   const latestTsbSnapshot = latestTsbPoint ? report.points[latestTsbPoint.index] : null;
   const latestLoadMarkerColor = latestLoadSnapshot && latestLoadSnapshot.currentCtl === null ? '#ff7a45' : '#22d3ee';
+  const highlightedLoadSeriesLabel = latestLoadSnapshot && latestLoadSnapshot.currentCtl === null ? 'fatigue' : 'fitness';
   const hoveredLoadPoint = seriesPointAtIndex(ctlPoints, activeLoadIndex) ?? seriesPointAtIndex(atlPoints, activeLoadIndex);
   const hoveredTsbPoint = seriesPointAtIndex(tsbPoints, activeTsbIndex);
   const hoveredLoadSnapshot = activeLoadIndex === null ? null : report.points[activeLoadIndex] ?? null;
@@ -200,10 +70,64 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
   const optimalHeight = riskBoundary - freshnessBoundary;
   const riskHeight = 100 - riskBoundary;
   const tsbHasGap = tsbValues.some((value) => value === null);
+  const ctlLinePath = buildLinePath(ctlValues, loadMin, loadMax, 100, 100);
+  const atlLinePath = buildLinePath(atlValues, loadMin, loadMax, 100, 100);
+  const tsbLinePath = buildLinePath(tsbValues, tsbMin, tsbMax, 100, 100);
+  const tsbAreaPath = buildAreaPath(tsbPoints, 100);
+  const latestLoadSnapshotDate = latestLoadSnapshot ? formatShortDate(latestLoadSnapshot.date, language) : null;
+  const latestLoadSnapshotMetrics = latestLoadSnapshot
+    ? t('dashboard.charts.load.latestSnapshot.summary', {
+        ctl: formatMetricValue(latestLoadSnapshot.currentCtl, language),
+        atl: formatMetricValue(latestLoadSnapshot.currentAtl, language),
+      })
+    : null;
+  const hoveredLoadSnapshotDate = hoveredLoadSnapshot ? formatShortDate(hoveredLoadSnapshot.date, language) : null;
+  const hoveredLoadSnapshotMetrics = hoveredLoadSnapshot
+    ? t('dashboard.charts.load.tooltip.summary', {
+        ctl: formatMetricValue(hoveredLoadSnapshot.currentCtl, language),
+        atl: formatMetricValue(hoveredLoadSnapshot.currentAtl, language),
+      })
+    : null;
+  const latestTsbSnapshotDate = latestTsbSnapshot ? formatShortDate(latestTsbSnapshot.date, language) : null;
+  const latestTsbSnapshotValue = latestTsbSnapshot ? formatMetricValue(latestTsbSnapshot.currentTsb, language) : null;
+  const hoveredTsbSnapshotDate = hoveredTsbSnapshot ? formatShortDate(hoveredTsbSnapshot.date, language) : null;
+  const hoveredTsbSnapshotValue = hoveredTsbSnapshot ? formatMetricValue(hoveredTsbSnapshot.currentTsb, language) : null;
+  const timelineStartLabel = timelineLabels[0]?.label ?? t('dashboard.charts.shared.timeline.startFallback');
+  const timelineEndLabel = timelineLabels[timelineLabels.length - 1]?.label ?? t('dashboard.charts.shared.timeline.latestFallback');
+  const loadLatestSnapshotAria = latestLoadSnapshotDate && latestLoadSnapshot
+    ? t('dashboard.charts.load.aria.latestSnapshotAvailable', {
+        date: latestLoadSnapshotDate,
+        ctl: formatMetricValue(latestLoadSnapshot.currentCtl, language),
+        atl: formatMetricValue(latestLoadSnapshot.currentAtl, language),
+      })
+    : t('dashboard.charts.load.aria.latestSnapshotUnavailable');
+  const tsbLatestSnapshotAria = latestTsbSnapshotDate && latestTsbSnapshotValue
+    ? t('dashboard.charts.tsb.aria.latestSnapshotAvailable', {
+        date: latestTsbSnapshotDate,
+        tsb: latestTsbSnapshotValue,
+      })
+    : t('dashboard.charts.tsb.aria.latestSnapshotUnavailable');
+  const loadAriaLabel = t('dashboard.charts.load.aria.description', {
+    start: timelineStartLabel,
+    end: timelineEndLabel,
+    latestSnapshot: loadLatestSnapshotAria,
+    series: highlightedLoadSeriesLabel === 'fatigue'
+      ? t('dashboard.charts.load.aria.series.fatigue')
+      : t('dashboard.charts.load.aria.series.fitness'),
+  });
+  const tsbAriaLabel = t('dashboard.charts.tsb.aria.description', {
+    start: timelineStartLabel,
+    end: timelineEndLabel,
+    latestSnapshot: tsbLatestSnapshotAria,
+  });
 
   const handleLoadHover = (event: MouseEvent<SVGSVGElement>) => {
     const nextIndex = resolveHoveredIndex(event, report.points.length);
     setActiveLoadIndex((current) => current === nextIndex ? current : nextIndex);
+  };
+
+  const handleLoadLeave = () => {
+    setActiveLoadIndex(null);
   };
 
   const handleTsbHover = (event: MouseEvent<SVGSVGElement>) => {
@@ -211,181 +135,68 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
     setActiveTsbIndex((current) => current === nextIndex ? current : nextIndex);
   };
 
+  const handleTsbLeave = () => {
+    setActiveTsbIndex(null);
+  };
+
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
-        <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
-          <div className="flex flex-wrap gap-8">
-            <Metric label="Fitness (CTL)" value={report.summary.currentCtl} tone="cyan" />
-            <Metric label="Fatigue (ATL)" value={report.summary.currentAtl} tone="orange" />
-          </div>
-          {latestLoadSnapshot ? (
-            <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-right">
-              <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300/80">Latest snapshot</p>
-              <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(latestLoadSnapshot.date)}</p>
-              <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">
-                CTL {formatMetricValue(latestLoadSnapshot.currentCtl)} / ATL {formatMetricValue(latestLoadSnapshot.currentAtl)}
-              </p>
-            </div>
-          ) : null}
-        </div>
-        <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[linear-gradient(to_right,rgba(249,250,251,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.045)_1px,transparent_1px)] bg-[size:40px_40px] pl-12 pr-4 pt-4">
-          <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
-            {loadAxisLabels.map((label) => (
-              <span
-                key={label.key}
-                className="absolute left-0 -translate-y-1/2"
-                style={{ top: `${label.top}%` }}
-              >
-                {label.label}
-              </span>
-            ))}
-          </div>
-          <div className="relative h-full w-full">
-            {loadFocusPoint ? (
-              <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${loadFocusPoint.x}%` }}>
-                <div className="h-full w-px bg-lime-300/25" />
-              </div>
-            ) : null}
-            {hoveredLoadSnapshot && hoveredLoadPoint ? (
-              <div
-                className="pointer-events-none absolute z-20 w-48 -translate-x-1/2 rounded-2xl border border-white/12 bg-[#18212a]/92 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
-                style={{ left: `${clamp(hoveredLoadPoint.x, 20, 80)}%`, top: `${hoveredLoadTooltipTop}%` }}
-              >
-                <p className="text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200/80">Snapshot</p>
-                <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(hoveredLoadSnapshot.date)}</p>
-                <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">
-                  CTL {formatMetricValue(hoveredLoadSnapshot.currentCtl)} / ATL {formatMetricValue(hoveredLoadSnapshot.currentAtl)}
-                </p>
-              </div>
-            ) : null}
-            <svg
-              viewBox="0 0 100 100"
-              preserveAspectRatio="none"
-              className="relative h-full w-full"
-              role="img"
-              aria-label={`Fitness and fatigue chart from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest load snapshot ${latestLoadSnapshot ? `${formatShortDate(latestLoadSnapshot.date)} with CTL ${formatMetricValue(latestLoadSnapshot.currentCtl)} and ATL ${formatMetricValue(latestLoadSnapshot.currentAtl)}` : 'is unavailable'}. The highlighted dot follows ${latestLoadSnapshot && latestLoadSnapshot.currentCtl === null ? 'fatigue' : 'fitness'} because that is the latest available load series point.`}
-              onMouseEnter={handleLoadHover}
-              onMouseMove={handleLoadHover}
-              onMouseLeave={() => setActiveLoadIndex(null)}
-            >
-              <path d={buildLinePath(atlValues, loadMin, loadMax, 100, 100)} fill="none" stroke="#ff7a45" strokeWidth="0.5" strokeLinecap="round" />
-              <path d={buildLinePath(ctlValues, loadMin, loadMax, 100, 100)} fill="none" stroke="#22d3ee" strokeWidth="0.5" strokeLinecap="round" />
-              {loadFocusPoint ? <circle cx={loadFocusPoint.x} cy={loadFocusPoint.y} r="0.6" fill={loadFocusMarkerColor} /> : null}
-            </svg>
-          </div>
-        </div>
-        <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
-          {timelineLabels.map((label, index) => (
-            <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
-          ))}
-        </div>
-      </section>
+      <TrainingLoadLoadChart
+        axisLabels={loadAxisLabels}
+        timelineLabels={timelineLabels}
+        ariaLabel={loadAriaLabel}
+        currentCtl={formatMetricValue(report.summary.currentCtl, language)}
+        currentAtl={formatMetricValue(report.summary.currentAtl, language)}
+        latestSnapshotDate={latestLoadSnapshotDate}
+        latestSnapshotMetrics={latestLoadSnapshotMetrics}
+        hoveredSnapshotDate={hoveredLoadSnapshotDate}
+        hoveredSnapshotMetrics={hoveredLoadSnapshotMetrics}
+        focusPoint={loadFocusPoint}
+        hoveredPoint={hoveredLoadPoint}
+        hoveredTooltipTop={hoveredLoadTooltipTop}
+        focusMarkerColor={loadFocusMarkerColor}
+        ctlLinePath={ctlLinePath}
+        atlLinePath={atlLinePath}
+        onHover={handleLoadHover}
+        onLeave={handleLoadLeave}
+        strings={{
+          fitnessLabel: t('dashboard.charts.load.metrics.fitness'),
+          fatigueLabel: t('dashboard.charts.load.metrics.fatigue'),
+          latestSnapshotLabel: t('dashboard.charts.load.latestSnapshot.eyebrow'),
+          snapshotLabel: t('dashboard.charts.load.tooltip.eyebrow'),
+        }}
+      />
 
-      <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
-        <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
-          <Metric label="Form (TSB)" value={report.summary.currentTsb} tone="lime" />
-          <div className="flex flex-wrap gap-4 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">
-            <LegendDot label="Freshness / Peak" tone="cyan" />
-            <LegendDot label="Optimal Training" tone="lime" />
-            <LegendDot label="High Risk" tone="red" />
-          </div>
-        </div>
-        <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[#0b1117] pl-12 pr-4 pt-4">
-          <div className="absolute inset-0 flex flex-col">
-            <div className="relative border-b border-cyan-300/10 bg-cyan-300/6" style={{ height: `${freshnessHeight}%` }}>
-              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-cyan-300/45">Freshness / Peak</span>
-            </div>
-            <div className="relative border-b border-lime-300/10 bg-lime-300/6" style={{ height: `${optimalHeight}%` }}>
-              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-lime-300/45">Optimal Training</span>
-            </div>
-            <div className="relative bg-red-400/6" style={{ height: `${riskHeight}%` }}>
-              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-red-300/45">High Risk</span>
-            </div>
-          </div>
-          <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(249,250,251,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.04)_1px,transparent_1px)] bg-[size:40px_40px]" />
-          <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
-            {tsbAxisLabels.map((label) => (
-              <span
-                key={label.key}
-                className="absolute left-0 -translate-y-1/2"
-                style={{ top: `${label.top}%` }}
-              >
-                {label.label}
-              </span>
-            ))}
-          </div>
-          <div className="relative h-full w-full">
-            {tsbFocusPoint ? (
-              <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${tsbFocusPoint.x}%` }}>
-                <div className="h-full w-px bg-lime-300/30" />
-              </div>
-            ) : null}
-            <svg
-              viewBox="0 0 100 100"
-              preserveAspectRatio="none"
-              className="relative h-full w-full"
-              role="img"
-              aria-label={`Form chart with freshness, optimal training, and high risk zones from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest TSB snapshot ${latestTsbSnapshot ? `${formatShortDate(latestTsbSnapshot.date)} with TSB ${formatMetricValue(latestTsbSnapshot.currentTsb)}` : 'is unavailable'}.`}
-              onMouseEnter={handleTsbHover}
-              onMouseMove={handleTsbHover}
-              onMouseLeave={() => setActiveTsbIndex(null)}
-            >
-              <defs>
-                <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="0%" stopColor="#bef264" stopOpacity="0.26" />
-                  <stop offset="100%" stopColor="#bef264" stopOpacity="0" />
-                </linearGradient>
-              </defs>
-              {!tsbHasGap ? <path d={buildAreaPath(tsbPoints, 100)} fill={`url(#${gradientId})`} /> : null}
-              <path d={buildLinePath(tsbValues, tsbMin, tsbMax, 100, 100)} fill="none" stroke="#bef264" strokeWidth="0.5" strokeLinecap="round" />
-              {tsbFocusPoint ? <circle cx={tsbFocusPoint.x} cy={tsbFocusPoint.y} r="0.6" fill="#d9f99d" /> : null}
-            </svg>
-            {hoveredTsbSnapshot && hoveredTsbPoint ? (
-              <div
-                className="pointer-events-none absolute z-20 w-44 -translate-x-1/2 rounded-2xl border border-lime-300/20 bg-[#1a232c]/90 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
-                style={{ left: `${clamp(hoveredTsbPoint.x, 18, 82)}%`, top: `${hoveredTsbTooltipTop}%` }}
-              >
-                <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300">Latest snapshot</p>
-                <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(hoveredTsbSnapshot.date)}</p>
-                <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">Form (TSB)</p>
-                <p className="mt-1 text-lg font-black text-lime-200">{formatMetricValue(hoveredTsbSnapshot.currentTsb)}</p>
-              </div>
-            ) : null}
-          </div>
-        </div>
-        <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
-          {timelineLabels.map((label, index) => (
-            <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function LegendDot({ label, tone }: { label: string; tone: 'cyan' | 'lime' | 'red' }) {
-  const toneClass = tone === 'cyan' ? 'bg-cyan-300/40' : tone === 'lime' ? 'bg-lime-300/35' : 'bg-red-300/35';
-
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span className={`h-2.5 w-2.5 rounded-full ${toneClass}`} />
-      <span>{label}</span>
-    </span>
-  );
-}
-
-function Metric({ label, value, tone }: { label: string; value: number | null; tone: 'cyan' | 'orange' | 'lime' }) {
-  const toneClass = tone === 'cyan' ? 'bg-cyan-300' : tone === 'orange' ? 'bg-orange-400' : 'bg-lime-300';
-  const valueClass = tone === 'lime' ? 'text-lime-200' : 'text-white';
-
-  return (
-    <div className="flex items-center gap-3">
-      <div className={`h-1.5 w-12 rounded-full ${toneClass}`} />
-      <div>
-        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">{label}</p>
-        <p className={`text-[2rem] font-black leading-none ${valueClass}`}>{value ?? '-'}</p>
-      </div>
+      <TrainingLoadTsbChart
+        axisLabels={tsbAxisLabels}
+        timelineLabels={timelineLabels}
+        ariaLabel={tsbAriaLabel}
+        currentTsb={formatMetricValue(report.summary.currentTsb, language)}
+        latestSnapshotDate={latestTsbSnapshotDate}
+        latestSnapshotValue={latestTsbSnapshotValue}
+        hoveredSnapshotDate={hoveredTsbSnapshotDate}
+        hoveredSnapshotValue={hoveredTsbSnapshotValue}
+        focusPoint={tsbFocusPoint}
+        hoveredPoint={hoveredTsbPoint}
+        hoveredTooltipTop={hoveredTsbTooltipTop}
+        linePath={tsbLinePath}
+        areaPath={tsbAreaPath}
+        showArea={!tsbHasGap}
+        gradientId={gradientId}
+        freshnessHeight={freshnessHeight}
+        optimalHeight={optimalHeight}
+        riskHeight={riskHeight}
+        onHover={handleTsbHover}
+        onLeave={handleTsbLeave}
+        strings={{
+          formLabel: t('dashboard.charts.tsb.metric'),
+          freshnessPeakLabel: t('dashboard.charts.tsb.legend.freshnessPeak'),
+          optimalTrainingLabel: t('dashboard.charts.tsb.legend.optimalTraining'),
+          highRiskLabel: t('dashboard.charts.tsb.legend.highRisk'),
+          latestSnapshotLabel: t('dashboard.charts.tsb.latestSnapshot.eyebrow'),
+          snapshotLabel: t('dashboard.charts.tsb.tooltip.eyebrow'),
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
@@ -181,14 +181,16 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
   const latestTsbPoint = latestSeriesPoint(tsbPoints);
   const latestLoadSnapshot = latestLoadPoint ? report.points[latestLoadPoint.index] : null;
   const latestTsbSnapshot = latestTsbPoint ? report.points[latestTsbPoint.index] : null;
-  const latestLoadMarkerColor = latestLoadSnapshot?.currentCtl !== null ? '#22d3ee' : '#ff7a45';
+  const latestLoadMarkerColor = latestLoadSnapshot && latestLoadSnapshot.currentCtl === null ? '#ff7a45' : '#22d3ee';
   const hoveredLoadPoint = seriesPointAtIndex(ctlPoints, activeLoadIndex) ?? seriesPointAtIndex(atlPoints, activeLoadIndex);
   const hoveredTsbPoint = seriesPointAtIndex(tsbPoints, activeTsbIndex);
   const hoveredLoadSnapshot = activeLoadIndex === null ? null : report.points[activeLoadIndex] ?? null;
   const hoveredTsbSnapshot = activeTsbIndex === null ? null : report.points[activeTsbIndex] ?? null;
   const loadFocusPoint = hoveredLoadPoint ?? latestLoadPoint;
   const tsbFocusPoint = hoveredTsbPoint ?? latestTsbPoint;
-  const loadFocusMarkerColor = hoveredLoadSnapshot?.currentCtl !== null ? '#22d3ee' : latestLoadMarkerColor;
+  const loadFocusMarkerColor = hoveredLoadSnapshot
+    ? (hoveredLoadSnapshot.currentCtl === null ? '#ff7a45' : '#22d3ee')
+    : latestLoadMarkerColor;
   const hoveredLoadTooltipTop = hoveredLoadPoint ? clamp(hoveredLoadPoint.y - 20, 7, 60) : 7;
   const hoveredTsbTooltipTop = hoveredTsbPoint ? clamp(hoveredTsbPoint.y - 18, 7, 62) : 7;
   const tsbRange = Math.max(tsbMax - tsbMin, 1);
@@ -262,7 +264,7 @@ export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
               preserveAspectRatio="none"
               className="relative h-full w-full"
               role="img"
-              aria-label={`Fitness and fatigue chart from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest load snapshot ${latestLoadSnapshot ? `${formatShortDate(latestLoadSnapshot.date)} with CTL ${formatMetricValue(latestLoadSnapshot.currentCtl)} and ATL ${formatMetricValue(latestLoadSnapshot.currentAtl)}` : 'is unavailable'}. The highlighted dot follows ${latestLoadSnapshot?.currentCtl !== null ? 'fitness' : 'fatigue'} because that is the latest available load series point.`}
+              aria-label={`Fitness and fatigue chart from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest load snapshot ${latestLoadSnapshot ? `${formatShortDate(latestLoadSnapshot.date)} with CTL ${formatMetricValue(latestLoadSnapshot.currentCtl)} and ATL ${formatMetricValue(latestLoadSnapshot.currentAtl)}` : 'is unavailable'}. The highlighted dot follows ${latestLoadSnapshot && latestLoadSnapshot.currentCtl === null ? 'fatigue' : 'fitness'} because that is the latest available load series point.`}
               onMouseEnter={handleLoadHover}
               onMouseMove={handleLoadHover}
               onMouseLeave={() => setActiveLoadIndex(null)}

--- a/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadCharts.tsx
@@ -1,0 +1,389 @@
+import { useId, useState, type MouseEvent } from 'react';
+
+import type { TrainingLoadDashboardResponse } from '../types';
+
+type TrainingLoadChartsProps = {
+  report: TrainingLoadDashboardResponse;
+};
+
+type SeriesPoint = {
+  index: number;
+  value: number;
+  x: number;
+  y: number;
+};
+
+const CHART_X_INSET = 2;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function buildPointX(index: number, total: number, width: number) {
+  return total === 1 ? width / 2 : CHART_X_INSET + (index / (total - 1)) * (width - (CHART_X_INSET * 2));
+}
+
+function buildSeriesPoints(values: Array<number | null>, min: number, max: number, height: number, width: number): SeriesPoint[] {
+  const denominator = Math.max(max - min, 1);
+
+  return values.flatMap((value, index) => {
+    if (value === null) {
+      return [];
+    }
+
+    const x = buildPointX(index, values.length, width);
+    const y = height - ((value - min) / denominator) * height;
+    return [{ index, value, x, y }];
+  });
+}
+
+function buildLinePath(values: Array<number | null>, min: number, max: number, height: number, width: number) {
+  const denominator = Math.max(max - min, 1);
+  let segmentOpen = false;
+
+  return values.reduce((path, value, index) => {
+    if (value === null) {
+      segmentOpen = false;
+      return path;
+    }
+
+    const x = buildPointX(index, values.length, width);
+    const y = height - ((value - min) / denominator) * height;
+    const command = `${segmentOpen ? 'L' : 'M'}${x.toFixed(2)},${y.toFixed(2)}`;
+    segmentOpen = true;
+    return path ? `${path} ${command}` : command;
+  }, '');
+}
+
+function buildAreaPath(points: SeriesPoint[], height: number) {
+  if (points.length < 2) {
+    return '';
+  }
+
+  const line = points.map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(' ');
+  return `${line} L${points[points.length - 1].x.toFixed(2)},${height.toFixed(2)} L${points[0].x.toFixed(2)},${height.toFixed(2)} Z`;
+}
+
+function formatAxisLabel(value: number) {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(0);
+}
+
+function formatMetricValue(value: number | null) {
+  return value === null ? '-' : value.toFixed(1);
+}
+
+function formatShortDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime())
+    ? date
+    : new Intl.DateTimeFormat('en-US', { month: 'short', day: '2-digit', timeZone: 'UTC' }).format(parsed);
+}
+
+function buildPositionedAxisLabels(values: number[], min: number, max: number) {
+  const range = Math.max(max - min, 1);
+  const seen = new Set<string>();
+
+  return values.flatMap((value) => {
+    if (value < min || value > max) {
+      return [];
+    }
+
+    const key = value.toFixed(3);
+    if (seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+
+    return [{
+      key,
+      label: formatAxisLabel(value),
+      top: clamp(((max - value) / range) * 100, 0, 100),
+    }];
+  });
+}
+
+function buildTimelineLabels(dates: string[]) {
+  if (dates.length === 0) {
+    return [] as Array<{ key: string; label: string }>;
+  }
+
+  const candidateIndexes = Array.from(new Set([
+    0,
+    Math.floor((dates.length - 1) * 0.33),
+    Math.floor((dates.length - 1) * 0.66),
+    dates.length - 1,
+  ]));
+
+  return candidateIndexes.map((index) => ({ key: `${dates[index]}-${index}`, label: formatShortDate(dates[index]) }));
+}
+
+function latestSeriesPoint(...seriesCollections: SeriesPoint[][]) {
+  return seriesCollections.flat().reduce<SeriesPoint | null>((latest, point) => {
+    if (!latest || point.index > latest.index) {
+      return point;
+    }
+
+    return latest;
+  }, null);
+}
+
+function seriesPointAtIndex(points: SeriesPoint[], index: number | null) {
+  if (index === null) {
+    return null;
+  }
+
+  return points.find((point) => point.index === index) ?? null;
+}
+
+function resolveHoveredIndex(event: MouseEvent<SVGSVGElement>, totalPoints: number) {
+  if (totalPoints === 0) {
+    return null;
+  }
+
+  if (totalPoints === 1) {
+    return 0;
+  }
+
+  const bounds = event.currentTarget.getBoundingClientRect();
+  if (bounds.width <= 0) {
+    return totalPoints - 1;
+  }
+
+  const ratio = clamp((event.clientX - bounds.left) / bounds.width, 0, 1);
+  return Math.round(ratio * (totalPoints - 1));
+}
+
+export function TrainingLoadCharts({ report }: TrainingLoadChartsProps) {
+  const gradientId = useId().replace(/:/g, '');
+  const [activeLoadIndex, setActiveLoadIndex] = useState<number | null>(null);
+  const [activeTsbIndex, setActiveTsbIndex] = useState<number | null>(null);
+  const ctlValues = report.points.map((point) => point.currentCtl);
+  const atlValues = report.points.map((point) => point.currentAtl);
+  const tsbValues = report.points.map((point) => point.currentTsb);
+  const loadNumbers = [...ctlValues, ...atlValues].filter((value): value is number => value !== null);
+  const tsbNumbers = tsbValues.filter((value): value is number => value !== null);
+  const loadMin = Math.min(...loadNumbers, 0);
+  const loadMax = Math.max(...loadNumbers, 100);
+  const tsbMin = Math.min(...tsbNumbers, -60);
+  const tsbMax = Math.max(...tsbNumbers, 40);
+  const loadAxisLabels = buildPositionedAxisLabels([
+    loadMax,
+    loadMin + ((loadMax - loadMin) * 2) / 3,
+    loadMin + (loadMax - loadMin) / 3,
+    loadMin,
+  ], loadMin, loadMax);
+  const timelineLabels = buildTimelineLabels(report.points.map((point) => point.date));
+  const tsbAxisLabels = buildPositionedAxisLabels([tsbMax, 0, -30, tsbMin], tsbMin, tsbMax);
+  const ctlPoints = buildSeriesPoints(ctlValues, loadMin, loadMax, 100, 100);
+  const atlPoints = buildSeriesPoints(atlValues, loadMin, loadMax, 100, 100);
+  const tsbPoints = buildSeriesPoints(tsbValues, tsbMin, tsbMax, 100, 100);
+  const latestLoadPoint = latestSeriesPoint(ctlPoints, atlPoints);
+  const latestTsbPoint = latestSeriesPoint(tsbPoints);
+  const latestLoadSnapshot = latestLoadPoint ? report.points[latestLoadPoint.index] : null;
+  const latestTsbSnapshot = latestTsbPoint ? report.points[latestTsbPoint.index] : null;
+  const latestLoadMarkerColor = latestLoadSnapshot?.currentCtl !== null ? '#22d3ee' : '#ff7a45';
+  const hoveredLoadPoint = seriesPointAtIndex(ctlPoints, activeLoadIndex) ?? seriesPointAtIndex(atlPoints, activeLoadIndex);
+  const hoveredTsbPoint = seriesPointAtIndex(tsbPoints, activeTsbIndex);
+  const hoveredLoadSnapshot = activeLoadIndex === null ? null : report.points[activeLoadIndex] ?? null;
+  const hoveredTsbSnapshot = activeTsbIndex === null ? null : report.points[activeTsbIndex] ?? null;
+  const loadFocusPoint = hoveredLoadPoint ?? latestLoadPoint;
+  const tsbFocusPoint = hoveredTsbPoint ?? latestTsbPoint;
+  const loadFocusMarkerColor = hoveredLoadSnapshot?.currentCtl !== null ? '#22d3ee' : latestLoadMarkerColor;
+  const hoveredLoadTooltipTop = hoveredLoadPoint ? clamp(hoveredLoadPoint.y - 20, 7, 60) : 7;
+  const hoveredTsbTooltipTop = hoveredTsbPoint ? clamp(hoveredTsbPoint.y - 18, 7, 62) : 7;
+  const tsbRange = Math.max(tsbMax - tsbMin, 1);
+  const freshnessBoundary = clamp(((tsbMax - clamp(0, tsbMin, tsbMax)) / tsbRange) * 100, 0, 100);
+  const riskBoundary = clamp(((tsbMax - clamp(-30, tsbMin, tsbMax)) / tsbRange) * 100, freshnessBoundary, 100);
+  const freshnessHeight = freshnessBoundary;
+  const optimalHeight = riskBoundary - freshnessBoundary;
+  const riskHeight = 100 - riskBoundary;
+  const tsbHasGap = tsbValues.some((value) => value === null);
+
+  const handleLoadHover = (event: MouseEvent<SVGSVGElement>) => {
+    const nextIndex = resolveHoveredIndex(event, report.points.length);
+    setActiveLoadIndex((current) => current === nextIndex ? current : nextIndex);
+  };
+
+  const handleTsbHover = (event: MouseEvent<SVGSVGElement>) => {
+    const nextIndex = resolveHoveredIndex(event, report.points.length);
+    setActiveTsbIndex((current) => current === nextIndex ? current : nextIndex);
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
+          <div className="flex flex-wrap gap-8">
+            <Metric label="Fitness (CTL)" value={report.summary.currentCtl} tone="cyan" />
+            <Metric label="Fatigue (ATL)" value={report.summary.currentAtl} tone="orange" />
+          </div>
+          {latestLoadSnapshot ? (
+            <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-right">
+              <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300/80">Latest snapshot</p>
+              <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(latestLoadSnapshot.date)}</p>
+              <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">
+                CTL {formatMetricValue(latestLoadSnapshot.currentCtl)} / ATL {formatMetricValue(latestLoadSnapshot.currentAtl)}
+              </p>
+            </div>
+          ) : null}
+        </div>
+        <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[linear-gradient(to_right,rgba(249,250,251,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.045)_1px,transparent_1px)] bg-[size:40px_40px] pl-12 pr-4 pt-4">
+          <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+            {loadAxisLabels.map((label) => (
+              <span
+                key={label.key}
+                className="absolute left-0 -translate-y-1/2"
+                style={{ top: `${label.top}%` }}
+              >
+                {label.label}
+              </span>
+            ))}
+          </div>
+          <div className="relative h-full w-full">
+            {loadFocusPoint ? (
+              <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${loadFocusPoint.x}%` }}>
+                <div className="h-full w-px bg-lime-300/25" />
+              </div>
+            ) : null}
+            {hoveredLoadSnapshot && hoveredLoadPoint ? (
+              <div
+                className="pointer-events-none absolute z-20 w-48 -translate-x-1/2 rounded-2xl border border-white/12 bg-[#18212a]/92 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
+                style={{ left: `${clamp(hoveredLoadPoint.x, 20, 80)}%`, top: `${hoveredLoadTooltipTop}%` }}
+              >
+                <p className="text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200/80">Snapshot</p>
+                <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(hoveredLoadSnapshot.date)}</p>
+                <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">
+                  CTL {formatMetricValue(hoveredLoadSnapshot.currentCtl)} / ATL {formatMetricValue(hoveredLoadSnapshot.currentAtl)}
+                </p>
+              </div>
+            ) : null}
+            <svg
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+              className="relative h-full w-full"
+              role="img"
+              aria-label={`Fitness and fatigue chart from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest load snapshot ${latestLoadSnapshot ? `${formatShortDate(latestLoadSnapshot.date)} with CTL ${formatMetricValue(latestLoadSnapshot.currentCtl)} and ATL ${formatMetricValue(latestLoadSnapshot.currentAtl)}` : 'is unavailable'}. The highlighted dot follows ${latestLoadSnapshot?.currentCtl !== null ? 'fitness' : 'fatigue'} because that is the latest available load series point.`}
+              onMouseEnter={handleLoadHover}
+              onMouseMove={handleLoadHover}
+              onMouseLeave={() => setActiveLoadIndex(null)}
+            >
+              <path d={buildLinePath(atlValues, loadMin, loadMax, 100, 100)} fill="none" stroke="#ff7a45" strokeWidth="0.5" strokeLinecap="round" />
+              <path d={buildLinePath(ctlValues, loadMin, loadMax, 100, 100)} fill="none" stroke="#22d3ee" strokeWidth="0.5" strokeLinecap="round" />
+              {loadFocusPoint ? <circle cx={loadFocusPoint.x} cy={loadFocusPoint.y} r="0.6" fill={loadFocusMarkerColor} /> : null}
+            </svg>
+          </div>
+        </div>
+        <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+          {timelineLabels.map((label, index) => (
+            <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
+          <Metric label="Form (TSB)" value={report.summary.currentTsb} tone="lime" />
+          <div className="flex flex-wrap gap-4 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">
+            <LegendDot label="Freshness / Peak" tone="cyan" />
+            <LegendDot label="Optimal Training" tone="lime" />
+            <LegendDot label="High Risk" tone="red" />
+          </div>
+        </div>
+        <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[#0b1117] pl-12 pr-4 pt-4">
+          <div className="absolute inset-0 flex flex-col">
+            <div className="relative border-b border-cyan-300/10 bg-cyan-300/6" style={{ height: `${freshnessHeight}%` }}>
+              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-cyan-300/45">Freshness / Peak</span>
+            </div>
+            <div className="relative border-b border-lime-300/10 bg-lime-300/6" style={{ height: `${optimalHeight}%` }}>
+              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-lime-300/45">Optimal Training</span>
+            </div>
+            <div className="relative bg-red-400/6" style={{ height: `${riskHeight}%` }}>
+              <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-red-300/45">High Risk</span>
+            </div>
+          </div>
+          <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(249,250,251,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.04)_1px,transparent_1px)] bg-[size:40px_40px]" />
+          <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+            {tsbAxisLabels.map((label) => (
+              <span
+                key={label.key}
+                className="absolute left-0 -translate-y-1/2"
+                style={{ top: `${label.top}%` }}
+              >
+                {label.label}
+              </span>
+            ))}
+          </div>
+          <div className="relative h-full w-full">
+            {tsbFocusPoint ? (
+              <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${tsbFocusPoint.x}%` }}>
+                <div className="h-full w-px bg-lime-300/30" />
+              </div>
+            ) : null}
+            <svg
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+              className="relative h-full w-full"
+              role="img"
+              aria-label={`Form chart with freshness, optimal training, and high risk zones from ${timelineLabels[0]?.label ?? 'start'} to ${timelineLabels[timelineLabels.length - 1]?.label ?? 'latest'}. Latest TSB snapshot ${latestTsbSnapshot ? `${formatShortDate(latestTsbSnapshot.date)} with TSB ${formatMetricValue(latestTsbSnapshot.currentTsb)}` : 'is unavailable'}.`}
+              onMouseEnter={handleTsbHover}
+              onMouseMove={handleTsbHover}
+              onMouseLeave={() => setActiveTsbIndex(null)}
+            >
+              <defs>
+                <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor="#bef264" stopOpacity="0.26" />
+                  <stop offset="100%" stopColor="#bef264" stopOpacity="0" />
+                </linearGradient>
+              </defs>
+              {!tsbHasGap ? <path d={buildAreaPath(tsbPoints, 100)} fill={`url(#${gradientId})`} /> : null}
+              <path d={buildLinePath(tsbValues, tsbMin, tsbMax, 100, 100)} fill="none" stroke="#bef264" strokeWidth="0.5" strokeLinecap="round" />
+              {tsbFocusPoint ? <circle cx={tsbFocusPoint.x} cy={tsbFocusPoint.y} r="0.6" fill="#d9f99d" /> : null}
+            </svg>
+            {hoveredTsbSnapshot && hoveredTsbPoint ? (
+              <div
+                className="pointer-events-none absolute z-20 w-44 -translate-x-1/2 rounded-2xl border border-lime-300/20 bg-[#1a232c]/90 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
+                style={{ left: `${clamp(hoveredTsbPoint.x, 18, 82)}%`, top: `${hoveredTsbTooltipTop}%` }}
+              >
+                <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300">Latest snapshot</p>
+                <p className="mt-2 text-sm font-semibold text-white">{formatShortDate(hoveredTsbSnapshot.date)}</p>
+                <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">Form (TSB)</p>
+                <p className="mt-1 text-lg font-black text-lime-200">{formatMetricValue(hoveredTsbSnapshot.currentTsb)}</p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+          {timelineLabels.map((label, index) => (
+            <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LegendDot({ label, tone }: { label: string; tone: 'cyan' | 'lime' | 'red' }) {
+  const toneClass = tone === 'cyan' ? 'bg-cyan-300/40' : tone === 'lime' ? 'bg-lime-300/35' : 'bg-red-300/35';
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className={`h-2.5 w-2.5 rounded-full ${toneClass}`} />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: number | null; tone: 'cyan' | 'orange' | 'lime' }) {
+  const toneClass = tone === 'cyan' ? 'bg-cyan-300' : tone === 'orange' ? 'bg-orange-400' : 'bg-lime-300';
+  const valueClass = tone === 'lime' ? 'text-lime-200' : 'text-white';
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className={`h-1.5 w-12 rounded-full ${toneClass}`} />
+      <div>
+        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">{label}</p>
+        <p className={`text-[2rem] font-black leading-none ${valueClass}`}>{value ?? '-'}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadEmptyState.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadEmptyState.tsx
@@ -1,0 +1,12 @@
+export function TrainingLoadEmptyState() {
+  return (
+    <section className="rounded-[2rem] border border-dashed border-white/10 bg-[#0d141f] p-10 text-center shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">Dashboard</p>
+      <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white">Training load will appear here</h2>
+      <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-slate-400">
+        Once completed workouts and daily snapshots are available, this dashboard will show CTL, ATL,
+        TSB and the trend of your recent load.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadEmptyState.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadEmptyState.tsx
@@ -1,11 +1,14 @@
+import { useTranslation } from 'react-i18next';
+
 export function TrainingLoadEmptyState() {
+  const { t } = useTranslation();
+
   return (
     <section className="rounded-[2rem] border border-dashed border-white/10 bg-[#0d141f] p-10 text-center shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">Dashboard</p>
-      <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white">Training load will appear here</h2>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">{t('dashboard.empty.eyebrow')}</p>
+      <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white">{t('dashboard.empty.title')}</h2>
       <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-slate-400">
-        Once completed workouts and daily snapshots are available, this dashboard will show CTL, ATL,
-        TSB and the trend of your recent load.
+        {t('dashboard.empty.description')}
       </p>
     </section>
   );

--- a/frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx
@@ -1,0 +1,85 @@
+import type { TrainingLoadDashboardResponse } from '../types';
+
+type TrainingLoadInsightCardProps = {
+  report: TrainingLoadDashboardResponse;
+};
+
+function formatWindowDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime())
+    ? date
+    : new Intl.DateTimeFormat('en-US', { month: 'short', day: '2-digit', year: 'numeric', timeZone: 'UTC' }).format(parsed);
+}
+
+export function TrainingLoadInsightCard({ report }: TrainingLoadInsightCardProps) {
+  const delta = report.summary.loadDeltaCtl14d;
+  const zone = report.summary.tsbZone;
+  const headline = zone === 'freshness_peak'
+    ? 'Trending towards peak'
+    : zone === 'high_risk'
+      ? 'Fatigue is accumulating'
+      : 'Productive load block';
+  const detail = delta === null
+    ? 'Not enough history yet to compare the current load trend with the last two weeks.'
+    : `CTL changed by ${delta > 0 ? '+' : ''}${delta.toFixed(1)} over the last 14 days while TSB sits at ${report.summary.currentTsb ?? '-'}. Keep translating this load into adaptation without reintroducing unnecessary fatigue.`;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.4)]">
+        <div className="flex items-center gap-4">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-lime-300/10 text-lime-200" aria-hidden="true">
+            <span className="text-lg font-black">i</span>
+          </div>
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-slate-500">Form Breakdown</p>
+            <h3 className="mt-1 text-2xl font-black tracking-tight text-white">Understanding Form (TSB)</h3>
+          </div>
+        </div>
+
+        <p className="mt-5 text-sm leading-7 text-slate-300">
+          Training Stress Balance is the relationship between <span className="font-bold text-cyan-300">Fitness (CTL)</span> and <span className="font-bold text-orange-300">Fatigue (ATL)</span>.
+          It helps frame whether you are carrying useful training load, approaching peak freshness, or drifting into excessive risk.
+        </p>
+
+        <div className="mt-7 grid gap-4 md:grid-cols-3">
+          <ZoneCard title="Freshness / Peak" tone="cyan" detail="Positive TSB. Fatigue has dropped while fitness is still present, so readiness is improving." />
+          <ZoneCard title="Optimal Training" tone="lime" detail="TSB sits in the productive band where adaptation is possible without excessive cost." />
+          <ZoneCard title="High Risk" tone="red" detail="TSB is too negative. Load may be outpacing recovery, which raises overreaching risk." />
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-lime-300/12 bg-[radial-gradient(circle_at_top,rgba(190,242,100,0.14),transparent_45%),#0f151b] p-7 shadow-[0_24px_70px_rgba(8,47,73,0.32)]">
+        <p className="text-[11px] font-black uppercase tracking-[0.24em] text-lime-300">Coach Insight</p>
+        <h3 className="mt-3 text-3xl font-black tracking-tight text-white">{headline}</h3>
+        <p className="mt-4 text-sm leading-7 text-slate-300">{detail}</p>
+        <dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
+          <Metric label="FTP" value={report.summary.ftpWatts !== null ? `${report.summary.ftpWatts} W` : '-'} />
+          <Metric label="IF 28d" value={report.summary.averageIf28d !== null ? report.summary.averageIf28d.toFixed(2) : '-'} />
+          <Metric label="EF 28d" value={report.summary.averageEf28d !== null ? report.summary.averageEf28d.toFixed(2) : '-'} />
+          <Metric label="Window" value={`${formatWindowDate(report.windowStart)} to ${formatWindowDate(report.windowEnd)}`} />
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+function ZoneCard({ title, detail, tone }: { title: string; detail: string; tone: 'cyan' | 'lime' | 'red' }) {
+  const toneClass = tone === 'cyan' ? 'bg-cyan-300' : tone === 'lime' ? 'bg-lime-300' : 'bg-red-300';
+
+  return (
+    <div className="space-y-3 rounded-[1.4rem] border border-white/8 bg-white/[0.03] p-4">
+      <div className={`h-1.5 w-full rounded-full ${toneClass}`} />
+      <p className="text-sm font-black text-white">{title}</p>
+      <p className="text-xs leading-6 text-slate-400">{detail}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
+      <dt className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">{label}</dt>
+      <dd className="mt-2 text-base font-semibold text-white">{value}</dd>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadInsightCard.tsx
@@ -1,27 +1,28 @@
+import { Trans, useTranslation } from 'react-i18next';
+
 import type { TrainingLoadDashboardResponse } from '../types';
+import { formatMetricValue, formatSignedMetricValue, formatTwoDecimalValue, formatWattsValue, formatWindowDate } from './trainingLoadFormatters';
 
 type TrainingLoadInsightCardProps = {
   report: TrainingLoadDashboardResponse;
 };
 
-function formatWindowDate(date: string) {
-  const parsed = new Date(`${date}T00:00:00Z`);
-  return Number.isNaN(parsed.getTime())
-    ? date
-    : new Intl.DateTimeFormat('en-US', { month: 'short', day: '2-digit', year: 'numeric', timeZone: 'UTC' }).format(parsed);
-}
-
 export function TrainingLoadInsightCard({ report }: TrainingLoadInsightCardProps) {
+  const { i18n, t } = useTranslation();
+  const language = i18n.resolvedLanguage ?? i18n.language ?? 'en';
   const delta = report.summary.loadDeltaCtl14d;
   const zone = report.summary.tsbZone;
   const headline = zone === 'freshness_peak'
-    ? 'Trending towards peak'
+    ? t('dashboard.insights.coachInsight.headlines.freshnessPeak')
     : zone === 'high_risk'
-      ? 'Fatigue is accumulating'
-      : 'Productive load block';
+      ? t('dashboard.insights.coachInsight.headlines.highRisk')
+      : t('dashboard.insights.coachInsight.headlines.optimalTraining');
   const detail = delta === null
-    ? 'Not enough history yet to compare the current load trend with the last two weeks.'
-    : `CTL changed by ${delta > 0 ? '+' : ''}${delta.toFixed(1)} over the last 14 days while TSB sits at ${report.summary.currentTsb ?? '-'}. Keep translating this load into adaptation without reintroducing unnecessary fatigue.`;
+    ? t('dashboard.insights.coachInsight.details.insufficientHistory')
+    : t('dashboard.insights.coachInsight.details.trend', {
+        delta: formatSignedMetricValue(delta, language),
+        tsb: formatMetricValue(report.summary.currentTsb, language),
+      });
 
   return (
     <div className="space-y-6">
@@ -31,32 +32,55 @@ export function TrainingLoadInsightCard({ report }: TrainingLoadInsightCardProps
             <span className="text-lg font-black">i</span>
           </div>
           <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-slate-500">Form Breakdown</p>
-            <h3 className="mt-1 text-2xl font-black tracking-tight text-white">Understanding Form (TSB)</h3>
+            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-slate-500">{t('dashboard.insights.formBreakdown.eyebrow')}</p>
+            <h3 className="mt-1 text-2xl font-black tracking-tight text-white">{t('dashboard.insights.formBreakdown.title')}</h3>
           </div>
         </div>
 
         <p className="mt-5 text-sm leading-7 text-slate-300">
-          Training Stress Balance is the relationship between <span className="font-bold text-cyan-300">Fitness (CTL)</span> and <span className="font-bold text-orange-300">Fatigue (ATL)</span>.
-          It helps frame whether you are carrying useful training load, approaching peak freshness, or drifting into excessive risk.
+          <Trans
+            i18nKey="dashboard.insights.formBreakdown.description"
+            components={{
+              fitness: <span className="font-bold text-cyan-300" />,
+              fatigue: <span className="font-bold text-orange-300" />,
+            }}
+          />
         </p>
 
         <div className="mt-7 grid gap-4 md:grid-cols-3">
-          <ZoneCard title="Freshness / Peak" tone="cyan" detail="Positive TSB. Fatigue has dropped while fitness is still present, so readiness is improving." />
-          <ZoneCard title="Optimal Training" tone="lime" detail="TSB sits in the productive band where adaptation is possible without excessive cost." />
-          <ZoneCard title="High Risk" tone="red" detail="TSB is too negative. Load may be outpacing recovery, which raises overreaching risk." />
+          <ZoneCard
+            title={t('dashboard.insights.formBreakdown.zones.freshnessPeak.title')}
+            tone="cyan"
+            detail={t('dashboard.insights.formBreakdown.zones.freshnessPeak.detail')}
+          />
+          <ZoneCard
+            title={t('dashboard.insights.formBreakdown.zones.optimalTraining.title')}
+            tone="lime"
+            detail={t('dashboard.insights.formBreakdown.zones.optimalTraining.detail')}
+          />
+          <ZoneCard
+            title={t('dashboard.insights.formBreakdown.zones.highRisk.title')}
+            tone="red"
+            detail={t('dashboard.insights.formBreakdown.zones.highRisk.detail')}
+          />
         </div>
       </section>
 
       <section className="rounded-[2rem] border border-lime-300/12 bg-[radial-gradient(circle_at_top,rgba(190,242,100,0.14),transparent_45%),#0f151b] p-7 shadow-[0_24px_70px_rgba(8,47,73,0.32)]">
-        <p className="text-[11px] font-black uppercase tracking-[0.24em] text-lime-300">Coach Insight</p>
+        <p className="text-[11px] font-black uppercase tracking-[0.24em] text-lime-300">{t('dashboard.insights.coachInsight.eyebrow')}</p>
         <h3 className="mt-3 text-3xl font-black tracking-tight text-white">{headline}</h3>
         <p className="mt-4 text-sm leading-7 text-slate-300">{detail}</p>
         <dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
-          <Metric label="FTP" value={report.summary.ftpWatts !== null ? `${report.summary.ftpWatts} W` : '-'} />
-          <Metric label="IF 28d" value={report.summary.averageIf28d !== null ? report.summary.averageIf28d.toFixed(2) : '-'} />
-          <Metric label="EF 28d" value={report.summary.averageEf28d !== null ? report.summary.averageEf28d.toFixed(2) : '-'} />
-          <Metric label="Window" value={`${formatWindowDate(report.windowStart)} to ${formatWindowDate(report.windowEnd)}`} />
+          <Metric label={t('dashboard.insights.coachInsight.metrics.ftp')} value={formatWattsValue(report.summary.ftpWatts, language)} />
+          <Metric label={t('dashboard.insights.coachInsight.metrics.if28d')} value={formatTwoDecimalValue(report.summary.averageIf28d, language)} />
+          <Metric label={t('dashboard.insights.coachInsight.metrics.ef28d')} value={formatTwoDecimalValue(report.summary.averageEf28d, language)} />
+          <Metric
+            label={t('dashboard.insights.coachInsight.metrics.window')}
+            value={t('dashboard.insights.coachInsight.metrics.windowRange', {
+              start: formatWindowDate(report.windowStart, language),
+              end: formatWindowDate(report.windowEnd, language),
+            })}
+          />
         </dl>
       </section>
     </div>

--- a/frontend/src/features/dashboard/components/TrainingLoadLoadChart.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadLoadChart.tsx
@@ -1,0 +1,145 @@
+import type { MouseEvent } from 'react';
+
+type AxisLabel = {
+  key: string;
+  label: string;
+  top: number;
+};
+
+type TimelineLabel = {
+  key: string;
+  label: string;
+};
+
+type ChartPoint = {
+  x: number;
+  y: number;
+};
+
+type TrainingLoadLoadChartProps = {
+  axisLabels: AxisLabel[];
+  timelineLabels: TimelineLabel[];
+  ariaLabel: string;
+  currentCtl: string;
+  currentAtl: string;
+  latestSnapshotDate: string | null;
+  latestSnapshotMetrics: string | null;
+  hoveredSnapshotDate: string | null;
+  hoveredSnapshotMetrics: string | null;
+  focusPoint: ChartPoint | null;
+  hoveredPoint: ChartPoint | null;
+  hoveredTooltipTop: number;
+  focusMarkerColor: string;
+  ctlLinePath: string;
+  atlLinePath: string;
+  onHover: (event: MouseEvent<SVGSVGElement>) => void;
+  onLeave: () => void;
+  strings: {
+    fitnessLabel: string;
+    fatigueLabel: string;
+    latestSnapshotLabel: string;
+    snapshotLabel: string;
+  };
+};
+
+export function TrainingLoadLoadChart({
+  axisLabels,
+  timelineLabels,
+  ariaLabel,
+  currentCtl,
+  currentAtl,
+  latestSnapshotDate,
+  latestSnapshotMetrics,
+  hoveredSnapshotDate,
+  hoveredSnapshotMetrics,
+  focusPoint,
+  hoveredPoint,
+  hoveredTooltipTop,
+  focusMarkerColor,
+  ctlLinePath,
+  atlLinePath,
+  onHover,
+  onLeave,
+  strings,
+}: TrainingLoadLoadChartProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
+        <div className="flex flex-wrap gap-8">
+          <Metric label={strings.fitnessLabel} value={currentCtl} tone="cyan" />
+          <Metric label={strings.fatigueLabel} value={currentAtl} tone="orange" />
+        </div>
+        {latestSnapshotDate && latestSnapshotMetrics ? (
+          <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-right">
+            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300/80">{strings.latestSnapshotLabel}</p>
+            <p className="mt-2 text-sm font-semibold text-white">{latestSnapshotDate}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">{latestSnapshotMetrics}</p>
+          </div>
+        ) : null}
+      </div>
+      <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[linear-gradient(to_right,rgba(249,250,251,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.045)_1px,transparent_1px)] bg-[size:40px_40px] pl-12 pr-4 pt-4">
+        <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+          {axisLabels.map((label) => (
+            <span
+              key={label.key}
+              className="absolute left-0 -translate-y-1/2"
+              style={{ top: `${label.top}%` }}
+            >
+              {label.label}
+            </span>
+          ))}
+        </div>
+        <div className="relative h-full w-full">
+          {focusPoint ? (
+            <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${focusPoint.x}%` }}>
+              <div className="h-full w-px bg-lime-300/25" />
+            </div>
+          ) : null}
+          {hoveredSnapshotDate && hoveredSnapshotMetrics && hoveredPoint ? (
+            <div
+              className="pointer-events-none absolute z-20 w-48 -translate-x-1/2 rounded-2xl border border-white/12 bg-[#18212a]/92 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
+              style={{ left: `${Math.min(Math.max(hoveredPoint.x, 20), 80)}%`, top: `${hoveredTooltipTop}%` }}
+            >
+              <p className="text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200/80">{strings.snapshotLabel}</p>
+              <p className="mt-2 text-sm font-semibold text-white">{hoveredSnapshotDate}</p>
+              <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">{hoveredSnapshotMetrics}</p>
+            </div>
+          ) : null}
+          <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="relative h-full w-full"
+            role="img"
+            aria-label={ariaLabel}
+            onMouseEnter={onHover}
+            onMouseMove={onHover}
+            onMouseLeave={onLeave}
+          >
+            <path d={atlLinePath} fill="none" stroke="#ff7a45" strokeWidth="0.5" strokeLinecap="round" />
+            <path d={ctlLinePath} fill="none" stroke="#22d3ee" strokeWidth="0.5" strokeLinecap="round" />
+            {focusPoint ? <circle cx={focusPoint.x} cy={focusPoint.y} r="0.6" fill={focusMarkerColor} /> : null}
+          </svg>
+        </div>
+      </div>
+      <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+        {timelineLabels.map((label, index) => (
+          <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: 'cyan' | 'orange' }) {
+  const toneClass = tone === 'cyan' ? 'bg-cyan-300' : 'bg-orange-400';
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className={`h-1.5 w-12 rounded-full ${toneClass}`} />
+      <div>
+        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">{label}</p>
+        <p className="text-[2rem] font-black leading-none text-white">{value}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import type { DashboardRange } from '../types';
 
 type TrainingLoadRangeSwitchProps = {
@@ -5,16 +7,18 @@ type TrainingLoadRangeSwitchProps = {
   onChange: (next: DashboardRange) => void;
 };
 
-const OPTIONS: Array<{ value: DashboardRange; label: string }> = [
-  { value: '90d', label: '90 DAYS' },
-  { value: 'season', label: 'SEASON' },
-  { value: 'all-time', label: 'ALL TIME' },
+const OPTIONS: Array<{ value: DashboardRange; labelKey: string }> = [
+  { value: '90d', labelKey: 'dashboard.range.options.90d' },
+  { value: 'season', labelKey: 'dashboard.range.options.season' },
+  { value: 'all-time', labelKey: 'dashboard.range.options.allTime' },
 ];
 
 export function TrainingLoadRangeSwitch({ value, onChange }: TrainingLoadRangeSwitchProps) {
+  const { t } = useTranslation();
+
   return (
     <fieldset className="flex w-full flex-wrap rounded-2xl border border-white/8 bg-[#0d131a] p-1.5 shadow-[0_20px_50px_rgba(2,8,23,0.35)] sm:inline-flex sm:w-auto">
-      <legend className="sr-only">Dashboard time range</legend>
+      <legend className="sr-only">{t('dashboard.range.legend')}</legend>
       {OPTIONS.map((option) => {
         const active = option.value === value;
         const optionId = `dashboard-range-${option.value}`;
@@ -39,7 +43,7 @@ export function TrainingLoadRangeSwitch({ value, onChange }: TrainingLoadRangeSw
                 'peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-cyan-300/70'
               ].join(' ')}
             >
-              {option.label}
+              {t(option.labelKey)}
             </label>
           </div>
         );

--- a/frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadRangeSwitch.tsx
@@ -1,0 +1,49 @@
+import type { DashboardRange } from '../types';
+
+type TrainingLoadRangeSwitchProps = {
+  value: DashboardRange;
+  onChange: (next: DashboardRange) => void;
+};
+
+const OPTIONS: Array<{ value: DashboardRange; label: string }> = [
+  { value: '90d', label: '90 DAYS' },
+  { value: 'season', label: 'SEASON' },
+  { value: 'all-time', label: 'ALL TIME' },
+];
+
+export function TrainingLoadRangeSwitch({ value, onChange }: TrainingLoadRangeSwitchProps) {
+  return (
+    <fieldset className="flex w-full flex-wrap rounded-2xl border border-white/8 bg-[#0d131a] p-1.5 shadow-[0_20px_50px_rgba(2,8,23,0.35)] sm:inline-flex sm:w-auto">
+      <legend className="sr-only">Dashboard time range</legend>
+      {OPTIONS.map((option) => {
+        const active = option.value === value;
+        const optionId = `dashboard-range-${option.value}`;
+
+        return (
+          <div key={option.value} className="flex-1 sm:flex-none">
+            <input
+              id={optionId}
+              name="dashboard-range"
+              type="radio"
+              className="peer sr-only"
+              checked={active}
+              onChange={() => { onChange(option.value); }}
+            />
+            <label
+              htmlFor={optionId}
+              className={[
+                'block cursor-pointer rounded-xl px-3 py-2.5 text-center text-[11px] font-black tracking-[0.18em] transition sm:px-4 sm:tracking-[0.22em]',
+                active
+                  ? 'bg-[#202a36] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_8px_30px_rgba(15,23,42,0.45)]'
+                  : 'text-slate-400 hover:bg-white/5 hover:text-slate-200',
+                'peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-cyan-300/70'
+              ].join(' ')}
+            >
+              {option.label}
+            </label>
+          </div>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadReport.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadReport.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import type { DashboardRange, TrainingLoadDashboardResponse } from '../types';
 import { TrainingLoadCharts } from './TrainingLoadCharts';
 import { TrainingLoadEmptyState } from './TrainingLoadEmptyState';
@@ -11,19 +13,21 @@ type TrainingLoadReportProps = {
 };
 
 export function TrainingLoadReport({ report, range, onRangeChange }: TrainingLoadReportProps) {
+  const { t } = useTranslation();
+
   return (
     <section className="space-y-8">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div className="space-y-3">
-          <p className="text-[11px] font-black uppercase tracking-[0.28em] text-lime-300/80">Performance Management</p>
+          <p className="text-[11px] font-black uppercase tracking-[0.28em] text-lime-300/80">{t('dashboard.report.eyebrow')}</p>
           <div>
-            <h2 className="text-4xl font-black tracking-[-0.04em] text-white sm:text-5xl">Training Stress and Recovery</h2>
+            <h2 className="text-4xl font-black tracking-[-0.04em] text-white sm:text-5xl">{t('dashboard.report.title')}</h2>
             <p className="mt-3 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Snapshot-driven readiness and load analysis for the signed-in athlete
+              {t('dashboard.report.subtitle')}
             </p>
           </div>
           <p className="max-w-2xl text-sm leading-7 text-slate-400">
-            Daily CTL, ATL, TSB, FTP, and rolling efficiency metrics rendered from persisted training-load snapshots.
+            {t('dashboard.report.description')}
           </p>
         </div>
         <TrainingLoadRangeSwitch value={range} onChange={onRangeChange} />

--- a/frontend/src/features/dashboard/components/TrainingLoadReport.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadReport.tsx
@@ -1,0 +1,42 @@
+import type { DashboardRange, TrainingLoadDashboardResponse } from '../types';
+import { TrainingLoadCharts } from './TrainingLoadCharts';
+import { TrainingLoadEmptyState } from './TrainingLoadEmptyState';
+import { TrainingLoadInsightCard } from './TrainingLoadInsightCard';
+import { TrainingLoadRangeSwitch } from './TrainingLoadRangeSwitch';
+
+type TrainingLoadReportProps = {
+  report: TrainingLoadDashboardResponse;
+  range: DashboardRange;
+  onRangeChange: (range: DashboardRange) => void;
+};
+
+export function TrainingLoadReport({ report, range, onRangeChange }: TrainingLoadReportProps) {
+  return (
+    <section className="space-y-8">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-[11px] font-black uppercase tracking-[0.28em] text-lime-300/80">Performance Management</p>
+          <div>
+            <h2 className="text-4xl font-black tracking-[-0.04em] text-white sm:text-5xl">Training Stress and Recovery</h2>
+            <p className="mt-3 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Snapshot-driven readiness and load analysis for the signed-in athlete
+            </p>
+          </div>
+          <p className="max-w-2xl text-sm leading-7 text-slate-400">
+            Daily CTL, ATL, TSB, FTP, and rolling efficiency metrics rendered from persisted training-load snapshots.
+          </p>
+        </div>
+        <TrainingLoadRangeSwitch value={range} onChange={onRangeChange} />
+      </div>
+
+      {!report.hasTrainingLoad ? (
+        <TrainingLoadEmptyState />
+      ) : (
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(19rem,0.95fr)]">
+          <TrainingLoadCharts report={report} />
+          <TrainingLoadInsightCard report={report} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/components/TrainingLoadTsbChart.tsx
+++ b/frontend/src/features/dashboard/components/TrainingLoadTsbChart.tsx
@@ -1,0 +1,185 @@
+import type { MouseEvent } from 'react';
+
+type AxisLabel = {
+  key: string;
+  label: string;
+  top: number;
+};
+
+type TimelineLabel = {
+  key: string;
+  label: string;
+};
+
+type ChartPoint = {
+  x: number;
+  y: number;
+};
+
+type TrainingLoadTsbChartProps = {
+  axisLabels: AxisLabel[];
+  timelineLabels: TimelineLabel[];
+  ariaLabel: string;
+  currentTsb: string;
+  latestSnapshotDate: string | null;
+  latestSnapshotValue: string | null;
+  hoveredSnapshotDate: string | null;
+  hoveredSnapshotValue: string | null;
+  focusPoint: ChartPoint | null;
+  hoveredPoint: ChartPoint | null;
+  hoveredTooltipTop: number;
+  linePath: string;
+  areaPath: string;
+  showArea: boolean;
+  gradientId: string;
+  freshnessHeight: number;
+  optimalHeight: number;
+  riskHeight: number;
+  onHover: (event: MouseEvent<SVGSVGElement>) => void;
+  onLeave: () => void;
+  strings: {
+    formLabel: string;
+    freshnessPeakLabel: string;
+    optimalTrainingLabel: string;
+    highRiskLabel: string;
+    latestSnapshotLabel: string;
+    snapshotLabel: string;
+  };
+};
+
+export function TrainingLoadTsbChart({
+  axisLabels,
+  timelineLabels,
+  ariaLabel,
+  currentTsb,
+  latestSnapshotDate,
+  latestSnapshotValue,
+  hoveredSnapshotDate,
+  hoveredSnapshotValue,
+  focusPoint,
+  hoveredPoint,
+  hoveredTooltipTop,
+  linePath,
+  areaPath,
+  showArea,
+  gradientId,
+  freshnessHeight,
+  optimalHeight,
+  riskHeight,
+  onHover,
+  onLeave,
+  strings,
+}: TrainingLoadTsbChartProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-white/8 bg-[#10161d] p-7 shadow-[0_30px_80px_rgba(2,8,23,0.45)]">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
+        <Metric label={strings.formLabel} value={currentTsb} tone="lime" />
+        {latestSnapshotDate && latestSnapshotValue ? (
+          <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-right">
+            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300/80">{strings.latestSnapshotLabel}</p>
+            <p className="mt-2 text-sm font-semibold text-white">{latestSnapshotDate}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">{latestSnapshotValue}</p>
+          </div>
+        ) : null}
+        <div className="flex flex-wrap gap-4 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">
+          <LegendDot label={strings.freshnessPeakLabel} tone="cyan" />
+          <LegendDot label={strings.optimalTrainingLabel} tone="lime" />
+          <LegendDot label={strings.highRiskLabel} tone="red" />
+        </div>
+      </div>
+      <div className="relative h-72 overflow-hidden rounded-[1.6rem] border border-white/8 bg-[#0b1117] pl-12 pr-4 pt-4">
+        <div className="absolute inset-0 flex flex-col">
+          <div className="relative border-b border-cyan-300/10 bg-cyan-300/6" style={{ height: `${freshnessHeight}%` }}>
+            <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-cyan-300/45">{strings.freshnessPeakLabel}</span>
+          </div>
+          <div className="relative border-b border-lime-300/10 bg-lime-300/6" style={{ height: `${optimalHeight}%` }}>
+            <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-lime-300/45">{strings.optimalTrainingLabel}</span>
+          </div>
+          <div className="relative bg-red-400/6" style={{ height: `${riskHeight}%` }}>
+            <span className="absolute bottom-3 right-4 text-[9px] font-black uppercase tracking-[0.22em] text-red-300/45">{strings.highRiskLabel}</span>
+          </div>
+        </div>
+        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(249,250,251,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(249,250,251,0.04)_1px,transparent_1px)] bg-[size:40px_40px]" />
+        <div className="pointer-events-none absolute inset-y-4 left-4 z-10 w-7 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+          {axisLabels.map((label) => (
+            <span
+              key={label.key}
+              className="absolute left-0 -translate-y-1/2"
+              style={{ top: `${label.top}%` }}
+            >
+              {label.label}
+            </span>
+          ))}
+        </div>
+        <div className="relative h-full w-full">
+          {focusPoint ? (
+            <div className="pointer-events-none absolute inset-y-0 z-10 -translate-x-px" style={{ left: `${focusPoint.x}%` }}>
+              <div className="h-full w-px bg-lime-300/30" />
+            </div>
+          ) : null}
+          <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="relative h-full w-full"
+            role="img"
+            aria-label={ariaLabel}
+            onMouseEnter={onHover}
+            onMouseMove={onHover}
+            onMouseLeave={onLeave}
+          >
+            <defs>
+              <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="#bef264" stopOpacity="0.26" />
+                <stop offset="100%" stopColor="#bef264" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            {showArea ? <path d={areaPath} fill={`url(#${gradientId})`} /> : null}
+            <path d={linePath} fill="none" stroke="#bef264" strokeWidth="0.5" strokeLinecap="round" />
+            {focusPoint ? <circle cx={focusPoint.x} cy={focusPoint.y} r="0.6" fill="#d9f99d" /> : null}
+          </svg>
+          {hoveredSnapshotDate && hoveredSnapshotValue && hoveredPoint ? (
+            <div
+              className="pointer-events-none absolute z-20 w-44 -translate-x-1/2 rounded-2xl border border-lime-300/20 bg-[#1a232c]/90 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur"
+              style={{ left: `${Math.min(Math.max(hoveredPoint.x, 18), 82)}%`, top: `${hoveredTooltipTop}%` }}
+            >
+              <p className="text-[10px] font-black uppercase tracking-[0.24em] text-lime-300">{strings.snapshotLabel}</p>
+              <p className="mt-2 text-sm font-semibold text-white">{hoveredSnapshotDate}</p>
+              <p className="mt-2 text-xs uppercase tracking-[0.18em] text-slate-400">{strings.formLabel}</p>
+              <p className="mt-1 text-lg font-black text-lime-200">{hoveredSnapshotValue}</p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-4 flex justify-between gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+        {timelineLabels.map((label, index) => (
+          <span key={label.key} className={index === timelineLabels.length - 1 ? 'text-lime-300' : ''}>{label.label}</span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function LegendDot({ label, tone }: { label: string; tone: 'cyan' | 'lime' | 'red' }) {
+  const toneClass = tone === 'cyan' ? 'bg-cyan-300/40' : tone === 'lime' ? 'bg-lime-300/35' : 'bg-red-300/35';
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className={`h-2.5 w-2.5 rounded-full ${toneClass}`} />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: 'lime' }) {
+  const toneClass = tone === 'lime' ? 'bg-lime-300' : 'bg-lime-300';
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className={`h-1.5 w-12 rounded-full ${toneClass}`} />
+      <div>
+        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">{label}</p>
+        <p className="text-[2rem] font-black leading-none text-lime-200">{value}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/trainingLoadChartUtils.ts
+++ b/frontend/src/features/dashboard/components/trainingLoadChartUtils.ts
@@ -1,0 +1,128 @@
+import type { MouseEvent } from 'react';
+
+export type SeriesPoint = {
+  index: number;
+  value: number;
+  x: number;
+  y: number;
+};
+
+type PositionedAxisLabel = {
+  key: string;
+  label: string;
+  top: number;
+};
+
+const CHART_X_INSET = 2;
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function buildPointX(index: number, total: number, width: number) {
+  return total === 1 ? width / 2 : CHART_X_INSET + (index / (total - 1)) * (width - (CHART_X_INSET * 2));
+}
+
+export function buildSeriesPoints(values: Array<number | null>, min: number, max: number, height: number, width: number): SeriesPoint[] {
+  const denominator = Math.max(max - min, 1);
+
+  return values.flatMap((value, index) => {
+    if (value === null) {
+      return [];
+    }
+
+    const x = buildPointX(index, values.length, width);
+    const y = height - ((value - min) / denominator) * height;
+    return [{ index, value, x, y }];
+  });
+}
+
+export function buildLinePath(values: Array<number | null>, min: number, max: number, height: number, width: number) {
+  const denominator = Math.max(max - min, 1);
+  let segmentOpen = false;
+
+  return values.reduce((path, value, index) => {
+    if (value === null) {
+      segmentOpen = false;
+      return path;
+    }
+
+    const x = buildPointX(index, values.length, width);
+    const y = height - ((value - min) / denominator) * height;
+    const command = `${segmentOpen ? 'L' : 'M'}${x.toFixed(2)},${y.toFixed(2)}`;
+    segmentOpen = true;
+    return path ? `${path} ${command}` : command;
+  }, '');
+}
+
+export function buildAreaPath(points: SeriesPoint[], height: number) {
+  if (points.length < 2) {
+    return '';
+  }
+
+  const line = points.map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(' ');
+  return `${line} L${points[points.length - 1].x.toFixed(2)},${height.toFixed(2)} L${points[0].x.toFixed(2)},${height.toFixed(2)} Z`;
+}
+
+function formatAxisLabel(value: number) {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(0);
+}
+
+export function buildPositionedAxisLabels(values: number[], min: number, max: number): PositionedAxisLabel[] {
+  const range = Math.max(max - min, 1);
+  const seen = new Set<string>();
+
+  return values.flatMap((value) => {
+    if (value < min || value > max) {
+      return [];
+    }
+
+    const key = value.toFixed(3);
+    if (seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+
+    return [{
+      key,
+      label: formatAxisLabel(value),
+      top: clamp(((max - value) / range) * 100, 0, 100),
+    }];
+  });
+}
+
+export function latestSeriesPoint(...seriesCollections: SeriesPoint[][]) {
+  return seriesCollections.flat().reduce<SeriesPoint | null>((latest, point) => {
+    if (!latest || point.index > latest.index) {
+      return point;
+    }
+
+    return latest;
+  }, null);
+}
+
+export function seriesPointAtIndex(points: SeriesPoint[], index: number | null) {
+  if (index === null) {
+    return null;
+  }
+
+  return points.find((point) => point.index === index) ?? null;
+}
+
+export function resolveHoveredIndex(event: MouseEvent<SVGSVGElement>, totalPoints: number) {
+  if (totalPoints === 0) {
+    return null;
+  }
+
+  if (totalPoints === 1) {
+    return 0;
+  }
+
+  const bounds = event.currentTarget.getBoundingClientRect();
+  if (bounds.width <= 0) {
+    return totalPoints - 1;
+  }
+
+  const ratio = clamp((event.clientX - bounds.left) / bounds.width, 0, 1);
+  return Math.round(ratio * (totalPoints - 1));
+}

--- a/frontend/src/features/dashboard/components/trainingLoadFormatters.ts
+++ b/frontend/src/features/dashboard/components/trainingLoadFormatters.ts
@@ -1,0 +1,74 @@
+type TimelineLabel = {
+  key: string;
+  label: string;
+};
+
+function formatNumber(value: number, language: string, fractionDigits: number) {
+  return new Intl.NumberFormat(language, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value);
+}
+
+export function formatMetricValue(value: number | null, language: string) {
+  return value === null ? '-' : formatNumber(value, language, 1);
+}
+
+export function formatSignedMetricValue(value: number | null, language: string) {
+  if (value === null) {
+    return '-';
+  }
+
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${formatNumber(value, language, 1)}`;
+}
+
+export function formatTwoDecimalValue(value: number | null, language: string) {
+  return value === null ? '-' : formatNumber(value, language, 2);
+}
+
+export function formatWattsValue(value: number | null, language: string) {
+  if (value === null) {
+    return '-';
+  }
+
+  try {
+    return new Intl.NumberFormat(language, {
+      style: 'unit',
+      unit: 'watt',
+      unitDisplay: 'narrow',
+      maximumFractionDigits: 0,
+    }).format(value);
+  } catch {
+    return `${formatNumber(value, language, 0)} W`;
+  }
+}
+
+export function formatShortDate(date: string, language: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime())
+    ? date
+    : new Intl.DateTimeFormat(language, { month: 'short', day: '2-digit', timeZone: 'UTC' }).format(parsed);
+}
+
+export function formatWindowDate(date: string, language: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime())
+    ? date
+    : new Intl.DateTimeFormat(language, { month: 'short', day: '2-digit', year: 'numeric', timeZone: 'UTC' }).format(parsed);
+}
+
+export function buildTimelineLabels(dates: string[], language: string): TimelineLabel[] {
+  if (dates.length === 0) {
+    return [];
+  }
+
+  const candidateIndexes = Array.from(new Set([
+    0,
+    Math.floor((dates.length - 1) * 0.33),
+    Math.floor((dates.length - 1) * 0.66),
+    dates.length - 1,
+  ]));
+
+  return candidateIndexes.map((index) => ({ key: `${dates[index]}-${index}`, label: formatShortDate(dates[index], language) }));
+}

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const dashboardRangeSchema = z.enum(['90d', 'season', 'all-time']);
+export const dashboardTsbZoneSchema = z.enum(['freshness_peak', 'optimal_training', 'high_risk']);
+
+export const trainingLoadDashboardPointSchema = z.object({
+  date: z.string(),
+  dailyTss: z.number().int().nullable(),
+  currentCtl: z.number().nullable(),
+  currentAtl: z.number().nullable(),
+  currentTsb: z.number().nullable(),
+});
+
+export const trainingLoadDashboardSummarySchema = z.object({
+  currentCtl: z.number().nullable(),
+  currentAtl: z.number().nullable(),
+  currentTsb: z.number().nullable(),
+  ftpWatts: z.number().int().nullable(),
+  averageIf28d: z.number().nullable(),
+  averageEf28d: z.number().nullable(),
+  loadDeltaCtl14d: z.number().nullable(),
+  tsbZone: dashboardTsbZoneSchema,
+});
+
+export const trainingLoadDashboardResponseSchema = z.object({
+  range: dashboardRangeSchema,
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  hasTrainingLoad: z.boolean(),
+  summary: trainingLoadDashboardSummarySchema,
+  points: z.array(trainingLoadDashboardPointSchema),
+});
+
+export type DashboardRange = z.infer<typeof dashboardRangeSchema>;
+export type TrainingLoadDashboardResponse = z.infer<typeof trainingLoadDashboardResponseSchema>;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -9,11 +9,28 @@
     "description": "Manage your AI agents, integrations, analysis preferences, and cycling biometrics."
   },
   "nav": {
+    "dashboard": "Dashboard",
     "settings": "Settings",
     "calendar": "Calendar",
+    "races": "Races",
     "aiCoach": "AI Coach",
     "workspace": "Workspace",
     "systemInfo": "System Info"
+  },
+  "appShell": {
+    "brand": {
+      "subtitle": "Elite Performance"
+    },
+    "notifications": "Notifications",
+    "pageTitles": {
+      "dashboard": "Dashboard",
+      "settings": "Settings",
+      "calendar": "Calendar",
+      "races": "Races",
+      "aiCoach": "AI Coach",
+      "workspace": "Workspace",
+      "systemInfo": "System Info"
+    }
   },
   "aiAgents": {
     "title": "AI Agents",
@@ -196,6 +213,123 @@
     "dayItems": "Day items",
     "viewItems_one": "View {{count}} item",
     "viewItems_other": "View {{count}} items"
+  },
+  "dashboard": {
+    "loading": "Loading dashboard",
+    "unavailable": {
+      "title": "Dashboard unavailable",
+      "fallbackMessage": "Failed to load dashboard."
+    },
+    "report": {
+      "eyebrow": "Performance Management",
+      "title": "Training Stress and Recovery",
+      "subtitle": "Snapshot-driven readiness and load analysis for the signed-in athlete",
+      "description": "Daily CTL, ATL, TSB, FTP, and rolling efficiency metrics rendered from persisted training-load snapshots."
+    },
+    "range": {
+      "legend": "Dashboard time range",
+      "options": {
+        "90d": "90 DAYS",
+        "season": "SEASON",
+        "allTime": "ALL TIME"
+      }
+    },
+    "empty": {
+      "eyebrow": "Dashboard",
+      "title": "Training load will appear here",
+      "description": "Once completed workouts and daily snapshots are available, this dashboard will show CTL, ATL, TSB and the trend of your recent load."
+    },
+    "charts": {
+      "shared": {
+        "timeline": {
+          "startFallback": "start",
+          "latestFallback": "latest"
+        }
+      },
+      "load": {
+        "metrics": {
+          "fitness": "Fitness (CTL)",
+          "fatigue": "Fatigue (ATL)"
+        },
+        "latestSnapshot": {
+          "eyebrow": "Latest snapshot",
+          "summary": "CTL {{ctl}} / ATL {{atl}}"
+        },
+        "tooltip": {
+          "eyebrow": "Snapshot",
+          "summary": "CTL {{ctl}} / ATL {{atl}}"
+        },
+        "aria": {
+          "description": "Fitness and fatigue chart from {{start}} to {{end}}. Latest load snapshot {{latestSnapshot}}. The highlighted dot follows {{series}} because that is the latest available load series point.",
+          "latestSnapshotAvailable": "{{date}} with CTL {{ctl}} and ATL {{atl}}",
+          "latestSnapshotUnavailable": "is unavailable",
+          "series": {
+            "fitness": "fitness",
+            "fatigue": "fatigue"
+          }
+        }
+      },
+      "tsb": {
+        "metric": "Form (TSB)",
+        "legend": {
+          "freshnessPeak": "Freshness / Peak",
+          "optimalTraining": "Optimal Training",
+          "highRisk": "High Risk"
+        },
+        "latestSnapshot": {
+          "eyebrow": "Latest snapshot"
+        },
+        "tooltip": {
+          "eyebrow": "Snapshot",
+          "metric": "Form (TSB)"
+        },
+        "aria": {
+          "description": "Form chart with freshness, optimal training, and high risk zones from {{start}} to {{end}}. Latest TSB snapshot {{latestSnapshot}}.",
+          "latestSnapshotAvailable": "{{date}} with TSB {{tsb}}",
+          "latestSnapshotUnavailable": "is unavailable"
+        }
+      }
+    },
+    "insights": {
+      "formBreakdown": {
+        "eyebrow": "Form Breakdown",
+        "title": "Understanding Form (TSB)",
+        "description": "Training Stress Balance is the relationship between <fitness>Fitness (CTL)</fitness> and <fatigue>Fatigue (ATL)</fatigue>. It helps frame whether you are carrying useful training load, approaching peak freshness, or drifting into excessive risk.",
+        "zones": {
+          "freshnessPeak": {
+            "title": "Freshness / Peak",
+            "detail": "Positive TSB. Fatigue has dropped while fitness is still present, so readiness is improving."
+          },
+          "optimalTraining": {
+            "title": "Optimal Training",
+            "detail": "TSB sits in the productive band where adaptation is possible without excessive cost."
+          },
+          "highRisk": {
+            "title": "High Risk",
+            "detail": "TSB is too negative. Load may be outpacing recovery, which raises overreaching risk."
+          }
+        }
+      },
+      "coachInsight": {
+        "eyebrow": "Coach Insight",
+        "headlines": {
+          "freshnessPeak": "Trending towards peak",
+          "highRisk": "Fatigue is accumulating",
+          "optimalTraining": "Productive load block"
+        },
+        "details": {
+          "insufficientHistory": "Not enough history yet to compare the current load trend with the last two weeks.",
+          "trend": "CTL changed by {{delta}} over the last 14 days while TSB sits at {{tsb}}. Keep translating this load into adaptation without reintroducing unnecessary fatigue."
+        },
+        "metrics": {
+          "ftp": "FTP",
+          "if28d": "IF 28d",
+          "ef28d": "EF 28d",
+          "window": "Window",
+          "windowRange": "{{start}} to {{end}}"
+        }
+      }
+    }
   },
   "races": {
     "eyebrow": "Race calendar",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -9,11 +9,28 @@
     "description": "Zarządzaj agentami AI, integracjami, preferencjami analizy i danymi biometrycznymi kolarskimi."
   },
   "nav": {
+    "dashboard": "Dashboard",
     "settings": "Ustawienia",
     "calendar": "Kalendarz",
+    "races": "Wyścigi",
     "aiCoach": "AI Trener",
     "workspace": "Obszar roboczy",
     "systemInfo": "Info systemowe"
+  },
+  "appShell": {
+    "brand": {
+      "subtitle": "Elitarna wydajność"
+    },
+    "notifications": "Powiadomienia",
+    "pageTitles": {
+      "dashboard": "Dashboard",
+      "settings": "Ustawienia",
+      "calendar": "Kalendarz",
+      "races": "Wyścigi",
+      "aiCoach": "AI Trener",
+      "workspace": "Obszar roboczy",
+      "systemInfo": "Info systemowe"
+    }
   },
   "aiAgents": {
     "title": "Agenci AI",
@@ -200,6 +217,123 @@
     "viewItems_few": "Zobacz {{count}} elementy",
     "viewItems_many": "Zobacz {{count}} elementów",
     "viewItems_other": "Zobacz {{count}} elementu"
+  },
+  "dashboard": {
+    "loading": "Ładowanie dashboardu",
+    "unavailable": {
+      "title": "Dashboard jest niedostępny",
+      "fallbackMessage": "Nie udało się załadować dashboardu."
+    },
+    "report": {
+      "eyebrow": "Zarządzanie formą",
+      "title": "Obciążenie treningowe i regeneracja",
+      "subtitle": "Analiza gotowości i obciążenia oparta na snapshotach dla zalogowanego zawodnika",
+      "description": "Dzienne metryki CTL, ATL, TSB, FTP oraz kroczące wskaźniki efektywności renderowane z zapisanych snapshotów obciążenia treningowego."
+    },
+    "range": {
+      "legend": "Zakres czasu dashboardu",
+      "options": {
+        "90d": "90 DNI",
+        "season": "SEZON",
+        "allTime": "CAŁY OKRES"
+      }
+    },
+    "empty": {
+      "eyebrow": "Dashboard",
+      "title": "Obciążenie treningowe pojawi się tutaj",
+      "description": "Gdy pojawią się ukończone treningi i dzienne snapshoty, ten dashboard pokaże CTL, ATL, TSB oraz trend Twojego ostatniego obciążenia."
+    },
+    "charts": {
+      "shared": {
+        "timeline": {
+          "startFallback": "początek",
+          "latestFallback": "najnowszy punkt"
+        }
+      },
+      "load": {
+        "metrics": {
+          "fitness": "Sprawność (CTL)",
+          "fatigue": "Zmęczenie (ATL)"
+        },
+        "latestSnapshot": {
+          "eyebrow": "Najnowszy odczyt",
+          "summary": "CTL {{ctl}} / ATL {{atl}}"
+        },
+        "tooltip": {
+          "eyebrow": "Odczyt punktu",
+          "summary": "CTL {{ctl}} / ATL {{atl}}"
+        },
+        "aria": {
+          "description": "Wykres sprawności i zmęczenia od {{start}} do {{end}}. Najnowszy snapshot obciążenia {{latestSnapshot}}. Wyróżniony punkt podąża za serią {{series}}, ponieważ to najnowszy dostępny punkt serii obciążenia.",
+          "latestSnapshotAvailable": "{{date}} z CTL {{ctl}} i ATL {{atl}}",
+          "latestSnapshotUnavailable": "jest niedostępny",
+          "series": {
+            "fitness": "sprawność",
+            "fatigue": "zmęczenie"
+          }
+        }
+      },
+      "tsb": {
+        "metric": "Forma (TSB)",
+        "legend": {
+          "freshnessPeak": "Świeżość / Szczyt",
+          "optimalTraining": "Optymalny trening",
+          "highRisk": "Wysokie ryzyko"
+        },
+        "latestSnapshot": {
+          "eyebrow": "Najnowszy odczyt"
+        },
+        "tooltip": {
+          "eyebrow": "Odczyt punktu",
+          "metric": "Forma (TSB)"
+        },
+        "aria": {
+          "description": "Wykres formy ze strefami świeżości, optymalnego treningu i wysokiego ryzyka od {{start}} do {{end}}. Najnowszy snapshot formy {{latestSnapshot}}.",
+          "latestSnapshotAvailable": "{{date}} z TSB {{tsb}}",
+          "latestSnapshotUnavailable": "jest niedostępny"
+        }
+      }
+    },
+    "insights": {
+      "formBreakdown": {
+        "eyebrow": "Rozkład formy",
+        "title": "Jak rozumieć formę (TSB)",
+        "description": "Training Stress Balance to relacja między <fitness>Sprawnością (CTL)</fitness> a <fatigue>Zmęczeniem (ATL)</fatigue>. Pomaga ocenić, czy niesiesz użyteczne obciążenie treningowe, zbliżasz się do szczytu świeżości czy wchodzisz w zbyt duże ryzyko.",
+        "zones": {
+          "freshnessPeak": {
+            "title": "Świeżość / Szczyt",
+            "detail": "Dodatni TSB. Zmęczenie spadło, a sprawność nadal jest obecna, więc gotowość rośnie."
+          },
+          "optimalTraining": {
+            "title": "Optymalny trening",
+            "detail": "TSB znajduje się w produktywnym paśmie, gdzie adaptacja jest możliwa bez nadmiernego kosztu."
+          },
+          "highRisk": {
+            "title": "Wysokie ryzyko",
+            "detail": "TSB jest zbyt niski. Obciążenie może wyprzedzać regenerację, co zwiększa ryzyko przetrenowania funkcjonalnego."
+          }
+        }
+      },
+      "coachInsight": {
+        "eyebrow": "Wskazówka trenera",
+        "headlines": {
+          "freshnessPeak": "Trend w stronę szczytu",
+          "highRisk": "Zmęczenie się kumuluje",
+          "optimalTraining": "Produktywny blok obciążenia"
+        },
+        "details": {
+          "insufficientHistory": "Jest jeszcze za mało historii, aby porównać bieżący trend obciążenia z ostatnimi dwoma tygodniami.",
+          "trend": "CTL zmienił się o {{delta}} w ostatnich 14 dniach, a TSB wynosi {{tsb}}. Dalej zamieniaj to obciążenie w adaptację, ale bez dokładania niepotrzebnego zmęczenia."
+        },
+        "metrics": {
+          "ftp": "FTP",
+          "if28d": "IF 28d",
+          "ef28d": "EF 28d",
+          "window": "Okno",
+          "windowRange": "{{start}} do {{end}}"
+        }
+      }
+    }
   },
   "races": {
     "eyebrow": "Kalendarz wyścigów",

--- a/frontend/src/pages/AppHomePage.test.tsx
+++ b/frontend/src/pages/AppHomePage.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { createFetchMock, useFetchMock } from '../features/intervals/api/testHelpers';
+import { AppHomePage } from './AppHomePage';
+
+function buildResponse(range: '90d' | 'season' | 'all-time') {
+  const summary = range === 'season'
+    ? {
+        currentCtl: 41.2,
+        currentAtl: 46.1,
+        currentTsb: 4.9,
+        ftpWatts: 340,
+        averageIf28d: 76.1,
+        averageEf28d: 1.91,
+        loadDeltaCtl14d: 4.3,
+        tsbZone: 'freshness_peak' as const,
+      }
+    : {
+        currentCtl: 29.9,
+        currentAtl: 53.4,
+        currentTsb: -23.5,
+        ftpWatts: 340,
+        averageIf28d: 72.95,
+        averageEf28d: null,
+        loadDeltaCtl14d: 8.4,
+        tsbZone: 'optimal_training' as const,
+      };
+
+  return new Response(
+    JSON.stringify({
+      range,
+      windowStart: range === 'all-time' ? '2025-12-03' : range === 'season' ? '2026-01-01' : '2026-01-19',
+      windowEnd: '2026-04-18',
+      hasTrainingLoad: true,
+      summary,
+      points: [
+        {
+          date: '2026-04-01',
+          dailyTss: 44,
+          currentCtl: range === 'season' ? 34.8 : 20.0,
+          currentAtl: range === 'season' ? 40.2 : 30.0,
+          currentTsb: range === 'season' ? 1.8 : -10.0,
+        },
+        {
+          date: '2026-04-18',
+          dailyTss: 97,
+          currentCtl: summary.currentCtl,
+          currentAtl: summary.currentAtl,
+          currentTsb: summary.currentTsb,
+        },
+      ],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+describe('AppHomePage', () => {
+  it('loads dashboard and switches ranges', async () => {
+    const fetchMock = useFetchMock(
+      createFetchMock()
+        .mockResolvedValueOnce(buildResponse('90d'))
+        .mockResolvedValueOnce(buildResponse('season')),
+    );
+
+    render(<AppHomePage apiBaseUrl="" />);
+
+    expect(screen.getByText(/loading dashboard/i)).toBeInTheDocument();
+    await screen.findByRole('heading', { name: /training stress and recovery/i });
+    expect(screen.getByText('29.9')).toBeInTheDocument();
+    expect(screen.getByText(/understanding form \(tsb\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/coach insight/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/latest snapshot/i).length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole('radio', { name: /season/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/dashboard/training-load?range=season',
+        expect.any(Object),
+      );
+    });
+
+    expect(await screen.findByText('41.2')).toBeInTheDocument();
+    expect(screen.getByText(/trending towards peak/i)).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /season/i })).toBeChecked();
+  });
+
+  it('supports keyboard range changes', async () => {
+    useFetchMock(
+      createFetchMock()
+        .mockResolvedValueOnce(buildResponse('90d'))
+        .mockResolvedValueOnce(buildResponse('season')),
+    );
+
+    const user = userEvent.setup();
+
+    const { container } = render(<AppHomePage apiBaseUrl="" />);
+
+    await within(container).findByRole('heading', { name: /training stress and recovery/i });
+
+    const ninetyDays = screen.getByRole('radio', { name: /90 days/i });
+    ninetyDays.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(await screen.findByText('41.2')).toBeInTheDocument();
+    expect(screen.getByText(/trending towards peak/i)).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /season/i })).toBeChecked();
+  });
+
+  it('shows snapshot values on chart hover instead of keeping the tsb tooltip always visible', async () => {
+    const user = userEvent.setup();
+
+    useFetchMock(
+      createFetchMock().mockResolvedValueOnce(buildResponse('90d')),
+    );
+
+    const { container } = render(<AppHomePage apiBaseUrl="" />);
+
+    const tsbChart = await within(container).findByLabelText(/form chart with freshness, optimal training, and high risk zones/i);
+    const tsbSection = tsbChart.closest('section');
+
+    expect(tsbSection).not.toBeNull();
+
+    const tsbQueries = within(tsbSection!);
+
+    expect(tsbQueries.queryByText(/^latest snapshot$/i)).not.toBeInTheDocument();
+    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(1);
+
+    await user.hover(tsbChart);
+
+    expect(await tsbQueries.findByText(/^latest snapshot$/i)).toBeInTheDocument();
+    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(2);
+  });
+
+  it('renders empty state when report has no snapshots', async () => {
+    useFetchMock(
+      createFetchMock().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            range: 'all-time',
+            windowStart: '2026-04-18',
+            windowEnd: '2026-04-18',
+            hasTrainingLoad: false,
+            summary: {
+              currentCtl: null,
+              currentAtl: null,
+              currentTsb: null,
+              ftpWatts: null,
+              averageIf28d: null,
+              averageEf28d: null,
+              loadDeltaCtl14d: null,
+              tsbZone: 'optimal_training',
+            },
+            points: [],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    render(<AppHomePage apiBaseUrl="" />);
+
+    expect(await screen.findByText(/training load will appear here/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AppHomePage.test.tsx
+++ b/frontend/src/pages/AppHomePage.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createFetchMock, useFetchMock } from '../features/intervals/api/testHelpers';
+import i18n from '../i18n';
 import { AppHomePage } from './AppHomePage';
 
 function buildResponse(range: '90d' | 'season' | 'all-time') {
@@ -57,6 +58,10 @@ function buildResponse(range: '90d' | 'season' | 'all-time') {
 }
 
 describe('AppHomePage', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
   it('loads dashboard and switches ranges', async () => {
     const fetchMock = useFetchMock(
       createFetchMock()
@@ -68,8 +73,9 @@ describe('AppHomePage', () => {
 
     expect(screen.getByText(/loading dashboard/i)).toBeInTheDocument();
     await screen.findByRole('heading', { name: /training stress and recovery/i });
+    expect(screen.getByText(/performance management/i)).toBeInTheDocument();
     expect(screen.getByText('29.9')).toBeInTheDocument();
-    expect(screen.getByText(/understanding form \(tsb\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/understanding form/i)).toBeInTheDocument();
     expect(screen.getByText(/coach insight/i)).toBeInTheDocument();
     expect(screen.getAllByText(/latest snapshot/i).length).toBeGreaterThan(0);
 
@@ -125,13 +131,48 @@ describe('AppHomePage', () => {
 
     const tsbQueries = within(tsbSection!);
 
-    expect(tsbQueries.queryByText(/^latest snapshot$/i)).not.toBeInTheDocument();
-    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(1);
+    expect(tsbQueries.getByText(/^latest snapshot$/i)).toBeInTheDocument();
+    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(2);
 
     await user.hover(tsbChart);
 
-    expect(await tsbQueries.findByText(/^latest snapshot$/i)).toBeInTheDocument();
-    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(2);
+    expect(await tsbQueries.findByText(/^snapshot$/i)).toBeInTheDocument();
+    expect(tsbQueries.getAllByText('-23.5')).toHaveLength(3);
+  });
+
+  it('renders dashboard copy and metrics in Polish', async () => {
+    await i18n.changeLanguage('pl');
+
+    const user = userEvent.setup();
+
+    useFetchMock(
+      createFetchMock().mockResolvedValueOnce(buildResponse('90d')),
+    );
+
+    const { container } = render(<AppHomePage apiBaseUrl="" />);
+
+    await within(container).findByRole('heading', { name: /obciążenie treningowe i regeneracja/i });
+
+    expect(within(container).getByText(/zarządzanie formą/i)).toBeInTheDocument();
+    expect(within(container).getByText('29,9')).toBeInTheDocument();
+    expect(within(container).getByText('CAŁY OKRES')).toBeInTheDocument();
+
+    const tsbChart = within(container).getByLabelText(/wykres formy ze strefami świeżości, optymalnego treningu i wysokiego ryzyka/i);
+    const tsbSection = tsbChart.closest('section');
+    const loadChart = within(container).getByLabelText(/wykres sprawności i zmęczenia/i);
+    const loadSection = loadChart.closest('section');
+
+    expect(tsbSection).not.toBeNull();
+    expect(loadSection).not.toBeNull();
+    expect(within(tsbSection!).getByText(/^Najnowszy odczyt$/i)).toBeInTheDocument();
+
+    await user.hover(loadChart);
+
+    expect(await within(loadSection!).findByText(/^Odczyt punktu$/i)).toBeInTheDocument();
+
+    await user.hover(tsbChart);
+
+    expect(await within(tsbSection!).findByText(/^Odczyt punktu$/i)).toBeInTheDocument();
   });
 
   it('keeps the load chart marker and narration on fatigue when latest ctl is unavailable', async () => {

--- a/frontend/src/pages/AppHomePage.test.tsx
+++ b/frontend/src/pages/AppHomePage.test.tsx
@@ -134,6 +134,57 @@ describe('AppHomePage', () => {
     expect(tsbQueries.getAllByText('-23.5')).toHaveLength(2);
   });
 
+  it('keeps the load chart marker and narration on fatigue when latest ctl is unavailable', async () => {
+    useFetchMock(
+      createFetchMock().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            range: '90d',
+            windowStart: '2026-01-19',
+            windowEnd: '2026-04-18',
+            hasTrainingLoad: true,
+            summary: {
+              currentCtl: null,
+              currentAtl: 53.4,
+              currentTsb: -23.5,
+              ftpWatts: 340,
+              averageIf28d: 72.95,
+              averageEf28d: null,
+              loadDeltaCtl14d: null,
+              tsbZone: 'optimal_training',
+            },
+            points: [
+              {
+                date: '2026-04-01',
+                dailyTss: 44,
+                currentCtl: 20.0,
+                currentAtl: 30.0,
+                currentTsb: -10.0,
+              },
+              {
+                date: '2026-04-18',
+                dailyTss: 97,
+                currentCtl: null,
+                currentAtl: 53.4,
+                currentTsb: -23.5,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const { container } = render(<AppHomePage apiBaseUrl="" />);
+
+    const loadChart = await within(container).findByLabelText(/fitness and fatigue chart/i);
+    expect(loadChart).toHaveAttribute('aria-label', expect.stringContaining('highlighted dot follows fatigue'));
+
+    const marker = loadChart.querySelector('circle');
+    expect(marker).not.toBeNull();
+    expect(marker).toHaveAttribute('fill', '#ff7a45');
+  });
+
   it('renders empty state when report has no snapshots', async () => {
     useFetchMock(
       createFetchMock().mockResolvedValueOnce(

--- a/frontend/src/pages/AppHomePage.tsx
+++ b/frontend/src/pages/AppHomePage.tsx
@@ -1,14 +1,64 @@
-export function AppHomePage() {
-  return (
-    <section className="rounded-[2rem] border border-white/15 bg-slate-950/70 p-8 shadow-[0_30px_80px_rgba(15,23,42,0.45)] backdrop-blur">
-      <p className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-300">Athlete workspace</p>
-      <h1 className="mt-4 max-w-xl font-serif text-4xl leading-tight text-white md:text-5xl">
-        Signed in and ready for the next training workflow.
-      </h1>
-      <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300 md:text-lg">
-        This is the post-login home area for normal users. Future training, sync, and coaching
-        flows should branch from here.
-      </p>
-    </section>
-  );
+import { useEffect, useState } from 'react';
+
+import { loadTrainingLoadDashboard } from '../features/dashboard/api/dashboard';
+import { TrainingLoadReport } from '../features/dashboard/components/TrainingLoadReport';
+import type { DashboardRange, TrainingLoadDashboardResponse } from '../features/dashboard/types';
+
+type AppHomePageProps = {
+  apiBaseUrl: string;
+};
+
+export function AppHomePage({ apiBaseUrl }: AppHomePageProps) {
+  const [range, setRange] = useState<DashboardRange>('90d');
+  const [report, setReport] = useState<TrainingLoadDashboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+
+    void loadTrainingLoadDashboard(apiBaseUrl, range)
+      .then((payload) => {
+        if (!cancelled) {
+          setReport(payload);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load dashboard');
+          setReport(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, range]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[18rem] items-center justify-center rounded-[2rem] border border-white/10 bg-[#0d141f]">
+        <p className="text-sm uppercase tracking-[0.24em] text-slate-400">Loading dashboard</p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <section className="rounded-[2rem] border border-red-500/25 bg-red-500/10 p-8 text-center shadow-[0_20px_60px_rgba(127,29,29,0.25)]">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-red-300">Dashboard unavailable</p>
+        <p className="mt-4 text-base text-red-100">{error ?? 'Failed to load dashboard.'}</p>
+      </section>
+    );
+  }
+
+  return <TrainingLoadReport report={report} range={range} onRangeChange={setRange} />;
 }

--- a/frontend/src/pages/AppHomePage.tsx
+++ b/frontend/src/pages/AppHomePage.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
-
 import { loadTrainingLoadDashboard } from '../features/dashboard/api/dashboard';
 import { TrainingLoadReport } from '../features/dashboard/components/TrainingLoadReport';
 import type { DashboardRange, TrainingLoadDashboardResponse } from '../features/dashboard/types';
+import { useTranslation } from 'react-i18next';
 
 type AppHomePageProps = {
   apiBaseUrl: string;
 };
 
 export function AppHomePage({ apiBaseUrl }: AppHomePageProps) {
+  const { t } = useTranslation();
   const [range, setRange] = useState<DashboardRange>('90d');
   const [report, setReport] = useState<TrainingLoadDashboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -28,7 +29,7 @@ export function AppHomePage({ apiBaseUrl }: AppHomePageProps) {
       })
       .catch((err) => {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load dashboard');
+          setError(err instanceof Error ? err.message : null);
           setReport(null);
         }
       })
@@ -46,7 +47,7 @@ export function AppHomePage({ apiBaseUrl }: AppHomePageProps) {
   if (loading) {
     return (
       <div className="flex min-h-[18rem] items-center justify-center rounded-[2rem] border border-white/10 bg-[#0d141f]">
-        <p className="text-sm uppercase tracking-[0.24em] text-slate-400">Loading dashboard</p>
+        <p className="text-sm uppercase tracking-[0.24em] text-slate-400">{t('dashboard.loading')}</p>
       </div>
     );
   }
@@ -54,8 +55,8 @@ export function AppHomePage({ apiBaseUrl }: AppHomePageProps) {
   if (error || !report) {
     return (
       <section className="rounded-[2rem] border border-red-500/25 bg-red-500/10 p-8 text-center shadow-[0_20px_60px_rgba(127,29,29,0.25)]">
-        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-red-300">Dashboard unavailable</p>
-        <p className="mt-4 text-base text-red-100">{error ?? 'Failed to load dashboard.'}</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-red-300">{t('dashboard.unavailable.title')}</p>
+        <p className="mt-4 text-base text-red-100">{error ?? t('dashboard.unavailable.fallbackMessage')}</p>
       </section>
     );
   }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-04-17)
+# Graph Report - .  (2026-04-18)
 
 ## Corpus Check
-- 584 files · ~319,919 words
+- 604 files · ~334,988 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5528 nodes · 6845 edges · 685 communities detected
+- 5732 nodes · 7112 edges · 705 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -695,6 +695,26 @@
 - [[_COMMUNITY_Community 682|Community 682]]
 - [[_COMMUNITY_Community 683|Community 683]]
 - [[_COMMUNITY_Community 684|Community 684]]
+- [[_COMMUNITY_Community 685|Community 685]]
+- [[_COMMUNITY_Community 686|Community 686]]
+- [[_COMMUNITY_Community 687|Community 687]]
+- [[_COMMUNITY_Community 688|Community 688]]
+- [[_COMMUNITY_Community 689|Community 689]]
+- [[_COMMUNITY_Community 690|Community 690]]
+- [[_COMMUNITY_Community 691|Community 691]]
+- [[_COMMUNITY_Community 692|Community 692]]
+- [[_COMMUNITY_Community 693|Community 693]]
+- [[_COMMUNITY_Community 694|Community 694]]
+- [[_COMMUNITY_Community 695|Community 695]]
+- [[_COMMUNITY_Community 696|Community 696]]
+- [[_COMMUNITY_Community 697|Community 697]]
+- [[_COMMUNITY_Community 698|Community 698]]
+- [[_COMMUNITY_Community 699|Community 699]]
+- [[_COMMUNITY_Community 700|Community 700]]
+- [[_COMMUNITY_Community 701|Community 701]]
+- [[_COMMUNITY_Community 702|Community 702]]
+- [[_COMMUNITY_Community 703|Community 703]]
+- [[_COMMUNITY_Community 704|Community 704]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `resolve_user_id()` - 37 edges
@@ -702,11 +722,11 @@
 3. `FakeIntervalsApi` - 25 edges
 4. `()` - 23 edges
 5. `DefaultTrainingContextBuilder<Time>` - 21 edges
-6. `required_settings_map()` - 20 edges
+6. `required_settings_map()` - 21 edges
 7. `TestIntervalsService` - 20 edges
 8. `WorkoutSummaryService<Repo, Ops, Time, Ids>` - 19 edges
-9. `InMemoryIntervalsService` - 18 edges
-10. `TestWorkoutSummaryService` - 18 edges
+9. `AppState` - 18 edges
+10. `InMemoryIntervalsService` - 18 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `list_completed_workouts()` --calls--> `resolve_user_id()`  [EXTRACTED]
@@ -734,210 +754,218 @@ Cohesion: 0.02
 Nodes (39): capture_request(), CapturedRequest, CapturingChatPort, FailingReusableCacheRepository, FixedClock, FixedGeminiConfigProvider, gemini_cache_handler(), gemini_generate_handler() (+31 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.03
-Nodes (32): create_race_persists_and_syncs_to_intervals(), create_race_retry_after_lost_final_sync_write_updates_existing_remote_event(), create_race_retry_without_external_id_reuses_existing_remote_event(), delete_race_deletes_remote_event_before_local_remove(), delete_race_keeps_sync_state_when_local_delete_fails(), delete_race_refreshes_calendar_view_when_sync_state_delete_fails_after_local_delete(), FailingCalendarRefresh, FakeIntervalsService (+24 more)
+Cohesion: 0.07
+Nodes (34): epoch_seconds_to_utc_date(), FailingFtpHistoryRepository, find_settings_does_not_create_defaults_when_missing(), FtpHistoryWritePort, InMemoryProviderPollStateRepository, InMemoryUserSettingsRepository, map_poll_state_error(), map_training_load_error() (+26 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
 Nodes (37): calendar_entry_view_service_lists_mixed_entries_by_date_range(), completed_workout_projection_carries_local_summary(), completed_workout_projection_handles_short_start_date_local_without_panicking(), planned_workout_projection_builds_local_entry(), race_projection_keeps_label_shape_and_sync_metadata(), race_projection_panics_when_intervals_external_id_is_not_numeric(), rebuild_for_user_keeps_sync_on_merged_planned_entry_without_standalone_completed_entry(), rebuild_for_user_preserves_existing_sync_metadata() (+29 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.07
-Nodes (33): epoch_seconds_to_utc_date(), FailingFtpHistoryRepository, find_settings_does_not_create_defaults_when_missing(), FtpHistoryWritePort, InMemoryProviderPollStateRepository, InMemoryUserSettingsRepository, map_poll_state_error(), map_training_load_error() (+25 more)
+Cohesion: 0.04
+Nodes (22): auth_test_app(), auth_test_app_with_custom_settings(), auth_test_app_with_custom_settings_and_limited_whitelist_rate(), auth_test_app_with_limited_whitelist_rate(), auth_test_app_with_settings(), auth_test_app_without_identity(), frontend_fixture(), FrontendFixture (+14 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.04
-Nodes (19): auth_test_app(), auth_test_app_with_custom_settings(), auth_test_app_with_settings(), auth_test_app_without_identity(), frontend_fixture(), FrontendFixture, health_test_app(), HealthTestApp (+11 more)
+Nodes (18): FakeIntervalsService, FakeProjectionRepository, FixedClock, FixedIds, InMemoryCalendarEntryViewRepository, InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutSyncRepository, InMemoryProviderPollStateRepository (+10 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.05
 Nodes (29): EmptyCalendarLabelSource, EmptyTrainingPlanProjectionRepository, frontend_fixture(), FrontendFixture, get_json(), InMemoryCalendarEntryViewRepository, InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutSyncRepository (+21 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.05
+Nodes (19): create_race_persists_and_syncs_to_intervals(), create_race_retry_after_lost_final_sync_write_updates_existing_remote_event(), create_race_retry_without_external_id_reuses_existing_remote_event(), delete_race_deletes_remote_event_before_local_remove(), delete_race_keeps_sync_state_when_local_delete_fails(), delete_race_refreshes_calendar_view_when_sync_state_delete_fails_after_local_delete(), FailingCalendarRefresh, InMemoryExternalSyncStateRepository (+11 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.09
 Nodes (30): assert_event_order(), completed_operation(), completed_operation_at(), ensure_fresh_summary_generates_when_missing(), ensure_fresh_summary_reads_repository_once_when_summary_is_fresh(), ensure_fresh_summary_regenerates_when_older_than_monday(), ensure_fresh_summary_reuses_summary_generated_this_week(), failed_operation() (+22 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.04
 Nodes (16): default_dev_coach(), DevWorkoutCoach, existing_summary(), existing_summary_with_finished_conversation(), PersistCheckingTrainingPlanService, RecordingCompletedWorkoutTargetService, RecordingLatestCompletedActivityService, RecordingTrainingPlanService (+8 more)
 
-### Community 8 - "Community 8"
+### Community 9 - "Community 9"
 Cohesion: 0.06
 Nodes (40): AiAgentsDocument, AvailabilityDayDocument, AvailabilityDocument, bootstrap_intervals_updated_at(), build_intervals_poll_bootstrap_filter(), build_intervals_poll_bootstrap_filter_matches_non_empty_credentials_or_existing_users(), build_intervals_poll_bootstrap_filter_omits_user_id_clause_without_existing_users(), build_settings_document() (+32 more)
-
-### Community 9 - "Community 9"
-Cohesion: 0.07
-Nodes (48): buildCompletedWorkoutBars(), buildCompletedWorkoutPreviewBars(), buildExpandedGroupedPlannedChartSteps(), buildExpandedPlannedSegments(), buildGroupedPlannedWorkoutSections(), buildPlannedTargetLabel(), buildPlannedWorkoutBars(), buildPlannedWorkoutChartIntervals() (+40 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.05
 Nodes (11): AssertingIntervalsApi, FakeIntervalsApi, FakeIntervalsSettings, FixedIdGenerator, RecordingCalendarRefresh, RecordingImportService, RecordingIntervalsApi, RecordingProviderPollStateRepository (+3 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.07
+Nodes (48): buildCompletedWorkoutBars(), buildCompletedWorkoutPreviewBars(), buildExpandedGroupedPlannedChartSteps(), buildExpandedPlannedSegments(), buildGroupedPlannedWorkoutSections(), buildPlannedTargetLabel(), buildPlannedWorkoutBars(), buildPlannedWorkoutChartIntervals() (+40 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.08
 Nodes (26): build_direct_event_matches(), build_local_events(), canonical_event_id(), CompletedWorkoutReadPort, date_key(), default_special_day_name(), DefaultTrainingContextBuilder, DefaultTrainingContextBuilder<Time> (+18 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.09
 Nodes (45): admin_get_user_settings(), athlete_summary_service(), auth_and_get_calendar_labels_service(), auth_and_get_calendar_service(), CompletedWorkoutPath, connection_tester(), create_activity(), create_event() (+37 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
+Cohesion: 0.06
+Nodes (18): build_daily_training_load_snapshots_falls_back_to_provider_ftp_after_ftp_is_cleared(), build_daily_training_load_snapshots_keeps_intervals_if_and_ef_averages(), build_daily_training_load_snapshots_uses_app_ftp_only_on_or_after_app_entry_date(), completed_workout_repository_finds_by_source_activity_id(), completed_workout_repository_finds_latest_by_user(), completed_workout_repository_lists_by_user_and_date_range(), dashboard_report_for_all_time_uses_oldest_snapshot_date(), dashboard_report_for_last_90_days_uses_latest_snapshot_summary() (+10 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.08
 Nodes (41): build_workout_summary(), format_number(), is_exact_date(), mean_target_percent(), mean_target_percent_from_bounds(), normalize_definition(), normalize_spaces(), parse_amount_pair() (+33 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.06
 Nodes (28): Activity, ActivityDeduplicationIdentity, ActivityDetails, ActivityFallbackIdentity, ActivityInterval, ActivityIntervalGroup, ActivityMetrics, ActivityStream (+20 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.05
 Nodes (10): capture_request(), CapturedRequest, gemini_cache_handler(), gemini_generate_handler(), MockServerState, openai_handler(), openrouter_handler(), ServerState (+2 more)
 
-### Community 16 - "Community 16"
+### Community 18 - "Community 18"
 Cohesion: 0.05
 Nodes (1): RecordingMissingSettingsService
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.05
 Nodes (35): ActivityDetailsDto, ActivityDto, ActivityIntervalDto, ActivityIntervalGroupDto, ActivityMetricsDto, ActivityPath, ActivityStreamDto, ActivityZoneTimeDto (+27 more)
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.08
 Nodes (22): choose_preferred_planned_workout_link(), completed_workout_refresh_dates(), existing_link_candidate(), ExternalCompletedWorkoutImport, ExternalImportCommand, ExternalImportError, ExternalImportOutcome, ExternalImportService (+14 more)
 
-### Community 19 - "Community 19"
+### Community 21 - "Community 21"
 Cohesion: 0.07
 Nodes (19): AlwaysFailingCoach, CapturingAthleteSummaryCoach, CountingCoach, FailingAthleteSummaryService, generate_coach_reply_continues_when_athlete_summary_is_unavailable(), generate_coach_reply_marks_when_athlete_summary_was_regenerated(), generate_coach_reply_passes_fresh_athlete_summary_text_to_coach_once(), generate_coach_reply_preserves_oversized_context_error() (+11 more)
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.1
 Nodes (16): backfill_missing_details_imports_enriched_intervals_activity(), backfill_missing_details_reports_full_scanned_range(), backfill_missing_details_skips_activity_without_backfillable_details(), has_any_backfillable_details(), has_backfillable_activity_details(), IntervalsCompletedWorkoutBackfillService, IntervalsCompletedWorkoutBackfillService<Repo, Settings, Api, Imports>, needs_detail_backfill() (+8 more)
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.08
 Nodes (18): AiAgentsConfig, AnalysisOptions, availability_from_days_derives_configured_state(), availability_from_days_orders_weekdays_canonically(), availability_is_not_configured_without_any_available_days(), AvailabilityDay, AvailabilitySettings, cycling_settings_debug_redacts_sensitive_profile_fields() (+10 more)
 
-### Community 22 - "Community 22"
+### Community 24 - "Community 24"
 Cohesion: 0.08
 Nodes (19): completed_workout_document_round_trip_preserves_fields(), CompletedWorkoutDetailsDocument, CompletedWorkoutDocument, CompletedWorkoutIntervalDocument, CompletedWorkoutIntervalGroupDocument, CompletedWorkoutMetricsDocument, CompletedWorkoutStreamDocument, CompletedWorkoutZoneTimeDocument (+11 more)
 
-### Community 23 - "Community 23"
+### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (0): 
 
-### Community 24 - "Community 24"
+### Community 26 - "Community 26"
 Cohesion: 0.08
 Nodes (9): ApiFailure, GeminiClient, IntervalsIcuClient, map_error(), normalize_gemini_model_name(), OpenAiClient, OpenRouterClient, truncate_logged_response_body() (+1 more)
 
-### Community 25 - "Community 25"
+### Community 27 - "Community 27"
 Cohesion: 0.11
 Nodes (13): canonical_race_id_marker(), is_valid_date_format(), parse_intervals_event_id(), projected_event_category(), projected_event_description(), projected_event_name(), projected_event_start_date_local(), projected_event_type() (+5 more)
 
-### Community 26 - "Community 26"
+### Community 28 - "Community 28"
 Cohesion: 0.13
 Nodes (29): activity_hash_changes_when_details_unavailable_reason_changes(), activity_hash_changes_when_persisted_details_change(), event_date(), FixedIdGenerator, hash_activity(), hash_event(), infer_race_discipline(), infer_race_distance_meters() (+21 more)
 
-### Community 27 - "Community 27"
+### Community 29 - "Community 29"
 Cohesion: 0.09
 Nodes (3): RepositoryErrorSettingsService, TestSettingsService, UpdateIntervalsErrorSettingsService
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.11
 Nodes (24): imported_planned_workout_document_rejects_unknown_step_kind(), imported_planned_workout_document_round_trip_preserves_fields(), ImportedPlannedWorkoutDocument, load_imported_workouts(), load_projected_workouts(), load_snapshot_start_dates(), map_domain_line_to_stored_line(), map_domain_target_to_stored_target() (+16 more)
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.06
 Nodes (12): CanonicalEntityKind, CanonicalEntityRef, ConflictStatus, ExternalObjectKind, ExternalObservation, ExternalObservationParams, ExternalProvider, ExternalSyncRepositoryError (+4 more)
 
-### Community 30 - "Community 30"
-Cohesion: 0.08
-Nodes (9): build_daily_training_load_snapshots_keeps_intervals_if_and_ef_averages(), build_daily_training_load_snapshots_uses_app_ftp_only_on_or_after_app_entry_date(), completed_workout_repository_finds_by_source_activity_id(), completed_workout_repository_finds_latest_by_user(), completed_workout_repository_lists_by_user_and_date_range(), planned_workout_repository_lists_by_user_and_date_range(), recompute_from_rebuilds_snapshots_from_warmup_start(), sample_workout() (+1 more)
-
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.07
 Nodes (14): CoachReply, CoachReplyClaimResult, CoachReplyOperation, CoachReplyOperationFailureKind, CoachReplyOperationStatus, CompletedCoachReply, ConversationMessage, MessageRole (+6 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
+Cohesion: 0.1
+Nodes (23): AuthMeResponse, build_session_cookie(), buildAuthUrl(), buildGoogleLoginUrl(), clear_session_cookie(), ClientMetadata, current_user(), CurrentUserDto (+15 more)
+
+### Community 34 - "Community 34"
 Cohesion: 0.11
 Nodes (22): build_historical_context(), build_load_trend_from_snapshots(), build_planned_workout(), build_planned_workout_blocks(), build_projected_planned_workout(), build_recent_day_contexts(), build_recent_workout(), build_upcoming_day_contexts() (+14 more)
 
-### Community 33 - "Community 33"
+### Community 35 - "Community 35"
 Cohesion: 0.13
 Nodes (19): build_log_bridge_layer(), build_logger_provider(), build_resource(), build_tracer_provider(), combine_shutdown_errors(), combine_shutdown_errors_preserves_both_messages(), get_otlp_endpoint(), init_telemetry() (+11 more)
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
 Cohesion: 0.12
 Nodes (14): ConversationMessageDocument, current_workout_id_filter(), document_identity_filter(), editable_document_identity_filter(), find_preferred_document(), find_preferred_documents(), find_preferred_message_lookup_document(), legacy_event_id_filter() (+6 more)
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (2): ApiCall, FakeIntervalsApi
 
-### Community 36 - "Community 36"
+### Community 38 - "Community 38"
 Cohesion: 0.17
 Nodes (23): BodyLoggingMode, execute_and_log(), execute_and_log_no_body(), execute_and_log_with_body(), execute_and_log_without_body(), format_binary_body(), format_binary_body_formats_binary_payloads(), format_request_body() (+15 more)
 
-### Community 37 - "Community 37"
+### Community 39 - "Community 39"
 Cohesion: 0.08
 Nodes (7): IntervalsConnectionError, IntervalsConnectionTester, IntervalsService, IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>, IntervalsUseCases, LiveClock, normalize_workout_text()
 
-### Community 38 - "Community 38"
+### Community 40 - "Community 40"
+Cohesion: 0.14
+Nodes (23): env_lock(), google_oauth_settings_debug_redacts_client_secret(), required_settings_map(), settings_allow_cross_site_cookie_when_secure_and_same_site_none(), settings_allow_dev_auth_without_google_oauth_credentials(), settings_allow_dev_intervals_toggle(), settings_allow_dev_llm_coach_toggle(), settings_allow_trust_proxy_headers_toggle() (+15 more)
+
+### Community 41 - "Community 41"
 Cohesion: 0.08
 Nodes (6): ActualWorkoutMatch, MatchedWorkoutInterval, ParsedWorkoutDoc, WorkoutIntervalDefinition, WorkoutSegment, WorkoutSummary
 
-### Community 39 - "Community 39"
-Cohesion: 0.15
-Nodes (22): env_lock(), google_oauth_settings_debug_redacts_client_secret(), required_settings_map(), settings_allow_cross_site_cookie_when_secure_and_same_site_none(), settings_allow_dev_auth_without_google_oauth_credentials(), settings_allow_dev_intervals_toggle(), settings_allow_dev_llm_coach_toggle(), settings_from_env_rejects_non_unicode_values() (+14 more)
-
-### Community 40 - "Community 40"
+### Community 42 - "Community 42"
 Cohesion: 0.1
 Nodes (8): delete_race_returns_204(), EmptyHiddenSource, EmptyLabelSource, get_race_returns_race_for_existing_id(), list_races_is_scoped_to_authenticated_user(), list_races_returns_all_races(), RecordingRaceService, update_race_returns_updated_race_payload()
 
-### Community 41 - "Community 41"
+### Community 43 - "Community 43"
 Cohesion: 0.1
 Nodes (4): FailingUpsertTrainingPlanOperationRepository, InMemoryTrainingPlanOperationRepository, InMemoryTrainingPlanProjectedDayRepository, InMemoryTrainingPlanSnapshotRepository
 
-### Community 42 - "Community 42"
+### Community 44 - "Community 44"
 Cohesion: 0.08
 Nodes (14): ActivityIdResponse, ActivityIntervalGroupResponse, ActivityIntervalResponse, ActivityIntervalsResponse, ActivityResponse, ActivityStreamResponse, CreateEventRequest, EventResponse (+6 more)
 
-### Community 43 - "Community 43"
+### Community 45 - "Community 45"
 Cohesion: 0.16
 Nodes (12): activity_detail_richness(), ActivityDocument, build_activity_document(), infer_event_id_hint(), merge_activity_details(), merge_activity_for_storage(), merge_activity_metrics(), MongoActivityRepository (+4 more)
 
-### Community 44 - "Community 44"
-Cohesion: 0.08
-Nodes (5): FixedClock, FixedIds, NonRepositoryFailingReplyOperations, StubReplyOperations, StubSummaryRepository
+### Community 46 - "Community 46"
+Cohesion: 0.09
+Nodes (3): AppState, whitelist_rate_limiter_prunes_empty_ip_buckets(), WhitelistRateLimiter
 
-### Community 45 - "Community 45"
+### Community 47 - "Community 47"
 Cohesion: 0.08
 Nodes (1): ()
 
-### Community 46 - "Community 46"
+### Community 48 - "Community 48"
 Cohesion: 0.18
 Nodes (9): ActiveLogBufferGuard, capture_tracing_logs(), capture_tracing_logs_restores_outer_capture_after_nested_call(), CurrentCaptureScope, global_log_writer_commits_each_event_atomically(), GlobalLogRouter, GlobalLogWriter, init_test_tracing_subscriber() (+1 more)
 
-### Community 47 - "Community 47"
+### Community 49 - "Community 49"
 Cohesion: 0.17
 Nodes (15): canonical_entity_kind_as_str(), conflict_status_as_str(), ExternalSyncStateDocument, map_canonical_entity_kind(), map_conflict_status(), map_document_to_sync_state(), map_provider(), map_sync_state_to_document() (+7 more)
 
-### Community 48 - "Community 48"
+### Community 50 - "Community 50"
 Cohesion: 0.12
 Nodes (15): AttemptRecordDocument, map_attempt_to_document(), map_document_to_attempt(), map_document_to_failure(), map_document_to_operation(), map_document_to_phase(), map_document_to_status(), map_failure_to_document() (+7 more)
 
-### Community 49 - "Community 49"
+### Community 51 - "Community 51"
 Cohesion: 0.13
 Nodes (10): body_logging_enabled(), default_config_disables_body_logging(), EndpointLogConfig, full_config_enables_both(), insert_log_config_service_overrides_existing_config(), InsertLogConfigLayer, InsertLogConfigService, InsertLogConfigService<S> (+2 more)
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.09
 Nodes (18): AiAgentsDto, AvailabilityDayDto, AvailabilityDayRequest, AvailabilityDto, CyclingDto, IntervalsDto, OptionalStringInput, OptionsDto (+10 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.15
 Nodes (8): advance_calendar_cursor(), advance_completed_workout_cursor(), epoch_seconds_to_date(), format_date(), parse_date_cursor(), ProviderPollingService, ProviderPollingService<Api, Settings, PollStates, Imports, Time, Ids, Refresh>, spawn_provider_polling_loop()
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 0.1
 Nodes (6): CalendarEntryViewRefreshPort, CalendarEntryViewRefreshService, CalendarEntryViewRefreshService<
         Views,
@@ -959,151 +987,167 @@ Nodes (6): CalendarEntryViewRefreshPort, CalendarEntryViewRefreshService, Calend
         PlannedCompletedLinks,
     >, NoopCalendarEntryViewRefresh, NoopPlannedCompletedWorkoutLinkRepository
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.09
 Nodes (10): activity_date(), ActivityFileIdentityExtractorPort, ActivityRepositoryPort, ActivityUploadOperationRepositoryPort, EnrichedEvent, IntervalsApiPort, IntervalsSettingsPort, NoopActivityFileIdentityExtractor (+2 more)
 
-### Community 54 - "Community 54"
+### Community 56 - "Community 56"
 Cohesion: 0.09
 Nodes (10): PlannedWorkout, PlannedWorkoutDay, PlannedWorkoutDays, PlannedWorkoutLine, PlannedWorkoutParseError, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind (+2 more)
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.11
 Nodes (5): get_activity_returns_requested_seeded_activity(), InMemoryIntervalsService, list_and_get_activity_scope_results_by_user_id(), sample_activity(), sample_activity_uses_current_date_for_recent_window()
 
-### Community 56 - "Community 56"
+### Community 58 - "Community 58"
 Cohesion: 0.12
 Nodes (8): ctrl_c_registration_error_logs_and_finishes_shutdown_future(), FixedClock, reconcile_intervals_poll_states_seeds_missing_states_for_existing_connected_users(), SharedLogBuffer, sigterm_registration_error_logs_and_finishes_shutdown_future(), test_mongo_client_or_skip(), test_mongo_uri(), unique_test_database_name()
 
-### Community 57 - "Community 57"
+### Community 59 - "Community 59"
 Cohesion: 0.17
 Nodes (16): collect_body(), format_body_for_logging(), format_response_body_for_logging(), log_request(), log_response(), preserves_large_request_body_when_body_logging_enabled(), preserves_large_response_body_when_body_logging_enabled(), request_logging_json_preview_honors_configured_limit() (+8 more)
 
-### Community 58 - "Community 58"
+### Community 60 - "Community 60"
+Cohesion: 0.13
+Nodes (12): build_pending_approval_redirect(), compute_session_expiry(), GoogleLoginOutcome, GoogleLoginStart, GoogleLoginSuccess, IdentityService, IdentityService<Users, Sessions, LoginStates, Whitelist, GoogleOAuth, Time, Ids>, IdentityServiceConfig (+4 more)
+
+### Community 61 - "Community 61"
 Cohesion: 0.11
 Nodes (12): approximate_token_budget_for_model(), LlmCacheUsage, LlmChatMessage, LlmChatRequest, LlmChatResponse, LlmContextCache, LlmMessageRole, LlmProvider (+4 more)
 
-### Community 59 - "Community 59"
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (11): is_allowed_availability_duration(), validate_availability(), validate_availability_day(), validate_availability_derives_not_configured_when_all_days_unavailable(), validate_availability_ignores_incoming_false_configured_when_days_are_available(), validate_availability_rejects_duration_for_unavailable_day(), validate_availability_rejects_invalid_duration_for_available_day(), validate_optional_profile_text() (+3 more)
 
-### Community 60 - "Community 60"
+### Community 63 - "Community 63"
+Cohesion: 0.09
+Nodes (6): FtpHistoryRepository, InMemoryFtpHistoryRepository, InMemoryTrainingLoadDailySnapshotRepository, NoopFtpHistoryRepository, NoopTrainingLoadDailySnapshotRepository, TrainingLoadDailySnapshotRepository
+
+### Community 64 - "Community 64"
 Cohesion: 0.12
 Nodes (8): GeneratedTrainingPlan, TrainingPlanDay, TrainingPlanError, TrainingPlanFailureState, TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation, TrainingPlanProjectedDay, TrainingPlanSnapshot
 
-### Community 61 - "Community 61"
+### Community 65 - "Community 65"
 Cohesion: 0.1
 Nodes (7): EmptyHiddenSource, HiddenIdsSource, list_calendar_events_hides_intervals_events_linked_to_labels(), list_calendar_labels_is_scoped_to_authenticated_user(), list_calendar_labels_returns_race_labels_grouped_by_date(), RaceLabelSource, StubRaceService
 
-### Community 62 - "Community 62"
+### Community 66 - "Community 66"
 Cohesion: 0.13
 Nodes (8): activity_date(), activity_detail_richness(), FakeActivityRepository, merge_activity_details(), merge_activity_for_storage(), merge_activity_metrics(), prefer_non_empty(), RepoCall
 
-### Community 63 - "Community 63"
+### Community 67 - "Community 67"
+Cohesion: 0.12
+Nodes (10): AppUser, assign_roles(), authorize_admin_access(), AuthSession, GoogleIdentity, IdentityError, LoginState, normalize_email() (+2 more)
+
+### Community 68 - "Community 68"
 Cohesion: 0.1
 Nodes (20): AthleteProfileContext, FuturePlannedEventContext, HistoricalLoadTrendPoint, HistoricalTrainingContext, HistoricalWorkoutContext, IntervalsStatusContext, PlannedWorkoutBlockContext, PlannedWorkoutContext (+12 more)
 
-### Community 64 - "Community 64"
+### Community 69 - "Community 69"
 Cohesion: 0.1
-Nodes (6): FtpHistoryRepository, InMemoryFtpHistoryRepository, InMemoryTrainingLoadDailySnapshotRepository, NoopFtpHistoryRepository, NoopTrainingLoadDailySnapshotRepository, TrainingLoadDailySnapshotRepository
+Nodes (0): 
 
-### Community 65 - "Community 65"
+### Community 70 - "Community 70"
 Cohesion: 0.16
 Nodes (19): ActivityPath, AthletePath, capture_request(), create_event_handler(), delete_activity_handler(), delete_event_handler(), download_fit_handler(), EventPath (+11 more)
 
-### Community 66 - "Community 66"
+### Community 71 - "Community 71"
 Cohesion: 0.12
 Nodes (7): build_planned_workout(), list_calendar_events_returns_predicted_events_with_positive_safe_ids(), projected_day(), sync_planned_workout_is_scoped_to_authenticated_user(), sync_planned_workout_preserves_existing_remote_description(), sync_planned_workout_returns_synced_calendar_event(), TestTrainingPlanProjectionRepository
 
-### Community 67 - "Community 67"
+### Community 72 - "Community 72"
 Cohesion: 0.11
 Nodes (1): TestIntervalsService
 
-### Community 68 - "Community 68"
+### Community 73 - "Community 73"
 Cohesion: 0.16
 Nodes (12): build_due_filter(), due_filter_respects_backoff_window(), map_document_to_poll_state(), map_poll_state_to_document(), map_provider(), map_stream(), MongoProviderPollStateRepository, poll_state_document_rejects_unknown_stream() (+4 more)
 
-### Community 69 - "Community 69"
+### Community 74 - "Community 74"
 Cohesion: 0.17
 Nodes (17): accepts_html(), apply_incoming_trace_context(), internal_error_response(), is_api_route(), is_file_like_path(), is_health_request(), log_response_event(), make_request_span() (+9 more)
 
-### Community 70 - "Community 70"
+### Community 75 - "Community 75"
+Cohesion: 0.13
+Nodes (6): builder_ignores_snapshot_ftp_when_snapshot_window_is_incomplete(), builder_ignores_snapshot_windows_with_missing_days_inside_range(), builder_uses_ftp_history_for_chronological_ftp_change(), builder_uses_training_load_snapshots_for_historical_aggregates_and_trend(), seed_snapshot_trend(), seed_snapshot_trend_with_gap()
+
+### Community 76 - "Community 76"
 Cohesion: 0.15
 Nodes (1): WorkoutSummaryService<Repo, Ops, Time, Ids>
 
-### Community 71 - "Community 71"
+### Community 77 - "Community 77"
 Cohesion: 0.33
 Nodes (16): mongo_fixture_or_skip(), MongoFixture, sample_operation(), sample_projected_days(), sample_snapshot(), sample_snapshot_for_user(), training_plan_generation_operation_repository_round_trips_and_reclaims_failed_operations(), training_plan_generation_operation_repository_round_trips_recap_timestamp() (+8 more)
 
-### Community 72 - "Community 72"
+### Community 78 - "Community 78"
 Cohesion: 0.11
 Nodes (0): 
 
-### Community 73 - "Community 73"
+### Community 79 - "Community 79"
 Cohesion: 0.32
 Nodes (16): completed_workout_repository_round_trips_canonical_completed_workouts(), mongo_fixture_or_skip(), MongoFixture, planned_completed_link_repository_round_trips_and_indexes_links(), planned_workout_repository_excludes_snapshot_start_date_even_when_it_has_workout(), planned_workout_repository_merges_imported_and_projected_workouts(), planned_workout_repository_reads_active_projected_days_as_canonical_workouts(), planned_workout_token_repository_round_trips_and_indexes_tokens() (+8 more)
 
-### Community 74 - "Community 74"
+### Community 80 - "Community 80"
 Cohesion: 0.23
 Nodes (15): escaped_near_limit_valid_payload_is_still_accepted(), frontend_fixture(), FrontendFixture, log_ingestion_does_not_emit_request_body_log(), log_ingestion_rejects_requests_with_mismatched_origin(), log_ingestion_rejects_requests_without_origin(), log_ingestion_returns_not_found_when_disabled(), logs_request() (+7 more)
 
-### Community 75 - "Community 75"
+### Community 81 - "Community 81"
+Cohesion: 0.19
+Nodes (12): ApproveDuringPendingSaveWhitelist, handle_google_callback_adds_missing_user_to_whitelist_and_returns_pending_approval(), handle_google_callback_allows_new_user_when_whitelist_entry_is_approved(), handle_google_callback_consumes_login_state_atomically(), handle_google_callback_consumes_login_state_before_side_effects(), handle_google_callback_creates_new_user_and_session(), handle_google_callback_defaults_redirect_to_calendar_when_return_to_missing(), handle_google_callback_does_not_overwrite_concurrent_whitelist_approval() (+4 more)
+
+### Community 82 - "Community 82"
 Cohesion: 0.11
 Nodes (8): ResponseActivity, ResponseActivityGroup, ResponseActivityId, ResponseActivityInterval, ResponseActivityIntervals, ResponseActivityStream, ResponseEvent, ResponseUpload
 
-### Community 76 - "Community 76"
+### Community 83 - "Community 83"
+Cohesion: 0.14
+Nodes (2): AdminIdentityErrorService, TestIdentityServiceWithSession
+
+### Community 84 - "Community 84"
 Cohesion: 0.11
 Nodes (3): InMemoryCompletedWorkoutRepository, InMemoryPlannedWorkoutRepository, InMemorySpecialDayRepository
 
-### Community 77 - "Community 77"
+### Community 85 - "Community 85"
 Cohesion: 0.14
 Nodes (5): FixedClock, new_call_log(), push_call(), StubTrainingPlanGenerator, StubWorkoutSummaryPort
 
-### Community 78 - "Community 78"
+### Community 86 - "Community 86"
 Cohesion: 0.16
 Nodes (1): TestWorkoutSummaryService
 
-### Community 79 - "Community 79"
+### Community 87 - "Community 87"
 Cohesion: 0.19
 Nodes (11): canonical_entity_kind_as_str(), external_object_kind_as_str(), ExternalObservationDocument, map_canonical_entity_kind(), map_document_to_observation(), map_external_object_kind(), map_observation_to_document(), map_provider() (+3 more)
 
-### Community 80 - "Community 80"
-Cohesion: 0.16
-Nodes (14): AuthMeResponse, build_session_cookie(), buildAuthUrl(), buildGoogleLoginUrl(), clear_session_cookie(), current_user(), CurrentUserDto, finish_google_login() (+6 more)
-
-### Community 81 - "Community 81"
+### Community 88 - "Community 88"
 Cohesion: 0.22
 Nodes (15): build_projected_calendar_event(), build_update_event(), format_projected_step_duration(), format_projected_step_target(), merge_event_description(), projected_day_payload_hash(), projected_day_sync_status(), projected_event_payload_hash() (+7 more)
 
-### Community 82 - "Community 82"
-Cohesion: 0.14
-Nodes (9): AppUser, assign_roles(), authorize_admin_access(), AuthSession, GoogleIdentity, IdentityError, LoginState, normalize_email() (+1 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.16
-Nodes (9): compute_session_expiry(), GoogleLoginStart, GoogleLoginSuccess, IdentityService, IdentityService<Users, Sessions, LoginStates, GoogleOAuth, Time, Ids>, IdentityServiceConfig, IdentityUseCases, sanitize_return_to() (+1 more)
-
-### Community 84 - "Community 84"
+### Community 89 - "Community 89"
 Cohesion: 0.18
 Nodes (13): compress_encoded_runs(), compress_power_stream(), compress_stream_chunks(), encode_power_level(), EncodedPowerRun, extract_and_average_stream(), extract_raw_stream(), format_encoded_runs() (+5 more)
 
-### Community 85 - "Community 85"
+### Community 90 - "Community 90"
 Cohesion: 0.11
 Nodes (0): 
 
-### Community 86 - "Community 86"
+### Community 91 - "Community 91"
+Cohesion: 0.12
+Nodes (2): SessionMappedIdentityService, TestIdentityServiceWithSession
+
+### Community 92 - "Community 92"
 Cohesion: 0.13
 Nodes (10): map_legacy_projection_to_document(), map_record_to_document(), map_summary_to_document(), MongoPestParserPocWorkoutRepository, ParsedWorkoutDocDocument, PestParserPocParsedPayloadDocument, PestParserPocWorkoutDocument, WorkoutIntervalDefinitionDocument (+2 more)
 
-### Community 87 - "Community 87"
+### Community 93 - "Community 93"
 Cohesion: 0.12
 Nodes (9): AuthSettings, AuthSettingsParts, DevAuthSettings, GoogleOAuthSettings, MongoSettings, ServerSettings, SessionSettings, Settings (+1 more)
 
-### Community 88 - "Community 88"
+### Community 94 - "Community 94"
 Cohesion: 0.12
 Nodes (8): CalendarError, CalendarEvent, CalendarEventCategory, CalendarEventSource, CalendarProjectedWorkout, PlannedWorkoutSyncRecord, PlannedWorkoutSyncStatus, SyncPlannedWorkout
 
-### Community 89 - "Community 89"
+### Community 95 - "Community 95"
 Cohesion: 0.14
 Nodes (6): CalendarEntryViewService, CalendarEntryViewService<
         Repository,
@@ -1111,155 +1155,147 @@ Nodes (6): CalendarEntryViewService, CalendarEntryViewService<
         NoopExternalSyncStateRepository,
     >, CalendarEntryViewService<Repository, PlannedSyncs, SyncStates>, linked_intervals_event_id(), map_external_sync_state(), map_planned_sync_record_to_calendar_entry_sync()
 
-### Community 90 - "Community 90"
+### Community 96 - "Community 96"
 Cohesion: 0.12
 Nodes (6): ExternalObservationRepository, ExternalSyncStateRepository, NoopExternalObservationRepository, NoopExternalSyncStateRepository, NoopProviderPollStateRepository, ProviderPollStateRepository
 
-### Community 91 - "Community 91"
+### Community 97 - "Community 97"
 Cohesion: 0.12
 Nodes (7): CreateRace, Race, RaceDiscipline, RaceError, RacePriority, RaceResult, UpdateRace
 
-### Community 92 - "Community 92"
+### Community 98 - "Community 98"
 Cohesion: 0.15
-Nodes (2): AdminIdentityErrorService, TestIdentityServiceWithSession
+Nodes (5): InMemoryTrainingLoadDailySnapshotRepository, TestIdentityServiceWithSession, training_load_dashboard_rejects_unknown_range(), training_load_dashboard_returns_empty_payload_when_user_has_no_snapshots(), training_load_dashboard_returns_points_for_authenticated_user_only()
 
-### Community 93 - "Community 93"
+### Community 99 - "Community 99"
 Cohesion: 0.29
 Nodes (16): add_days(), date_epoch(), plan_with_invalid_day(), single_invalid_day(), single_rest_day(), snapshot_for_first_day(), snapshot_projected_days_for_first_day(), stale_pending_operation_with_checkpoints() (+8 more)
 
-### Community 94 - "Community 94"
+### Community 100 - "Community 100"
 Cohesion: 0.2
 Nodes (9): CalendarEntryRaceDocument, CalendarEntrySummaryDocument, CalendarEntrySyncDocument, CalendarEntryViewDocument, map_document_to_entry(), map_entry_to_document(), map_kind_from_str(), MongoCalendarEntryViewRepository (+1 more)
 
-### Community 95 - "Community 95"
+### Community 101 - "Community 101"
 Cohesion: 0.23
 Nodes (3): map_user_document(), MongoUserRepository, UserDocument
 
-### Community 96 - "Community 96"
+### Community 102 - "Community 102"
 Cohesion: 0.18
 Nodes (11): category_to_string(), map_actual_workout_to_dto(), map_calendar_event_to_dto(), map_calendar_label_payload_to_dto(), map_calendar_label_to_dto(), map_calendar_labels_to_dto(), map_category(), map_enriched_event_to_dto() (+3 more)
 
-### Community 97 - "Community 97"
-Cohesion: 0.12
-Nodes (1): AppState
-
-### Community 98 - "Community 98"
-Cohesion: 0.12
-Nodes (11): NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation, PestParserPocParsedPayload, PestParserPocRecordContext, PestParserPocRepositoryPort, PestParserPocSource, PestParserPocStatus (+3 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.14
-Nodes (3): builder_uses_ftp_history_for_chronological_ftp_change(), builder_uses_training_load_snapshots_for_historical_aggregates_and_trend(), seed_snapshot_trend()
-
-### Community 100 - "Community 100"
-Cohesion: 0.3
-Nodes (15): average_metric(), build_daily_training_load_snapshots(), date_range_inclusive(), effective_history_entry_for_date(), ewma_at_index(), format_date(), parse_date(), recent_workouts_until() (+7 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.12
-Nodes (0): 
-
-### Community 102 - "Community 102"
-Cohesion: 0.14
-Nodes (2): SessionMappedIdentityService, TestIdentityServiceWithSession
-
 ### Community 103 - "Community 103"
-Cohesion: 0.23
-Nodes (14): api_error_propagated_to_caller(), create_event_passes_event_to_api(), create_event_stores_failed_poc_record_for_malformed_workout(), create_event_stores_poc_record_for_outbound_push(), delete_event_calls_api_and_returns_ok(), download_fit_returns_bytes(), FixedClock, get_enriched_event_propagates_activity_lookup_failure() (+6 more)
+Cohesion: 0.13
+Nodes (3): IntervalsErrorWrapper, recording_import_service_failing_on_call_only_fails_configured_invocation(), sample_completed_workout_import_command()
 
 ### Community 104 - "Community 104"
 Cohesion: 0.12
-Nodes (2): InMemoryCoachReplyOperationRepository, InMemoryWorkoutSummaryRepository
+Nodes (11): NoopPestParserPocRepository, PestParserPocDirection, PestParserPocOperation, PestParserPocParsedPayload, PestParserPocRecordContext, PestParserPocRepositoryPort, PestParserPocSource, PestParserPocStatus (+3 more)
 
 ### Community 105 - "Community 105"
+Cohesion: 0.3
+Nodes (15): average_metric(), build_daily_training_load_snapshots(), date_range_inclusive(), effective_history_entry_for_date(), ewma_at_index(), format_date(), parse_date(), recent_workouts_until() (+7 more)
+
+### Community 106 - "Community 106"
 Cohesion: 0.12
 Nodes (0): 
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
+Cohesion: 0.23
+Nodes (14): api_error_propagated_to_caller(), create_event_passes_event_to_api(), create_event_stores_failed_poc_record_for_malformed_workout(), create_event_stores_poc_record_for_outbound_push(), delete_event_calls_api_and_returns_ok(), download_fit_returns_bytes(), FixedClock, get_enriched_event_propagates_activity_lookup_failure() (+6 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.12
+Nodes (2): InMemoryCoachReplyOperationRepository, InMemoryWorkoutSummaryRepository
+
+### Community 109 - "Community 109"
+Cohesion: 0.12
+Nodes (0): 
+
+### Community 110 - "Community 110"
 Cohesion: 0.14
 Nodes (3): claim_pending_reclaims_stale_pending_operations(), InMemoryCoachReplyOperationRepository, InMemoryWorkoutSummaryRepository
 
-### Community 107 - "Community 107"
+### Community 111 - "Community 111"
 Cohesion: 0.18
 Nodes (7): makeActivity(), makeActivityDetails(), makeActivityMetrics(), makeActualWorkout(), makeEvent(), makeEventDefinition(), makeWorkoutSummary()
 
-### Community 108 - "Community 108"
+### Community 112 - "Community 112"
 Cohesion: 0.16
 Nodes (4): listActivities(), listCalendarEvents(), listEvents(), toQueryString()
 
-### Community 109 - "Community 109"
+### Community 113 - "Community 113"
 Cohesion: 0.13
 Nodes (1): DevIntervalsClient
 
-### Community 110 - "Community 110"
+### Community 114 - "Community 114"
 Cohesion: 0.16
 Nodes (6): map_discipline(), map_document_to_race(), map_priority(), map_race_to_document(), MongoRaceRepository, RaceDocument
 
-### Community 111 - "Community 111"
+### Community 115 - "Community 115"
 Cohesion: 0.28
 Nodes (1): AthleteSummaryService<Repo, Ops, Generator, Time>
 
-### Community 112 - "Community 112"
+### Community 116 - "Community 116"
 Cohesion: 0.15
 Nodes (2): RecapSnapshot, WorkoutSummaryService<Repo, Ops, Time, Ids>
 
-### Community 113 - "Community 113"
+### Community 117 - "Community 117"
 Cohesion: 0.13
 Nodes (0): 
 
-### Community 114 - "Community 114"
+### Community 118 - "Community 118"
 Cohesion: 0.14
 Nodes (1): ScopedIntervalsService
 
-### Community 115 - "Community 115"
+### Community 119 - "Community 119"
 Cohesion: 0.13
 Nodes (0): 
 
-### Community 116 - "Community 116"
+### Community 120 - "Community 120"
 Cohesion: 0.13
 Nodes (2): FailingCalendarRefresh, RecordingCalendarRefresh
 
-### Community 117 - "Community 117"
+### Community 121 - "Community 121"
 Cohesion: 0.16
 Nodes (3): buildCalendarWeek(), roundMetric(), sumMetric()
 
-### Community 118 - "Community 118"
+### Community 122 - "Community 122"
 Cohesion: 0.23
 Nodes (8): addDays(), addWeeks(), formatDateRange(), getMondayOfWeek(), isSameDay(), isToday(), startOfLocalDay(), toDateKey()
 
-### Community 119 - "Community 119"
+### Community 123 - "Community 123"
 Cohesion: 0.14
 Nodes (1): IntervalsApiAdapter
 
-### Community 120 - "Community 120"
+### Community 124 - "Community 124"
 Cohesion: 0.21
 Nodes (7): training_plan_correction_system_prompt(), training_plan_initial_window_system_prompt(), training_plan_prompts_adjust_availability_guidance_when_not_configured(), training_plan_prompts_include_durability_guidelines(), training_plan_recap_system_prompt(), TrainingPlanLlmGenerator, TrainingPlanLlmGenerator<Time>
 
-### Community 121 - "Community 121"
+### Community 125 - "Community 125"
 Cohesion: 0.14
 Nodes (13): OpenRouterCacheControl, OpenRouterChatRequest, OpenRouterChatResponse, OpenRouterChoice, OpenRouterContentPart, OpenRouterMessage, OpenRouterMessageContent, OpenRouterMessageResponse (+5 more)
 
-### Community 122 - "Community 122"
+### Community 126 - "Community 126"
 Cohesion: 0.19
 Nodes (7): CalendarEntryRaceDocument, CalendarEntrySyncDocument, CalendarEntryViewDocument, map_race_label(), MongoCalendarEntryViewCalendarSource, parse_race_description(), strip_race_title_prefix()
 
-### Community 123 - "Community 123"
+### Community 127 - "Community 127"
 Cohesion: 0.22
 Nodes (11): binary_body_preview_format(), body_preview_truncates(), format_binary_body_preview(), format_body_preview(), header_redaction(), is_sensitive_header(), redact_headers(), redact_sensitive_child_value() (+3 more)
 
-### Community 124 - "Community 124"
+### Community 128 - "Community 128"
 Cohesion: 0.16
 Nodes (4): merge_connection_credentials(), merge_credentials(), MergedCredentials, normalize_optional_input()
 
-### Community 125 - "Community 125"
+### Community 129 - "Community 129"
 Cohesion: 0.25
 Nodes (13): completed_workout_dedup_key(), completed_workout_distance_bucket(), completed_workout_duration_seconds(), completed_workout_stream_bucket(), completed_workout_stream_distance_bucket(), completed_workout_stream_sample_count(), has_any_details(), last_numeric_value() (+5 more)
 
-### Community 126 - "Community 126"
+### Community 130 - "Community 130"
 Cohesion: 0.14
 Nodes (9): PlannedWorkout, PlannedWorkoutContent, PlannedWorkoutError, PlannedWorkoutLine, PlannedWorkoutRepeat, PlannedWorkoutStep, PlannedWorkoutStepKind, PlannedWorkoutTarget (+1 more)
 
-### Community 127 - "Community 127"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (2): TrainingPlanGenerationService<
         Snapshots,
@@ -1278,95 +1314,99 @@ Nodes (2): TrainingPlanGenerationService<
         Refresh,
     >
 
-### Community 128 - "Community 128"
+### Community 132 - "Community 132"
 Cohesion: 0.19
 Nodes (5): completed_workout_repository(), completed_workout_target_adapter_accepts_canonical_completed_workout_ids(), completed_workout_target_adapter_accepts_legacy_completed_workout_ids(), InMemoryCompletedWorkoutRepository, latest_completed_activity_adapter_falls_back_to_legacy_completed_workout_id()
 
-### Community 129 - "Community 129"
+### Community 133 - "Community 133"
 Cohesion: 0.14
 Nodes (0): 
 
-### Community 130 - "Community 130"
+### Community 134 - "Community 134"
 Cohesion: 0.16
 Nodes (2): LargeContextTrainingContextBuilder, UnconfiguredAvailabilityTrainingContextBuilder
 
-### Community 131 - "Community 131"
+### Community 135 - "Community 135"
 Cohesion: 0.26
 Nodes (8): getAiAgentsFieldValue(), getOptionalStringFieldValue(), normalizeAiAgentsPayload(), testAiAgentsConnection(), trimToUndefined(), updateAiAgents(), updateCycling(), updateIntervals()
 
-### Community 132 - "Community 132"
+### Community 136 - "Community 136"
 Cohesion: 0.23
 Nodes (7): ActivityFileIdentityExtractor, enum_u8_field(), extract_fit_identity(), float_field(), int_field(), map_fit_activity_type(), timestamp_field()
 
-### Community 133 - "Community 133"
+### Community 137 - "Community 137"
 Cohesion: 0.21
 Nodes (6): map_document_to_domain(), map_domain_to_document(), match_source_as_str(), match_source_from_str(), MongoPlannedCompletedWorkoutLinkRepository, PlannedCompletedWorkoutLinkDocument
 
-### Community 134 - "Community 134"
+### Community 138 - "Community 138"
 Cohesion: 0.49
 Nodes (10): calendar_entry_view_repository_creates_expected_indexes(), calendar_entry_view_repository_lists_mixed_entries_by_date_range(), calendar_entry_view_repository_rejects_replace_range_entries_outside_requested_dates(), calendar_entry_view_repository_replace_all_overwrites_stale_user_rows(), calendar_entry_view_repository_replaces_all_entries_for_user(), calendar_entry_view_repository_replaces_only_target_range_and_handles_date_moves(), mongo_fixture_or_skip(), MongoFixture (+2 more)
 
-### Community 135 - "Community 135"
+### Community 139 - "Community 139"
 Cohesion: 0.15
 Nodes (0): 
 
-### Community 136 - "Community 136"
+### Community 140 - "Community 140"
 Cohesion: 0.15
 Nodes (0): 
 
-### Community 137 - "Community 137"
+### Community 141 - "Community 141"
 Cohesion: 0.15
 Nodes (1): InMemoryWorkoutSummaryRepository
 
-### Community 138 - "Community 138"
+### Community 142 - "Community 142"
 Cohesion: 0.21
 Nodes (5): buildWorkoutItems(), chooseMatchedActivity(), inferEventIdHint(), namesLookRelated(), normalizeName()
 
-### Community 139 - "Community 139"
+### Community 143 - "Community 143"
 Cohesion: 0.26
 Nodes (9): AuthenticationError, buildUrl(), del(), get(), HttpError, patch(), post(), put() (+1 more)
 
-### Community 140 - "Community 140"
+### Community 144 - "Community 144"
 Cohesion: 0.24
 Nodes (8): finish_server_shutdown(), reconcile_intervals_poll_states(), should_reset_poll_state(), shutdown_signal(), TrainingPlanWorkoutSummaryAdapter, TrainingPlanWorkoutSummaryAdapter<Service>, wait_for_ctrl_c(), wait_for_sigterm()
 
-### Community 141 - "Community 141"
+### Community 145 - "Community 145"
 Cohesion: 0.17
 Nodes (1): IntervalsIcuClient
 
-### Community 142 - "Community 142"
+### Community 146 - "Community 146"
 Cohesion: 0.21
 Nodes (4): chat_times_out_when_model_exceeds_deadline(), is_thinking_model(), LlmAdapter, with_timeout()
 
-### Community 143 - "Community 143"
+### Community 147 - "Community 147"
 Cohesion: 0.21
 Nodes (2): CoachReplyOperationDocument, MongoCoachReplyOperationRepository
 
-### Community 144 - "Community 144"
+### Community 148 - "Community 148"
 Cohesion: 0.23
 Nodes (4): LoginStateDocument, map_login_state_document(), MongoLoginStateRepository, rejects_login_state_expiry_that_cannot_be_converted_to_bson_datetime()
 
-### Community 145 - "Community 145"
+### Community 149 - "Community 149"
 Cohesion: 0.23
 Nodes (6): map_document_to_special_day(), map_kind_from_str(), map_kind_to_str(), map_special_day_to_document(), MongoSpecialDayRepository, SpecialDayDocument
 
-### Community 146 - "Community 146"
+### Community 150 - "Community 150"
+Cohesion: 0.18
+Nodes (4): map_domain_to_document(), MongoTrainingLoadDailySnapshotRepository, TrainingLoadDailySnapshotDateOnlyDocument, TrainingLoadDailySnapshotDocument
+
+### Community 151 - "Community 151"
 Cohesion: 0.21
 Nodes (3): MongoTrainingPlanProjectionRepository, TrainingPlanProjectedDayDocument, validate_replacement_scope()
 
-### Community 147 - "Community 147"
+### Community 152 - "Community 152"
 Cohesion: 0.18
 Nodes (3): MongoTrainingPlanSnapshotRepository, TrainingPlanDayDocument, TrainingPlanSnapshotDocument
 
-### Community 148 - "Community 148"
+### Community 153 - "Community 153"
 Cohesion: 0.17
 Nodes (11): CalendarActivityLabelDto, CalendarCustomLabelDto, CalendarEventDto, CalendarHealthLabelDto, CalendarLabelDto, CalendarLabelPayloadDto, CalendarLabelsResponseDto, CalendarRaceLabelDto (+3 more)
 
-### Community 149 - "Community 149"
+### Community 154 - "Community 154"
 Cohesion: 0.24
 Nodes (6): optional_bool_setting(), optional_string_setting(), parse_bool_setting(), parse_dev_auth_settings(), parse_google_oauth_settings(), required()
 
-### Community 150 - "Community 150"
+### Community 155 - "Community 155"
 Cohesion: 0.24
 Nodes (8): CalendarService<
         Intervals,
@@ -1380,359 +1420,371 @@ Nodes (8): CalendarService<
         Completed,
     >, float_stream_values(), integer_stream_values(), legacy_activity_id(), map_calendar_entry_to_event(), map_calendar_sync_status(), map_completed_workout_to_actual_workout_match(), parse_projected_workout()
 
-### Community 151 - "Community 151"
+### Community 156 - "Community 156"
 Cohesion: 0.18
 Nodes (8): CalendarActivityLabel, CalendarCustomLabel, CalendarHealthLabel, CalendarLabel, CalendarLabelError, CalendarLabelPayload, CalendarLabelsResponse, CalendarRaceLabel
 
-### Community 152 - "Community 152"
+### Community 157 - "Community 157"
 Cohesion: 0.27
 Nodes (10): date_prefix(), linked_intervals_event_id(), map_sync_state(), planned_workout_title(), project_completed_workout_entry(), project_planned_workout_entry(), project_race_entry(), project_special_day_entry() (+2 more)
 
-### Community 153 - "Community 153"
-Cohesion: 0.17
-Nodes (9): CompletedWorkout, CompletedWorkoutDetails, CompletedWorkoutError, CompletedWorkoutInterval, CompletedWorkoutIntervalGroup, CompletedWorkoutMetrics, CompletedWorkoutSeries, CompletedWorkoutStream (+1 more)
-
-### Community 154 - "Community 154"
-Cohesion: 0.17
-Nodes (0): 
-
-### Community 155 - "Community 155"
-Cohesion: 0.17
-Nodes (10): CompactAvailabilityDay, CompactFuturePlannedEvent, CompactHistoricalLoadTrend, CompactHistoricalWorkout, CompactHistory, CompactIntervalsStatus, CompactPlannedWorkoutBlock, CompactProfile (+2 more)
-
-### Community 156 - "Community 156"
-Cohesion: 0.24
-Nodes (7): build_load_trend(), build_load_trend_point(), build_recent_interval_blocks(), build_recent_interval_blocks_by_activity_id(), ewma_at_index(), ewma_latest(), rolling_average_at_index()
-
-### Community 157 - "Community 157"
-Cohesion: 0.17
-Nodes (0): 
-
 ### Community 158 - "Community 158"
 Cohesion: 0.17
-Nodes (1): InMemoryUserSettingsRepository
+Nodes (9): CompletedWorkout, CompletedWorkoutDetails, CompletedWorkoutError, CompletedWorkoutInterval, CompletedWorkoutIntervalGroup, CompletedWorkoutMetrics, CompletedWorkoutSeries, CompletedWorkoutStream (+1 more)
 
 ### Community 159 - "Community 159"
 Cohesion: 0.17
 Nodes (0): 
 
 ### Community 160 - "Community 160"
+Cohesion: 0.17
+Nodes (10): CompactAvailabilityDay, CompactFuturePlannedEvent, CompactHistoricalLoadTrend, CompactHistoricalWorkout, CompactHistory, CompactIntervalsStatus, CompactPlannedWorkoutBlock, CompactProfile (+2 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.24
+Nodes (7): build_load_trend(), build_load_trend_point(), build_recent_interval_blocks(), build_recent_interval_blocks_by_activity_id(), ewma_at_index(), ewma_latest(), rolling_average_at_index()
+
+### Community 162 - "Community 162"
+Cohesion: 0.17
+Nodes (0): 
+
+### Community 163 - "Community 163"
+Cohesion: 0.17
+Nodes (10): FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadDashboardPoint, TrainingLoadDashboardRange, TrainingLoadDashboardReport, TrainingLoadDashboardSummary, TrainingLoadError (+2 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.38
+Nodes (8): ftp_history_repository_upserts_and_resolves_effective_entry(), mongo_fixture_or_skip(), MongoFixture, redact_uri_credentials(), sample_ftp_entry(), sample_snapshot(), training_load_daily_snapshot_repository_finds_oldest_date_for_user(), training_load_daily_snapshot_repository_replaces_days_and_deletes_from_date()
+
+### Community 165 - "Community 165"
+Cohesion: 0.17
+Nodes (1): InMemoryUserSettingsRepository
+
+### Community 166 - "Community 166"
+Cohesion: 0.17
+Nodes (0): 
+
+### Community 167 - "Community 167"
 Cohesion: 0.2
 Nodes (2): configured_availability(), TestAvailabilitySettingsService
 
-### Community 161 - "Community 161"
+### Community 168 - "Community 168"
+Cohesion: 0.2
+Nodes (2): clamp(), resolveHoveredIndex()
+
+### Community 169 - "Community 169"
 Cohesion: 0.27
 Nodes (8): buildTestStatusMessage(), clearDraftApiKeys(), clearTestStatusIfNeeded(), handleSave(), handleTest(), setStatusFromTest(), updateDraft(), updateProvider()
 
-### Community 162 - "Community 162"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (7): approximate_token_usage(), build_conversation(), build_stable_context(), build_volatile_context(), LlmWorkoutCoach, LlmWorkoutCoach<Time>, workout_coach_system_prompt()
 
-### Community 163 - "Community 163"
+### Community 171 - "Community 171"
 Cohesion: 0.35
 Nodes (10): activity_document_bson_round_trip_preserves_enriched_completed_fields(), enriched_activity(), infer_event_id_hint_checks_description_after_non_matching_external_id(), merge_activity_for_storage_drops_time_streams(), merge_equal_richness_payloads_preserves_complementary_detail_buckets(), merge_richer_incoming_activity_replaces_existing_payload(), merge_sparse_activity_payload_preserves_existing_enriched_fields(), normalize_activity_document_drops_time_streams_and_refreshes_dedupe_fields() (+2 more)
 
-### Community 164 - "Community 164"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (4): AthleteSummaryGenerationOperationDocument, map_document_to_domain(), map_domain_to_document(), MongoAthleteSummaryGenerationOperationRepository
 
-### Community 165 - "Community 165"
+### Community 173 - "Community 173"
 Cohesion: 0.22
 Nodes (5): map_document_to_record(), map_record_to_document(), map_status(), MongoPlannedWorkoutSyncRepository, PlannedWorkoutSyncDocument
 
-### Community 166 - "Community 166"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (4): map_session_document(), MongoSessionRepository, rejects_session_expiry_that_cannot_be_converted_to_bson_datetime(), SessionDocument
 
-### Community 167 - "Community 167"
+### Community 175 - "Community 175"
 Cohesion: 0.18
 Nodes (6): BackfillCompletedWorkoutDetailsResult, canonical_completed_workout_id(), CompletedWorkoutAdminUseCases, CompletedWorkoutReadService, CompletedWorkoutReadService<Repo>, CompletedWorkoutReadUseCases
 
-### Community 168 - "Community 168"
+### Community 176 - "Community 176"
 Cohesion: 0.35
 Nodes (9): detect_intervals_from_power_stream(), detected_interval_candidates(), evaluate_activity_match(), extract_float_stream(), extract_integer_stream(), find_best_activity_match(), IntervalCandidate, matching_segments() (+1 more)
 
-### Community 169 - "Community 169"
+### Community 177 - "Community 177"
 Cohesion: 0.18
 Nodes (10): CompactFocus, CompactPlannedWorkout, CompactPlannedWorkoutRef, CompactProjectedDay, CompactProjectedWorkout, CompactRecentDay, CompactRecentWorkout, CompactSpecialDay (+2 more)
 
-### Community 170 - "Community 170"
+### Community 178 - "Community 178"
+Cohesion: 0.18
+Nodes (0): 
+
+### Community 179 - "Community 179"
 Cohesion: 0.35
 Nodes (4): mongo_fixture_or_skip(), MongoFixture, pest_parser_poc_repository_creates_expected_indexes(), pest_parser_poc_repository_inserts_failed_record_document()
 
-### Community 171 - "Community 171"
+### Community 180 - "Community 180"
 Cohesion: 0.22
 Nodes (3): find_best_activity_match_prefers_detected_intervals_and_extracts_streams(), ignores_invalid_stream_samples_when_extracting_actual_workout_data(), sample_activity()
 
-### Community 172 - "Community 172"
+### Community 181 - "Community 181"
 Cohesion: 0.18
 Nodes (1): FakeSettingsUseCases
 
-### Community 173 - "Community 173"
+### Community 182 - "Community 182"
 Cohesion: 0.18
 Nodes (0): 
 
-### Community 174 - "Community 174"
+### Community 183 - "Community 183"
 Cohesion: 0.22
 Nodes (1): InMemoryCoachReplyOperationRepository
 
-### Community 175 - "Community 175"
+### Community 184 - "Community 184"
 Cohesion: 0.38
 Nodes (8): createWorkoutSummary(), ensureWorkoutSummary(), getWorkoutSummary(), normalizeWorkoutTargetId(), reopenWorkoutSummary(), saveWorkoutSummary(), sendWorkoutSummaryMessage(), updateWorkoutSummaryRpe()
 
-### Community 176 - "Community 176"
+### Community 185 - "Community 185"
 Cohesion: 0.22
 Nodes (2): formatRaceDate(), parseRaceDate()
 
-### Community 177 - "Community 177"
+### Community 186 - "Community 186"
 Cohesion: 0.29
 Nodes (4): extract_message_text(), map_message(), map_request(), map_response()
 
-### Community 178 - "Community 178"
+### Community 187 - "Community 187"
 Cohesion: 0.22
 Nodes (3): database_needs_bootstrap(), ensure_database_exists(), MongoConnectionError
 
-### Community 179 - "Community 179"
+### Community 188 - "Community 188"
 Cohesion: 0.22
 Nodes (3): FtpHistoryDocument, map_domain_to_document(), MongoFtpHistoryRepository
 
-### Community 180 - "Community 180"
+### Community 189 - "Community 189"
 Cohesion: 0.22
 Nodes (3): LlmContextCacheDocument, map_domain_to_document(), MongoLlmContextCacheRepository
 
-### Community 181 - "Community 181"
+### Community 190 - "Community 190"
 Cohesion: 0.22
-Nodes (3): map_domain_to_document(), MongoTrainingLoadDailySnapshotRepository, TrainingLoadDailySnapshotDocument
+Nodes (2): MongoWhitelistRepository, WhitelistEntryDocument
 
-### Community 182 - "Community 182"
+### Community 191 - "Community 191"
 Cohesion: 0.4
 Nodes (9): auth_and_get_race_service(), create_race(), delete_race(), get_race(), list_races(), map_request(), parse_discipline(), parse_priority() (+1 more)
 
-### Community 183 - "Community 183"
+### Community 192 - "Community 192"
 Cohesion: 0.38
 Nodes (9): client_error_message(), close_ws(), handle_socket(), handle_socket_message(), process_send_message(), send_ws_json(), should_close_worker(), SocketMessageAction (+1 more)
 
-### Community 184 - "Community 184"
-Cohesion: 0.2
-Nodes (0): 
-
-### Community 185 - "Community 185"
+### Community 193 - "Community 193"
 Cohesion: 0.38
 Nodes (9): base_values(), client_log_ingestion_can_be_enabled_explicitly(), client_log_ingestion_defaults_to_disabled(), dev_auth_can_supply_google_oauth_defaults(), dev_intervals_can_be_enabled_explicitly(), dev_llm_coach_can_be_enabled_explicitly(), dev_llm_coach_defaults_to_disabled(), legacy_time_stream_cleanup_can_be_enabled_explicitly() (+1 more)
 
-### Community 186 - "Community 186"
+### Community 194 - "Community 194"
 Cohesion: 0.38
 Nodes (9): build_standalone_completed_entries(), group_completed_workouts_by_planned_id(), index_planned_entry_positions(), merge_completed_workout_into_planned_entry(), merge_single_completed_match_into_planned_entries(), merge_workout_entries(), rebuild_calendar_entries(), should_keep_completed_workout_as_standalone_entry() (+1 more)
 
-### Community 187 - "Community 187"
+### Community 195 - "Community 195"
+Cohesion: 0.22
+Nodes (7): classify_tsb_zone(), round_to_2(), TrainingLoadDashboardReadService, TrainingLoadDashboardReadService<Snapshots>, TrainingLoadDashboardReadUseCases, TrainingLoadRecomputeService, TrainingLoadRecomputeUseCases
+
+### Community 196 - "Community 196"
 Cohesion: 0.56
 Nodes (7): calendar_entry_view_calendar_source_reads_race_labels_from_persisted_view(), mongo_fixture_or_skip(), MongoFixture, race_calendar_hides_only_intervals_events_linked_to_races_in_requested_range(), race_repository_creates_expected_indexes(), race_repository_round_trips_race_and_lists_by_date_range(), sample_race()
 
-### Community 188 - "Community 188"
+### Community 197 - "Community 197"
 Cohesion: 0.51
 Nodes (6): mongo_fixture_or_skip(), MongoFixture, sample_summary(), workout_summary_repository_creates_legacy_event_id_index(), workout_summary_repository_list_uses_legacy_fallback_when_current_match_is_absent(), workout_summary_repository_prefers_current_workout_id_over_legacy_event_id()
 
-### Community 189 - "Community 189"
+### Community 198 - "Community 198"
 Cohesion: 0.2
 Nodes (0): 
 
-### Community 190 - "Community 190"
+### Community 199 - "Community 199"
 Cohesion: 0.2
 Nodes (0): 
 
-### Community 191 - "Community 191"
+### Community 200 - "Community 200"
 Cohesion: 0.36
 Nodes (5): buildDayItems(), buildGenericEventItem(), formatMinutes(), summarizeCompletedActivity(), summarizePlannedEvent()
 
-### Community 192 - "Community 192"
+### Community 201 - "Community 201"
 Cohesion: 0.25
 Nodes (3): buildProtocol(), buildWorkoutSummaryWebSocketUrl(), StaleWorkoutSelectionError
 
-### Community 193 - "Community 193"
+### Community 202 - "Community 202"
+Cohesion: 0.33
+Nodes (5): formatMetricValue(), formatNumber(), formatSignedMetricValue(), formatTwoDecimalValue(), formatWattsValue()
+
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (6): formatLogMessage(), generateTraceparent(), getFrontendTraceparent(), getTraceId(), randomHex(), sendFrontendLog()
 
-### Community 194 - "Community 194"
+### Community 204 - "Community 204"
 Cohesion: 0.28
 Nodes (3): map_activity_response(), should_persist_stream(), should_persist_stream_type()
 
-### Community 195 - "Community 195"
+### Community 205 - "Community 205"
 Cohesion: 0.22
 Nodes (8): GeminiCachedContentResponse, GeminiCandidate, GeminiContent, GeminiCreateCacheRequest, GeminiGenerateContentRequest, GeminiGenerateContentResponse, GeminiTextPart, GeminiUsageMetadata
 
-### Community 196 - "Community 196"
+### Community 206 - "Community 206"
 Cohesion: 0.25
 Nodes (3): AthleteSummaryDocument, map_domain_to_document(), MongoAthleteSummaryRepository
-
-### Community 197 - "Community 197"
-Cohesion: 0.22
-Nodes (0): 
-
-### Community 198 - "Community 198"
-Cohesion: 0.22
-Nodes (7): AthleteSummary, AthleteSummaryError, AthleteSummaryGenerationClaimResult, AthleteSummaryGenerationOperation, AthleteSummaryGenerationOperationStatus, AthleteSummaryState, EnsuredAthleteSummary
-
-### Community 199 - "Community 199"
-Cohesion: 0.22
-Nodes (6): CalendarEntryKind, CalendarEntryRace, CalendarEntrySummary, CalendarEntrySync, CalendarEntryView, CalendarEntryViewError
-
-### Community 200 - "Community 200"
-Cohesion: 0.22
-Nodes (2): CompletedWorkoutRepository, NoopCompletedWorkoutRepository
-
-### Community 201 - "Community 201"
-Cohesion: 0.22
-Nodes (8): CadenceRange, ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst
-
-### Community 202 - "Community 202"
-Cohesion: 0.22
-Nodes (7): CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus, WorkoutSummaryService, WorkoutSummaryUseCases
-
-### Community 203 - "Community 203"
-Cohesion: 0.58
-Nodes (6): external_observation_repository_round_trips_by_provider_and_external_id(), external_sync_repositories_create_expected_indexes(), external_sync_state_repository_round_trips_by_provider_and_canonical_entity(), mongo_fixture_or_skip(), MongoFixture, provider_poll_state_repository_lists_due_items_and_round_trips_by_stream()
-
-### Community 204 - "Community 204"
-Cohesion: 0.22
-Nodes (0): 
-
-### Community 205 - "Community 205"
-Cohesion: 0.47
-Nodes (6): ftp_history_repository_upserts_and_resolves_effective_entry(), mongo_fixture_or_skip(), MongoFixture, sample_ftp_entry(), sample_snapshot(), training_load_daily_snapshot_repository_replaces_days_and_deletes_from_date()
-
-### Community 206 - "Community 206"
-Cohesion: 0.22
-Nodes (0): 
 
 ### Community 207 - "Community 207"
 Cohesion: 0.22
 Nodes (0): 
 
 ### Community 208 - "Community 208"
-Cohesion: 0.31
-Nodes (1): InMemoryAthleteSummaryService
+Cohesion: 0.22
+Nodes (7): AthleteSummary, AthleteSummaryError, AthleteSummaryGenerationClaimResult, AthleteSummaryGenerationOperation, AthleteSummaryGenerationOperationStatus, AthleteSummaryState, EnsuredAthleteSummary
 
 ### Community 209 - "Community 209"
 Cohesion: 0.22
-Nodes (0): 
+Nodes (6): CalendarEntryKind, CalendarEntryRace, CalendarEntrySummary, CalendarEntrySync, CalendarEntryView, CalendarEntryViewError
 
 ### Community 210 - "Community 210"
+Cohesion: 0.22
+Nodes (2): CompletedWorkoutRepository, NoopCompletedWorkoutRepository
+
+### Community 211 - "Community 211"
+Cohesion: 0.22
+Nodes (8): CadenceRange, ParserTarget, RepeatBlockAst, StepAmount, StepKind, WorkoutAst, WorkoutItem, WorkoutStepAst
+
+### Community 212 - "Community 212"
+Cohesion: 0.22
+Nodes (7): CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus, WorkoutSummaryService, WorkoutSummaryUseCases
+
+### Community 213 - "Community 213"
+Cohesion: 0.58
+Nodes (6): external_observation_repository_round_trips_by_provider_and_external_id(), external_sync_repositories_create_expected_indexes(), external_sync_state_repository_round_trips_by_provider_and_canonical_entity(), mongo_fixture_or_skip(), MongoFixture, provider_poll_state_repository_lists_due_items_and_round_trips_by_stream()
+
+### Community 214 - "Community 214"
+Cohesion: 0.33
+Nodes (5): dashboard_test_app(), frontend_fixture(), FrontendFixture, keep_frontend_fixture(), test_mongo_client()
+
+### Community 215 - "Community 215"
+Cohesion: 0.22
+Nodes (0): 
+
+### Community 216 - "Community 216"
+Cohesion: 0.22
+Nodes (0): 
+
+### Community 217 - "Community 217"
+Cohesion: 0.31
+Nodes (1): InMemoryAthleteSummaryService
+
+### Community 218 - "Community 218"
+Cohesion: 0.22
+Nodes (0): 
+
+### Community 219 - "Community 219"
 Cohesion: 0.5
 Nodes (4): builds_same_origin_callback_redirect(), DevGoogleOAuthClient, rejects_invalid_dev_code_as_unauthenticated(), returns_configured_identity_for_dev_code()
 
-### Community 211 - "Community 211"
+### Community 220 - "Community 220"
 Cohesion: 0.25
 Nodes (2): IntervalsSettingsAdapter, SettingsIntervalsProvider
 
-### Community 212 - "Community 212"
+### Community 221 - "Community 221"
 Cohesion: 0.25
 Nodes (7): OpenAiChatRequest, OpenAiChatResponse, OpenAiChoice, OpenAiMessage, OpenAiMessageResponse, OpenAiPromptTokenDetails, OpenAiUsage
 
-### Community 213 - "Community 213"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (2): ActivityUploadOperationDocument, MongoActivityUploadOperationRepository
 
-### Community 214 - "Community 214"
+### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (6): backfill_completed_workout_details(), CompletedWorkoutBackfillPath, CompletedWorkoutBackfillQuery, CompletedWorkoutBackfillResponse, map_backfill_error_status(), SystemInfoResponse
 
-### Community 215 - "Community 215"
+### Community 224 - "Community 224"
 Cohesion: 0.25
 Nodes (2): EventFileUpload, normalize_optional_upload_field()
 
-### Community 216 - "Community 216"
+### Community 225 - "Community 225"
 Cohesion: 0.36
 Nodes (5): current_api_key_is_saved(), map_validation_error_to_response(), merge_ai_connection_config(), MergedAiConnectionConfig, selected_key_was_not_provided()
 
-### Community 217 - "Community 217"
+### Community 226 - "Community 226"
 Cohesion: 0.25
 Nodes (4): CalendarUseCases, HiddenCalendarEventSource, NoopPlannedWorkoutSyncRepository, PlannedWorkoutSyncRepository
 
-### Community 218 - "Community 218"
+### Community 227 - "Community 227"
+Cohesion: 0.25
+Nodes (7): Clock, GoogleOAuthPort, IdGenerator, LoginStateRepository, SessionRepository, UserRepository, WhitelistRepository
+
+### Community 228 - "Community 228"
 Cohesion: 0.25
 Nodes (4): CompactHistory<'a>, CompactIntervalsStatus<'a>, CompactProfile<'a>, StablePayload<'a>
 
-### Community 219 - "Community 219"
+### Community 229 - "Community 229"
 Cohesion: 0.39
 Nodes (4): activity_date(), date_key(), event_date(), parse_date()
 
-### Community 220 - "Community 220"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 221 - "Community 221"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 222 - "Community 222"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 223 - "Community 223"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 224 - "Community 224"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 225 - "Community 225"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 226 - "Community 226"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 227 - "Community 227"
-Cohesion: 0.25
-Nodes (0): 
-
-### Community 228 - "Community 228"
-Cohesion: 0.36
-Nodes (1): TestAthleteSummaryService
-
-### Community 229 - "Community 229"
-Cohesion: 0.33
-Nodes (2): countRangeCalls(), hasRangeCall()
-
 ### Community 230 - "Community 230"
-Cohesion: 0.33
-Nodes (2): listRaces(), toQueryString()
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 231 - "Community 231"
-Cohesion: 0.33
-Nodes (2): handleSave(), normalizeDays()
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 232 - "Community 232"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (0): 
 
 ### Community 233 - "Community 233"
-Cohesion: 0.29
-Nodes (2): PlannedWorkoutDocument, PlannedWorkoutLineDocument
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 234 - "Community 234"
-Cohesion: 0.38
-Nodes (6): ErrorResponse, header_value(), ingest_logs(), LogIngestionRequest, request_has_same_origin(), StatusResponse
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 235 - "Community 235"
-Cohesion: 0.43
-Nodes (6): log_connection_error(), log_identity_error(), log_settings_error(), map_admin_identity_error(), map_connection_error_to_response(), map_settings_error()
+Cohesion: 0.25
+Nodes (0): 
 
 ### Community 236 - "Community 236"
-Cohesion: 0.38
-Nodes (4): FieldUpdate, normalize_string_input(), parse_provider_input(), parse_provider_settings_input()
+Cohesion: 0.36
+Nodes (1): TestAthleteSummaryService
 
 ### Community 237 - "Community 237"
+Cohesion: 0.33
+Nodes (2): countRangeCalls(), hasRangeCall()
+
+### Community 238 - "Community 238"
+Cohesion: 0.33
+Nodes (2): listRaces(), toQueryString()
+
+### Community 239 - "Community 239"
+Cohesion: 0.33
+Nodes (2): handleSave(), normalizeDays()
+
+### Community 240 - "Community 240"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 238 - "Community 238"
+### Community 241 - "Community 241"
+Cohesion: 0.29
+Nodes (2): PlannedWorkoutDocument, PlannedWorkoutLineDocument
+
+### Community 242 - "Community 242"
+Cohesion: 0.38
+Nodes (6): ErrorResponse, header_value(), ingest_logs(), LogIngestionRequest, request_has_same_origin(), StatusResponse
+
+### Community 243 - "Community 243"
+Cohesion: 0.43
+Nodes (6): log_connection_error(), log_identity_error(), log_settings_error(), map_admin_identity_error(), map_connection_error_to_response(), map_settings_error()
+
+### Community 244 - "Community 244"
+Cohesion: 0.38
+Nodes (4): FieldUpdate, normalize_string_input(), parse_provider_input(), parse_provider_settings_input()
+
+### Community 245 - "Community 245"
+Cohesion: 0.29
+Nodes (0): 
+
+### Community 246 - "Community 246"
 Cohesion: 0.48
 Nodes (5): map_message_to_dto(), map_save_summary_result_to_dto(), map_send_message_result_to_dto(), map_summary_to_dto(), map_workflow_status_to_dto()
 
-### Community 239 - "Community 239"
+### Community 247 - "Community 247"
 Cohesion: 0.29
 Nodes (1): CalendarService<
         Intervals,
@@ -1746,7 +1798,7 @@ Nodes (1): CalendarService<
         Completed,
     >
 
-### Community 240 - "Community 240"
+### Community 248 - "Community 248"
 Cohesion: 0.43
 Nodes (4): build_create_event(), CalendarService<
         Intervals,
@@ -1760,27 +1812,19 @@ Nodes (4): build_create_event(), CalendarService<
         Completed,
     >, ensure_planned_workout_marker(), find_existing_remote_event()
 
-### Community 241 - "Community 241"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (2): CalendarEntryViewRepository, InMemoryCalendarEntryViewRepository
 
-### Community 242 - "Community 242"
-Cohesion: 0.29
-Nodes (6): Clock, GoogleOAuthPort, IdGenerator, LoginStateRepository, SessionRepository, UserRepository
-
-### Community 243 - "Community 243"
+### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
-### Community 244 - "Community 244"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (4): SpecialDay, SpecialDayError, SpecialDayKind, validate_date()
 
-### Community 245 - "Community 245"
-Cohesion: 0.29
-Nodes (5): FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadError, TrainingLoadSnapshotRange
-
-### Community 246 - "Community 246"
+### Community 252 - "Community 252"
 Cohesion: 0.38
 Nodes (1): TrainingPlanGenerationService<
         Snapshots,
@@ -1792,57 +1836,33 @@ Nodes (1): TrainingPlanGenerationService<
         Refresh,
     >
 
-### Community 247 - "Community 247"
+### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 248 - "Community 248"
+### Community 254 - "Community 254"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 249 - "Community 249"
+### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (2): FakeActivityUploadOperationRepository, UploadOperationRepoCall
 
-### Community 250 - "Community 250"
+### Community 256 - "Community 256"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 251 - "Community 251"
+### Community 257 - "Community 257"
 Cohesion: 0.29
 Nodes (2): MockLlmChatService, TestLlmConfigProvider
 
-### Community 252 - "Community 252"
-Cohesion: 0.29
-Nodes (0): 
-
-### Community 253 - "Community 253"
-Cohesion: 0.4
-Nodes (1): FakeWebSocket
-
-### Community 254 - "Community 254"
-Cohesion: 0.4
-Nodes (2): InspectableBlob, readBlobText()
-
-### Community 255 - "Community 255"
-Cohesion: 0.47
-Nodes (3): map_error_response_from_logged_response(), sanitize_error_url(), summarize_log_body()
-
-### Community 256 - "Community 256"
-Cohesion: 0.4
-Nodes (3): ErrorResponse, log_workout_summary_error(), map_workout_summary_error()
-
-### Community 257 - "Community 257"
-Cohesion: 0.53
-Nodes (5): canonical_activity_id(), map_completed_workout_to_activity(), map_completed_workout_to_dto(), map_series_to_json(), map_stream_to_activity_stream()
-
 ### Community 258 - "Community 258"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (0): 
 
 ### Community 259 - "Community 259"
 Cohesion: 0.4
-Nodes (2): load_env_values(), Settings
+Nodes (1): FakeWebSocket
 
 ### Community 260 - "Community 260"
 Cohesion: 0.33
@@ -1850,33 +1870,65 @@ Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.4
-Nodes (4): CalendarEntryIntegrityIssue, CalendarEntryIntegrityReport, issue_sort_key(), verify_calendar_entry_integrity()
+Nodes (2): InspectableBlob, readBlobText()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.47
-Nodes (3): finalize_import(), refresh_imported_range(), refresh_range_bounds()
+Nodes (3): map_error_response_from_logged_response(), sanitize_error_url(), summarize_log_body()
 
 ### Community 263 - "Community 263"
-Cohesion: 0.47
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
+Cohesion: 0.53
+Nodes (5): canonical_activity_id(), map_completed_workout_to_activity(), map_completed_workout_to_dto(), map_series_to_json(), map_stream_to_activity_stream()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.33
-Nodes (3): PlannedCompletedWorkoutLink, PlannedCompletedWorkoutLinkError, PlannedCompletedWorkoutLinkMatchSource
+Cohesion: 0.53
+Nodes (4): map_dashboard_report_to_dto(), map_range(), map_summary(), map_tsb_zone()
 
 ### Community 265 - "Community 265"
-Cohesion: 0.33
-Nodes (2): NoopPlannedWorkoutRepository, PlannedWorkoutRepository
+Cohesion: 0.4
+Nodes (3): ErrorResponse, log_workout_summary_error(), map_workout_summary_error()
 
 ### Community 266 - "Community 266"
 Cohesion: 0.33
-Nodes (2): NoopSpecialDayRepository, SpecialDayRepository
+Nodes (0): 
 
 ### Community 267 - "Community 267"
+Cohesion: 0.4
+Nodes (2): load_env_values(), Settings
+
+### Community 268 - "Community 268"
+Cohesion: 0.33
+Nodes (0): 
+
+### Community 269 - "Community 269"
+Cohesion: 0.4
+Nodes (4): CalendarEntryIntegrityIssue, CalendarEntryIntegrityReport, issue_sort_key(), verify_calendar_entry_integrity()
+
+### Community 270 - "Community 270"
+Cohesion: 0.47
+Nodes (3): finalize_import(), refresh_imported_range(), refresh_range_bounds()
+
+### Community 271 - "Community 271"
+Cohesion: 0.47
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
+
+### Community 272 - "Community 272"
+Cohesion: 0.33
+Nodes (3): PlannedCompletedWorkoutLink, PlannedCompletedWorkoutLinkError, PlannedCompletedWorkoutLinkMatchSource
+
+### Community 273 - "Community 273"
+Cohesion: 0.33
+Nodes (2): NoopPlannedWorkoutRepository, PlannedWorkoutRepository
+
+### Community 274 - "Community 274"
+Cohesion: 0.33
+Nodes (2): NoopSpecialDayRepository, SpecialDayRepository
+
+### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (5): TrainingPlanGenerationOperationRepository, TrainingPlanGenerator, TrainingPlanProjectionRepository, TrainingPlanSnapshotRepository, TrainingPlanWorkoutSummaryPort
 
-### Community 268 - "Community 268"
+### Community 276 - "Community 276"
 Cohesion: 0.53
 Nodes (1): TrainingPlanGenerationService<
         Snapshots,
@@ -1888,209 +1940,177 @@ Nodes (1): TrainingPlanGenerationService<
         Refresh,
     >
 
-### Community 269 - "Community 269"
+### Community 277 - "Community 277"
 Cohesion: 0.67
 Nodes (5): lock_telemetry_env(), restore_env_var(), setup_telemetry_accepts_service_name_override_without_otlp_endpoint(), setup_telemetry_rejects_malformed_otlp_endpoint(), telemetry_env_lock()
 
-### Community 270 - "Community 270"
+### Community 278 - "Community 278"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 271 - "Community 271"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 272 - "Community 272"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 273 - "Community 273"
+### Community 281 - "Community 281"
 Cohesion: 0.47
 Nodes (1): MockIntervalsConnectionTester
 
-### Community 274 - "Community 274"
+### Community 282 - "Community 282"
 Cohesion: 0.6
 Nodes (4): getApiBaseUrl(), isDevAuthEnabled(), normalizeApiBaseUrl(), normalizeBooleanFlag()
 
-### Community 275 - "Community 275"
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (3): handleSave(), handleTest(), setStatusFromTest()
 
-### Community 276 - "Community 276"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (2): SystemClock, UuidIdGenerator
 
-### Community 277 - "Community 277"
+### Community 285 - "Community 285"
 Cohesion: 0.5
 Nodes (1): GoogleOAuthClient
 
-### Community 278 - "Community 278"
+### Community 286 - "Community 286"
 Cohesion: 0.8
 Nodes (1): IntervalsIcuClient
 
-### Community 279 - "Community 279"
+### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (2): HealthResponse, ReadinessResponse
 
-### Community 280 - "Community 280"
+### Community 288 - "Community 288"
 Cohesion: 0.6
 Nodes (4): log_calendar_error(), log_calendar_label_error(), map_calendar_error(), map_calendar_label_error()
 
-### Community 281 - "Community 281"
-Cohesion: 0.4
-Nodes (4): ListRacesQuery, RaceDto, RacePath, UpsertRaceRequest
-
-### Community 282 - "Community 282"
-Cohesion: 0.4
-Nodes (4): AttemptRecord, ValidationIssue, WorkflowPhase, WorkflowStatus
-
-### Community 283 - "Community 283"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 284 - "Community 284"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 285 - "Community 285"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 286 - "Community 286"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 287 - "Community 287"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 288 - "Community 288"
-Cohesion: 0.4
-Nodes (1): FakeSettingsPort
-
 ### Community 289 - "Community 289"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (4): TrainingLoadDashboardPointDto, TrainingLoadDashboardQuery, TrainingLoadDashboardResponseDto, TrainingLoadDashboardSummaryDto
 
 ### Community 290 - "Community 290"
 Cohesion: 0.4
-Nodes (1): InMemoryLlmContextCacheRepository
+Nodes (4): ListRacesQuery, RaceDto, RacePath, UpsertRaceRequest
 
 ### Community 291 - "Community 291"
 Cohesion: 0.4
-Nodes (1): TestCompletedWorkoutAdminService
+Nodes (4): AttemptRecord, ValidationIssue, WorkflowPhase, WorkflowStatus
 
 ### Community 292 - "Community 292"
-Cohesion: 0.7
-Nodes (4): existing_summary(), sample_summary(), sample_summary_for_user(), sample_summary_with_updated_at()
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
-Nodes (2): TestClock, TestIdGenerator
+Nodes (0): 
 
 ### Community 294 - "Community 294"
-Cohesion: 1.0
-Nodes (3): buildHookState(), buildRenderedWeeks(), buildWeek()
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 295 - "Community 295"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0): 
 
 ### Community 296 - "Community 296"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0): 
 
 ### Community 297 - "Community 297"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.4
+Nodes (1): FakeSettingsPort
 
 ### Community 298 - "Community 298"
-Cohesion: 0.67
-Nodes (2): hasExplicitAvailabilityWeek(), isAvailabilityConfigured()
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 299 - "Community 299"
-Cohesion: 0.83
-Nodes (3): handleGenerate(), load(), refreshSummary()
+Cohesion: 0.4
+Nodes (1): InMemoryLlmContextCacheRepository
 
 ### Community 300 - "Community 300"
-Cohesion: 0.67
-Nodes (2): getStatusPanelClass(), getStatusToneClass()
+Cohesion: 0.4
+Nodes (1): TestCompletedWorkoutAdminService
 
 ### Community 301 - "Community 301"
-Cohesion: 0.5
-Nodes (1): ApiError
+Cohesion: 0.7
+Nodes (4): existing_summary(), sample_summary(), sample_summary_for_user(), sample_summary_with_updated_at()
 
 ### Community 302 - "Community 302"
-Cohesion: 0.83
-Nodes (3): buildApiUrl(), formatCheckedAtLabel(), loadBackendStatus()
+Cohesion: 0.4
+Nodes (2): TestClock, TestIdGenerator
 
 ### Community 303 - "Community 303"
-Cohesion: 0.5
-Nodes (1): GoogleOAuthAdapter
+Cohesion: 1.0
+Nodes (3): buildHookState(), buildRenderedWeeks(), buildWeek()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.5
-Nodes (1): AthleteSummaryLlmGenerator
+Nodes (0): 
 
 ### Community 305 - "Community 305"
 Cohesion: 0.5
-Nodes (1): SettingsLlmConfigProvider
+Nodes (0): 
 
 ### Community 306 - "Community 306"
-Cohesion: 0.83
-Nodes (3): converts_epoch_seconds_to_bson_datetime(), epoch_seconds_to_bson_datetime(), rejects_epoch_seconds_that_overflow_bson_millis()
-
-### Community 307 - "Community 307"
-Cohesion: 0.5
-Nodes (1): SettingsError
-
-### Community 308 - "Community 308"
-Cohesion: 0.5
-Nodes (3): AthleteSummaryGenerationOperationRepository, AthleteSummaryGenerator, AthleteSummaryRepository
-
-### Community 309 - "Community 309"
-Cohesion: 0.5
-Nodes (3): AthleteSummaryService, AthleteSummaryUseCases, SummaryRecord
-
-### Community 310 - "Community 310"
-Cohesion: 0.83
-Nodes (1): CalendarLabelsService<Source>
-
-### Community 311 - "Community 311"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 307 - "Community 307"
+Cohesion: 0.67
+Nodes (2): hasExplicitAvailabilityWeek(), isAvailabilityConfigured()
+
+### Community 308 - "Community 308"
+Cohesion: 0.83
+Nodes (3): handleGenerate(), load(), refreshSummary()
+
+### Community 309 - "Community 309"
+Cohesion: 0.67
+Nodes (2): getStatusPanelClass(), getStatusToneClass()
+
+### Community 310 - "Community 310"
+Cohesion: 0.5
+Nodes (1): ApiError
+
+### Community 311 - "Community 311"
+Cohesion: 0.83
+Nodes (3): buildApiUrl(), formatCheckedAtLabel(), loadBackendStatus()
+
 ### Community 312 - "Community 312"
 Cohesion: 0.5
-Nodes (1): WorkoutPestParseError
+Nodes (1): GoogleOAuthAdapter
 
 ### Community 313 - "Community 313"
 Cohesion: 0.5
-Nodes (1): LlmError
+Nodes (1): AthleteSummaryLlmGenerator
 
 ### Community 314 - "Community 314"
 Cohesion: 0.5
-Nodes (3): LlmChatPort, LlmContextCacheRepository, UserLlmConfigProvider
+Nodes (1): SettingsLlmConfigProvider
 
 ### Community 315 - "Community 315"
-Cohesion: 0.5
-Nodes (1): SpecialDayService<Repository, Refresh>
+Cohesion: 0.83
+Nodes (3): converts_epoch_seconds_to_bson_datetime(), epoch_seconds_to_bson_datetime(), rejects_epoch_seconds_that_overflow_bson_millis()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (2): approximate_token_count(), render_training_context()
+Cohesion: 0.5
+Nodes (1): SettingsError
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
-Nodes (1): TrainingLoadRecomputeService<Workouts, FtpHistory, Snapshots, Settings>
+Nodes (3): AthleteSummaryGenerationOperationRepository, AthleteSummaryGenerator, AthleteSummaryRepository
 
 ### Community 318 - "Community 318"
 Cohesion: 0.5
-Nodes (3): ParsedPlanWindow, TrainingPlanGenerationService, TrainingPlanUseCases
+Nodes (3): AthleteSummaryService, AthleteSummaryUseCases, SummaryRecord
 
 ### Community 319 - "Community 319"
-Cohesion: 0.5
-Nodes (2): MockWorkoutCoach, WorkoutCoach
+Cohesion: 0.83
+Nodes (1): CalendarLabelsService<Source>
 
 ### Community 320 - "Community 320"
 Cohesion: 0.5
@@ -2098,67 +2118,67 @@ Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): WorkoutPestParseError
 
 ### Community 322 - "Community 322"
 Cohesion: 0.5
-Nodes (1): RecordingCalendarRefresh
+Nodes (1): LlmError
 
 ### Community 323 - "Community 323"
 Cohesion: 0.5
-Nodes (1): FakeActivityIdentityExtractor
+Nodes (3): LlmChatPort, LlmContextCacheRepository, UserLlmConfigProvider
 
 ### Community 324 - "Community 324"
 Cohesion: 0.5
-Nodes (1): BuiltService
+Nodes (1): SpecialDayService<Repository, Refresh>
 
 ### Community 325 - "Community 325"
-Cohesion: 0.5
-Nodes (1): TestIdGenerator
+Cohesion: 0.67
+Nodes (2): approximate_token_count(), render_training_context()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): TrainingLoadRecomputeService<Workouts, FtpHistory, Snapshots, Settings>
 
 ### Community 327 - "Community 327"
-Cohesion: 1.0
-Nodes (2): listCalendarLabels(), toQueryString()
+Cohesion: 0.5
+Nodes (3): ParsedPlanWindow, TrainingPlanGenerationService, TrainingPlanUseCases
 
 ### Community 328 - "Community 328"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): MockWorkoutCoach, WorkoutCoach
 
 ### Community 329 - "Community 329"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 330 - "Community 330"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0): 
 
 ### Community 331 - "Community 331"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): RecordingCalendarRefresh
 
 ### Community 332 - "Community 332"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): FakeActivityIdentityExtractor
 
 ### Community 333 - "Community 333"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.5
+Nodes (1): BuiltService
 
 ### Community 334 - "Community 334"
-Cohesion: 1.0
-Nodes (2): handleSave(), handleSaveClick()
+Cohesion: 0.5
+Nodes (1): TestIdGenerator
 
 ### Community 335 - "Community 335"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 336 - "Community 336"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): listCalendarLabels(), toQueryString()
 
 ### Community 337 - "Community 337"
 Cohesion: 0.67
@@ -2185,140 +2205,140 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 343 - "Community 343"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): handleSave(), handleSaveClick()
 
 ### Community 344 - "Community 344"
 Cohesion: 0.67
-Nodes (1): CompletedWorkoutTargetAdapter<Repo>
+Nodes (0): 
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
-Nodes (1): LatestCompletedActivityAdapter<Repo>
+Nodes (0): 
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
-Nodes (2): GoogleTokenResponse, GoogleUserInfoResponse
+Nodes (0): 
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
-Nodes (1): DevIntervalsSettingsProvider
+Nodes (0): 
 
 ### Community 348 - "Community 348"
 Cohesion: 0.67
-Nodes (1): DevLlmCoachAdapter
+Nodes (0): 
 
 ### Community 349 - "Community 349"
-Cohesion: 1.0
-Nodes (2): pseudonymize_user_id(), resolve_user_id()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 350 - "Community 350"
-Cohesion: 1.0
-Nodes (2): log_intervals_error(), map_intervals_error()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 351 - "Community 351"
-Cohesion: 1.0
-Nodes (2): log_race_error(), map_race_error()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 352 - "Community 352"
-Cohesion: 1.0
-Nodes (2): build_app(), build_app_with_frontend_dist()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 353 - "Community 353"
 Cohesion: 0.67
-Nodes (2): CalendarLabelSource, CalendarLabelsUseCases
+Nodes (1): CompletedWorkoutTargetAdapter<Repo>
 
 ### Community 354 - "Community 354"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): LatestCompletedActivityAdapter<Repo>
 
 ### Community 355 - "Community 355"
-Cohesion: 1.0
-Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
+Cohesion: 0.67
+Nodes (2): GoogleTokenResponse, GoogleUserInfoResponse
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
-Nodes (2): RaceRepository, RaceUseCases
+Nodes (1): DevIntervalsSettingsProvider
 
 ### Community 357 - "Community 357"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): DevLlmCoachAdapter
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): TrainingLoadRecomputeService, TrainingLoadRecomputeUseCases
+Cohesion: 1.0
+Nodes (2): pseudonymize_user_id(), resolve_user_id()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): get_training_load_dashboard(), parse_range()
 
 ### Community 360 - "Community 360"
-Cohesion: 0.67
-Nodes (2): CoachReplyOperationRepository, WorkoutSummaryRepository
+Cohesion: 1.0
+Nodes (2): log_intervals_error(), map_intervals_error()
 
 ### Community 361 - "Community 361"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log_race_error(), map_race_error()
 
 ### Community 362 - "Community 362"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): build_app(), build_app_with_frontend_dist()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (2): CalendarLabelSource, CalendarLabelsUseCases
 
 ### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (1): FakePestParserPocRepository
+Cohesion: 1.0
+Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (2): RaceRepository, RaceUseCases
 
 ### Community 367 - "Community 367"
 Cohesion: 0.67
-Nodes (1): TestClock
+Nodes (0): 
 
 ### Community 368 - "Community 368"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 369 - "Community 369"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): CoachReplyOperationRepository, WorkoutSummaryRepository
 
 ### Community 370 - "Community 370"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 371 - "Community 371"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 372 - "Community 372"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 373 - "Community 373"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 374 - "Community 374"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): FakePestParserPocRepository
 
 ### Community 375 - "Community 375"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 376 - "Community 376"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): TestClock
 
 ### Community 377 - "Community 377"
 Cohesion: 1.0
@@ -2450,15 +2470,15 @@ Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 1.0
-Nodes (1): CompletedWorkoutTargetAdapter
+Nodes (0): 
 
 ### Community 410 - "Community 410"
 Cohesion: 1.0
-Nodes (1): LatestCompletedActivityAdapter
+Nodes (0): 
 
 ### Community 411 - "Community 411"
 Cohesion: 1.0
-Nodes (1): IntervalsIcuClient
+Nodes (0): 
 
 ### Community 412 - "Community 412"
 Cohesion: 1.0
@@ -2478,7 +2498,7 @@ Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 1.0
-Nodes (1): AthleteSummaryDto
+Nodes (0): 
 
 ### Community 417 - "Community 417"
 Cohesion: 1.0
@@ -2490,13 +2510,65 @@ Nodes (0):
 
 ### Community 419 - "Community 419"
 Cohesion: 1.0
-Nodes (1): CreateRace
+Nodes (0): 
 
 ### Community 420 - "Community 420"
 Cohesion: 1.0
 Nodes (0): 
 
 ### Community 421 - "Community 421"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 422 - "Community 422"
+Cohesion: 1.0
+Nodes (1): CompletedWorkoutTargetAdapter
+
+### Community 423 - "Community 423"
+Cohesion: 1.0
+Nodes (1): LatestCompletedActivityAdapter
+
+### Community 424 - "Community 424"
+Cohesion: 1.0
+Nodes (1): IntervalsIcuClient
+
+### Community 425 - "Community 425"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 426 - "Community 426"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 427 - "Community 427"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 428 - "Community 428"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 429 - "Community 429"
+Cohesion: 1.0
+Nodes (1): AthleteSummaryDto
+
+### Community 430 - "Community 430"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 431 - "Community 431"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 432 - "Community 432"
+Cohesion: 1.0
+Nodes (1): CreateRace
+
+### Community 433 - "Community 433"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 434 - "Community 434"
 Cohesion: 1.0
 Nodes (1): ProviderPollingService<
         Api,
@@ -2508,15 +2580,15 @@ Nodes (1): ProviderPollingService<
         NoopCalendarEntryViewRefresh,
     >
 
-### Community 422 - "Community 422"
+### Community 435 - "Community 435"
 Cohesion: 1.0
 Nodes (0): 
 
-### Community 423 - "Community 423"
+### Community 436 - "Community 436"
 Cohesion: 1.0
 Nodes (1): CalendarService
 
-### Community 424 - "Community 424"
+### Community 437 - "Community 437"
 Cohesion: 1.0
 Nodes (1): CalendarService<
         Intervals,
@@ -2530,11 +2602,11 @@ Nodes (1): CalendarService<
         (),
     >
 
-### Community 425 - "Community 425"
+### Community 438 - "Community 438"
 Cohesion: 1.0
 Nodes (1): CalendarLabelsService
 
-### Community 426 - "Community 426"
+### Community 439 - "Community 439"
 Cohesion: 1.0
 Nodes (1): IntervalsService<
         Api,
@@ -2547,133 +2619,81 @@ Nodes (1): IntervalsService<
         NoopCalendarEntryViewRefresh,
     >
 
-### Community 427 - "Community 427"
+### Community 440 - "Community 440"
 Cohesion: 1.0
 Nodes (1): IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>
 
-### Community 428 - "Community 428"
+### Community 441 - "Community 441"
 Cohesion: 1.0
 Nodes (1): PlannedCompletedWorkoutLinkRepository
 
-### Community 429 - "Community 429"
+### Community 442 - "Community 442"
 Cohesion: 1.0
 Nodes (1): UserSettingsRepository
 
-### Community 430 - "Community 430"
+### Community 443 - "Community 443"
 Cohesion: 1.0
 Nodes (1): SpecialDayService
 
-### Community 431 - "Community 431"
+### Community 444 - "Community 444"
 Cohesion: 1.0
 Nodes (1): SpecialDayService<Repository>
 
-### Community 432 - "Community 432"
+### Community 445 - "Community 445"
 Cohesion: 1.0
 Nodes (1): CompactRace<'a>
 
-### Community 433 - "Community 433"
+### Community 446 - "Community 446"
 Cohesion: 1.0
 Nodes (1): CompactFuturePlannedEvent<'a>
 
-### Community 434 - "Community 434"
+### Community 447 - "Community 447"
 Cohesion: 1.0
 Nodes (1): CompactAvailabilityDay<'a>
 
-### Community 435 - "Community 435"
+### Community 448 - "Community 448"
 Cohesion: 1.0
 Nodes (1): CompactHistoricalLoadTrend<'a>
 
-### Community 436 - "Community 436"
+### Community 449 - "Community 449"
 Cohesion: 1.0
 Nodes (1): CompactHistoricalWorkout<'a>
 
-### Community 437 - "Community 437"
+### Community 450 - "Community 450"
 Cohesion: 1.0
 Nodes (1): VolatilePayload<'a>
 
-### Community 438 - "Community 438"
+### Community 451 - "Community 451"
 Cohesion: 1.0
 Nodes (1): CompactRecentDay<'a>
 
-### Community 439 - "Community 439"
+### Community 452 - "Community 452"
 Cohesion: 1.0
 Nodes (1): CompactRecentWorkout<'a>
 
-### Community 440 - "Community 440"
+### Community 453 - "Community 453"
 Cohesion: 1.0
 Nodes (1): CompactPlannedWorkoutRef<'a>
 
-### Community 441 - "Community 441"
+### Community 454 - "Community 454"
 Cohesion: 1.0
 Nodes (1): CompactPlannedWorkout<'a>
 
-### Community 442 - "Community 442"
+### Community 455 - "Community 455"
 Cohesion: 1.0
 Nodes (1): CompactSpecialDay<'a>
 
-### Community 443 - "Community 443"
+### Community 456 - "Community 456"
 Cohesion: 1.0
 Nodes (1): CompactUpcomingDay<'a>
 
-### Community 444 - "Community 444"
+### Community 457 - "Community 457"
 Cohesion: 1.0
 Nodes (1): CompactProjectedDay<'a>
 
-### Community 445 - "Community 445"
-Cohesion: 1.0
-Nodes (1): CompactProjectedWorkout<'a>
-
-### Community 446 - "Community 446"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 447 - "Community 447"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 448 - "Community 448"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 449 - "Community 449"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 450 - "Community 450"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 451 - "Community 451"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 452 - "Community 452"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 453 - "Community 453"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 454 - "Community 454"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 456 - "Community 456"
-Cohesion: 1.0
-Nodes (0): 
-
-### Community 457 - "Community 457"
-Cohesion: 1.0
-Nodes (0): 
-
 ### Community 458 - "Community 458"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): CompactProjectedWorkout<'a>
 
 ### Community 459 - "Community 459"
 Cohesion: 1.0
@@ -3133,562 +3153,650 @@ Nodes (0):
 
 ### Community 573 - "Community 573"
 Cohesion: 1.0
-Nodes (1): Hexagonal Architecture Rules
+Nodes (0): 
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
-Nodes (1): Persist Local State Before Side Effects
+Nodes (0): 
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (1): Single Container API And SPA Deployment
+Nodes (0): 
 
 ### Community 576 - "Community 576"
 Cohesion: 1.0
-Nodes (1): Operational Health And Readiness Endpoints
+Nodes (0): 
 
 ### Community 577 - "Community 577"
 Cohesion: 1.0
-Nodes (1): Coach Reply Operation
+Nodes (0): 
 
 ### Community 578 - "Community 578"
 Cohesion: 1.0
-Nodes (1): Pending Durable Coach Reply State
+Nodes (0): 
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
-Nodes (1): Coach Reply Recovery Rules
+Nodes (0): 
 
 ### Community 580 - "Community 580"
 Cohesion: 1.0
-Nodes (1): Same Request Local Write Retries
+Nodes (0): 
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
-Nodes (1): Compare And Swap Pending Operation Reclaim
+Nodes (0): 
 
 ### Community 582 - "Community 582"
 Cohesion: 1.0
-Nodes (1): Bootstrap Architecture
+Nodes (0): 
 
 ### Community 583 - "Community 583"
 Cohesion: 1.0
-Nodes (1): REST Adapter
+Nodes (0): 
 
 ### Community 584 - "Community 584"
 Cohesion: 1.0
-Nodes (1): Mongo Adapter
+Nodes (0): 
 
 ### Community 585 - "Community 585"
 Cohesion: 1.0
-Nodes (1): Planned Mongo Collections
+Nodes (0): 
 
 ### Community 586 - "Community 586"
 Cohesion: 1.0
-Nodes (1): Backend Bootstrap Foundation
+Nodes (0): 
 
 ### Community 587 - "Community 587"
 Cohesion: 1.0
-Nodes (1): Project Obsidian Handbook
+Nodes (0): 
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (1): Manual Tag Based Release Flow
+Nodes (0): 
 
 ### Community 589 - "Community 589"
 Cohesion: 1.0
-Nodes (1): Manual Coolify Deployment Path
+Nodes (0): 
 
 ### Community 590 - "Community 590"
 Cohesion: 1.0
-Nodes (1): Frontend Application Shell
+Nodes (0): 
 
 ### Community 591 - "Community 591"
 Cohesion: 1.0
-Nodes (1): Frontend Backend Connectivity
+Nodes (0): 
 
 ### Community 592 - "Community 592"
 Cohesion: 1.0
-Nodes (1): Identity Domain
+Nodes (0): 
 
 ### Community 593 - "Community 593"
 Cohesion: 1.0
-Nodes (1): Google OAuth Login Flow
+Nodes (1): Hexagonal Architecture Rules
 
 ### Community 594 - "Community 594"
 Cohesion: 1.0
-Nodes (1): Server Side Sessions
+Nodes (1): Persist Local State Before Side Effects
 
 ### Community 595 - "Community 595"
 Cohesion: 1.0
-Nodes (1): RBAC Policy
+Nodes (1): Single Container API And SPA Deployment
 
 ### Community 596 - "Community 596"
 Cohesion: 1.0
-Nodes (1): Draft Driven Intervals Settings Actions
+Nodes (1): Operational Health And Readiness Endpoints
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (1): Synthetic Trace Parent Fix
+Nodes (1): Coach Reply Operation
 
 ### Community 598 - "Community 598"
 Cohesion: 1.0
-Nodes (1): Atomic Tracing Capture Writes
+Nodes (1): Pending Durable Coach Reply State
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (1): Structured Mini Chart Bars
+Nodes (1): Coach Reply Recovery Rules
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (1): Completed Activity Enrichment
+Nodes (1): Same Request Local Write Retries
 
 ### Community 601 - "Community 601"
 Cohesion: 1.0
-Nodes (1): Partial Enrichment Fail Open
+Nodes (1): Compare And Swap Pending Operation Reclaim
 
 ### Community 602 - "Community 602"
 Cohesion: 1.0
-Nodes (1): Workout Detail Modal Flow
+Nodes (1): Bootstrap Architecture
 
 ### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (1): Event FIT Download Action
+Nodes (1): REST Adapter
 
 ### Community 604 - "Community 604"
 Cohesion: 1.0
-Nodes (1): Intervals Service Enrichment Placement
+Nodes (1): Mongo Adapter
 
 ### Community 605 - "Community 605"
 Cohesion: 1.0
-Nodes (1): Partial Modal Resilience
+Nodes (1): Planned Mongo Collections
 
 ### Community 606 - "Community 606"
 Cohesion: 1.0
-Nodes (1): Intervals Service Workout Enrichment
+Nodes (1): Backend Bootstrap Foundation
 
 ### Community 607 - "Community 607"
 Cohesion: 1.0
-Nodes (1): Partial Workout Detail Failure Resilience
+Nodes (1): Project Obsidian Handbook
 
 ### Community 608 - "Community 608"
 Cohesion: 1.0
-Nodes (1): Completed Workout Mode UI Cleanup
+Nodes (1): Manual Tag Based Release Flow
 
 ### Community 609 - "Community 609"
 Cohesion: 1.0
-Nodes (1): Remove Workout Detail Auto Scroll Side Effect
+Nodes (1): Manual Coolify Deployment Path
 
 ### Community 610 - "Community 610"
 Cohesion: 1.0
-Nodes (1): Preserve Workout Detail Selection Synchronization
+Nodes (1): Frontend Application Shell
 
 ### Community 611 - "Community 611"
 Cohesion: 1.0
-Nodes (1): Workout Detail ScrollIntoView Removal
+Nodes (1): Frontend Backend Connectivity
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (1): Workout Detail Interaction Test Updates
+Nodes (1): Identity Domain
 
 ### Community 613 - "Community 613"
 Cohesion: 1.0
-Nodes (1): Durable Recoverable Coach Replies
+Nodes (1): Google OAuth Login Flow
 
 ### Community 614 - "Community 614"
 Cohesion: 1.0
-Nodes (1): LLM Context Cache Invalidation
+Nodes (1): Server Side Sessions
 
 ### Community 615 - "Community 615"
 Cohesion: 1.0
-Nodes (1): Provider Observability And Cost Tracing
+Nodes (1): RBAC Policy
 
 ### Community 616 - "Community 616"
 Cohesion: 1.0
-Nodes (1): AI Settings UX Hardening
+Nodes (1): Draft Driven Intervals Settings Actions
 
 ### Community 617 - "Community 617"
 Cohesion: 1.0
-Nodes (1): Coach Reply Operation As Durable Workflow Record
+Nodes (1): Synthetic Trace Parent Fix
 
 ### Community 618 - "Community 618"
 Cohesion: 1.0
-Nodes (1): Idempotent Coach Reply Finalization
+Nodes (1): Atomic Tracing Capture Writes
 
 ### Community 619 - "Community 619"
 Cohesion: 1.0
-Nodes (1): Partial Persistence Failure Recovery For Finalization
+Nodes (1): Structured Mini Chart Bars
 
 ### Community 620 - "Community 620"
 Cohesion: 1.0
-Nodes (1): Coach Reply State Machine Documentation Update
+Nodes (1): Completed Activity Enrichment
 
 ### Community 621 - "Community 621"
 Cohesion: 1.0
-Nodes (1): Debug Level Successful Health Logs
+Nodes (1): Partial Enrichment Fail Open
 
 ### Community 622 - "Community 622"
 Cohesion: 1.0
-Nodes (1): Preserve Health Failure Visibility
+Nodes (1): Workout Detail Modal Flow
 
 ### Community 623 - "Community 623"
 Cohesion: 1.0
-Nodes (1): Reduce Health Endpoint Success Log Noise
+Nodes (1): Event FIT Download Action
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (1): Curated Provider Model Suggestion Refresh
+Nodes (1): Intervals Service Enrichment Placement
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (1): Preserve Freeform Model Input
+Nodes (1): Partial Modal Resilience
 
 ### Community 626 - "Community 626"
 Cohesion: 1.0
-Nodes (1): Refresh AI Agent Model Suggestions
+Nodes (1): Intervals Service Workout Enrichment
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (1): Lower Mongo Local Development Verbosity
+Nodes (1): Partial Workout Detail Failure Resilience
 
 ### Community 628 - "Community 628"
 Cohesion: 1.0
-Nodes (1): Quiet Docker Compose Mongo Startup Logs
+Nodes (1): Completed Workout Mode UI Cleanup
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (1): Safe Structured OpenRouter Diagnostics
+Nodes (1): Remove Workout Detail Auto Scroll Side Effect
 
 ### Community 630 - "Community 630"
 Cohesion: 1.0
-Nodes (1): Redacted Provider Request Metadata Logging
+Nodes (1): Preserve Workout Detail Selection Synchronization
 
 ### Community 631 - "Community 631"
 Cohesion: 1.0
-Nodes (1): OpenRouter Transport And Response Diagnostics
+Nodes (1): Workout Detail ScrollIntoView Removal
 
 ### Community 632 - "Community 632"
 Cohesion: 1.0
-Nodes (1): Multi Provider Logging Pattern Rollout
+Nodes (1): Workout Detail Interaction Test Updates
 
 ### Community 633 - "Community 633"
 Cohesion: 1.0
-Nodes (1): OpenAI And Gemini Diagnostic Logging
+Nodes (1): Durable Recoverable Coach Replies
 
 ### Community 634 - "Community 634"
 Cohesion: 1.0
-Nodes (1): Persisted Athlete Summary Feature
+Nodes (1): LLM Context Cache Invalidation
 
 ### Community 635 - "Community 635"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Prompt Context Integration
+Nodes (1): Provider Observability And Cost Tracing
 
 ### Community 636 - "Community 636"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Generation System Message
+Nodes (1): AI Settings UX Hardening
 
 ### Community 637 - "Community 637"
 Cohesion: 1.0
-Nodes (1): OpenRouter Stable Prefix Prompt Caching
+Nodes (1): Coach Reply Operation As Durable Workflow Record
 
 ### Community 638 - "Community 638"
 Cohesion: 1.0
-Nodes (1): Uncached Conversation Tail
+Nodes (1): Idempotent Coach Reply Finalization
 
 ### Community 639 - "Community 639"
 Cohesion: 1.0
-Nodes (1): Single WebSocket Control Loop
+Nodes (1): Partial Persistence Failure Recovery For Finalization
 
 ### Community 640 - "Community 640"
 Cohesion: 1.0
-Nodes (1): Drop Queued Messages After Disconnect
+Nodes (1): Coach Reply State Machine Documentation Update
 
 ### Community 641 - "Community 641"
 Cohesion: 1.0
-Nodes (1): Full Workout Summary Builder Request Logging
+Nodes (1): Debug Level Successful Health Logs
 
 ### Community 642 - "Community 642"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Durable Generation Operation
+Nodes (1): Preserve Health Failure Visibility
 
 ### Community 643 - "Community 643"
 Cohesion: 1.0
-Nodes (1): Athlete Summary Stale Work Reclaim
+Nodes (1): Reduce Health Endpoint Success Log Noise
 
 ### Community 644 - "Community 644"
 Cohesion: 1.0
-Nodes (1): Distinct Athlete Summary System Message Rendering
+Nodes (1): Curated Provider Model Suggestion Refresh
 
 ### Community 645 - "Community 645"
 Cohesion: 1.0
-Nodes (1): Compressed Raw Power Segments
+Nodes (1): Preserve Freeform Model Input
 
 ### Community 646 - "Community 646"
 Cohesion: 1.0
-Nodes (1): Compact Training Context Power Field
+Nodes (1): Refresh AI Agent Model Suggestions
 
 ### Community 647 - "Community 647"
 Cohesion: 1.0
-Nodes (1): Power Compression Prompt Encoding Legend
+Nodes (1): Lower Mongo Local Development Verbosity
 
 ### Community 648 - "Community 648"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Quiet Docker Compose Mongo Startup Logs
 
 ### Community 649 - "Community 649"
 Cohesion: 1.0
-Nodes (1): Replace LLM workout power arrays with compressed raw-power segments
+Nodes (1): Safe Structured OpenRouter Diagnostics
 
 ### Community 650 - "Community 650"
 Cohesion: 1.0
-Nodes (1): Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly
+Nodes (1): Redacted Provider Request Metadata Logging
 
 ### Community 651 - "Community 651"
 Cohesion: 1.0
-Nodes (1): RecentWorkoutContext.compressed_power_levels: Vec<String>
+Nodes (1): OpenRouter Transport And Response Diagnostics
 
 ### Community 652 - "Community 652"
 Cohesion: 1.0
-Nodes (1): Add power compression tests and implementation in training_context service
+Nodes (1): Multi Provider Logging Pattern Rollout
 
 ### Community 653 - "Community 653"
 Cohesion: 1.0
-Nodes (1): Pack pc instead of p5
+Nodes (1): OpenAI And Gemini Diagnostic Logging
 
 ### Community 654 - "Community 654"
 Cohesion: 1.0
-Nodes (1): Update the workout coach prompt with power-compression semantics
+Nodes (1): Persisted Athlete Summary Feature
 
 ### Community 655 - "Community 655"
 Cohesion: 1.0
-Nodes (1): Update LLM flow assertions to expect pc in live requests
+Nodes (1): Athlete Summary Prompt Context Integration
 
 ### Community 656 - "Community 656"
 Cohesion: 1.0
-Nodes (1): Run full formatting, lint, Rust tests, and repo verification
+Nodes (1): Athlete Summary Generation System Message
 
 ### Community 657 - "Community 657"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): OpenRouter Stable Prefix Prompt Caching
 
 ### Community 658 - "Community 658"
 Cohesion: 1.0
-Nodes (1): Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior
+Nodes (1): Uncached Conversation Tail
 
 ### Community 659 - "Community 659"
 Cohesion: 1.0
-Nodes (1): Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged
+Nodes (1): Single WebSocket Control Loop
 
 ### Community 660 - "Community 660"
 Cohesion: 1.0
-Nodes (1): Split training_context service into focused service/ siblings
+Nodes (1): Drop Queued Messages After Disconnect
 
 ### Community 661 - "Community 661"
 Cohesion: 1.0
-Nodes (1): Split workout_summary service into focused service/ siblings
+Nodes (1): Full Workout Summary Builder Request Logging
 
 ### Community 662 - "Community 662"
 Cohesion: 1.0
-Nodes (1): Split training_context packing into focused packing/ siblings
+Nodes (1): Athlete Summary Durable Generation Operation
 
 ### Community 663 - "Community 663"
 Cohesion: 1.0
-Nodes (1): Split Mongo workout-summary adapter tests first and helper concerns only if still oversized
+Nodes (1): Athlete Summary Stale Work Reclaim
 
 ### Community 664 - "Community 664"
 Cohesion: 1.0
-Nodes (1): Split bulky current-slice shared helpers and integration suites into directory-based test modules
+Nodes (1): Distinct Athlete Summary System Message Rendering
 
 ### Community 665 - "Community 665"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Compressed Raw Power Segments
 
 ### Community 666 - "Community 666"
 Cohesion: 1.0
-Nodes (1): Split training_context service into focused directory modules
+Nodes (1): Compact Training Context Power Field
 
 ### Community 667 - "Community 667"
 Cohesion: 1.0
-Nodes (1): Split workout_summary service while keeping WorkoutSummaryService as the entrypoint
+Nodes (1): Power Compression Prompt Encoding Legend
 
 ### Community 668 - "Community 668"
 Cohesion: 1.0
-Nodes (1): Split training_context packing into focused payload and rendering modules
+Nodes (0): 
 
 ### Community 669 - "Community 669"
 Cohesion: 1.0
-Nodes (1): Split the Mongo workout-summary adapter by moving tests first and helpers only if needed
+Nodes (1): Replace LLM workout power arrays with compressed raw-power segments
 
 ### Community 670 - "Community 670"
 Cohesion: 1.0
-Nodes (1): Split bulky workout-summary shared helpers and remaining oversized current-slice tests
+Nodes (1): Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly
 
 ### Community 671 - "Community 671"
 Cohesion: 1.0
-Nodes (1): Run broader backend verification after the refactor
+Nodes (1): RecentWorkoutContext.compressed_power_levels: Vec<String>
 
 ### Community 672 - "Community 672"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Add power compression tests and implementation in training_context service
 
 ### Community 673 - "Community 673"
 Cohesion: 1.0
-Nodes (1): Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits
+Nodes (1): Pack pc instead of p5
 
 ### Community 674 - "Community 674"
 Cohesion: 1.0
-Nodes (1): Make projection replay heal partial same-operation inserts
+Nodes (1): Update the workout coach prompt with power-compression semantics
 
 ### Community 675 - "Community 675"
 Cohesion: 1.0
-Nodes (1): Make workout-summary legacy fallback deterministic
+Nodes (1): Update LLM flow assertions to expect pc in live requests
 
 ### Community 676 - "Community 676"
 Cohesion: 1.0
-Nodes (1): Preserve correction retry budget across reclaim
+Nodes (1): Run full formatting, lint, Rust tests, and repo verification
 
 ### Community 677 - "Community 677"
 Cohesion: 1.0
-Nodes (1): Close low-level test and docs nits
+Nodes (0): 
 
 ### Community 678 - "Community 678"
 Cohesion: 1.0
-Nodes (1): Run targeted tests, fmt, and clippy for the follow-up batch
+Nodes (1): Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior
 
 ### Community 679 - "Community 679"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged
 
 ### Community 680 - "Community 680"
 Cohesion: 1.0
-Nodes (1): Cyclist athlete
+Nodes (1): Split training_context service into focused service/ siblings
 
 ### Community 681 - "Community 681"
 Cohesion: 1.0
-Nodes (1): Endurance cycling performance
+Nodes (1): Split workout_summary service into focused service/ siblings
 
 ### Community 682 - "Community 682"
 Cohesion: 1.0
-Nodes (1): Hero background imagery
+Nodes (1): Split training_context packing into focused packing/ siblings
 
 ### Community 683 - "Community 683"
 Cohesion: 1.0
-Nodes (1): Performance coaching brand tone
+Nodes (1): Split Mongo workout-summary adapter tests first and helper concerns only if still oversized
 
 ### Community 684 - "Community 684"
+Cohesion: 1.0
+Nodes (1): Split bulky current-slice shared helpers and integration suites into directory-based test modules
+
+### Community 685 - "Community 685"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 686 - "Community 686"
+Cohesion: 1.0
+Nodes (1): Split training_context service into focused directory modules
+
+### Community 687 - "Community 687"
+Cohesion: 1.0
+Nodes (1): Split workout_summary service while keeping WorkoutSummaryService as the entrypoint
+
+### Community 688 - "Community 688"
+Cohesion: 1.0
+Nodes (1): Split training_context packing into focused payload and rendering modules
+
+### Community 689 - "Community 689"
+Cohesion: 1.0
+Nodes (1): Split the Mongo workout-summary adapter by moving tests first and helpers only if needed
+
+### Community 690 - "Community 690"
+Cohesion: 1.0
+Nodes (1): Split bulky workout-summary shared helpers and remaining oversized current-slice tests
+
+### Community 691 - "Community 691"
+Cohesion: 1.0
+Nodes (1): Run broader backend verification after the refactor
+
+### Community 692 - "Community 692"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 693 - "Community 693"
+Cohesion: 1.0
+Nodes (1): Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits
+
+### Community 694 - "Community 694"
+Cohesion: 1.0
+Nodes (1): Make projection replay heal partial same-operation inserts
+
+### Community 695 - "Community 695"
+Cohesion: 1.0
+Nodes (1): Make workout-summary legacy fallback deterministic
+
+### Community 696 - "Community 696"
+Cohesion: 1.0
+Nodes (1): Preserve correction retry budget across reclaim
+
+### Community 697 - "Community 697"
+Cohesion: 1.0
+Nodes (1): Close low-level test and docs nits
+
+### Community 698 - "Community 698"
+Cohesion: 1.0
+Nodes (1): Run targeted tests, fmt, and clippy for the follow-up batch
+
+### Community 699 - "Community 699"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 700 - "Community 700"
+Cohesion: 1.0
+Nodes (1): Cyclist athlete
+
+### Community 701 - "Community 701"
+Cohesion: 1.0
+Nodes (1): Endurance cycling performance
+
+### Community 702 - "Community 702"
+Cohesion: 1.0
+Nodes (1): Hero background imagery
+
+### Community 703 - "Community 703"
+Cohesion: 1.0
+Nodes (1): Performance coaching brand tone
+
+### Community 704 - "Community 704"
 Cohesion: 1.0
 Nodes (1): Outdoor road training context
 
 ## Knowledge Gaps
-- **623 isolated node(s):** `TrainingPlanWorkoutSummaryAdapter`, `CompletedWorkoutTargetAdapter`, `LatestCompletedActivityAdapter`, `GoogleTokenResponse`, `GoogleUserInfoResponse` (+618 more)
+- **641 isolated node(s):** `TrainingPlanWorkoutSummaryAdapter`, `CompletedWorkoutTargetAdapter`, `LatestCompletedActivityAdapter`, `GoogleTokenResponse`, `GoogleUserInfoResponse` (+636 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 368`** (2 nodes): `PublicLayout.tsx`, `PublicLayout()`
+- **Thin community `Community 377`** (2 nodes): `jsonResponse()`, `App.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `ApiConfigCard()`, `ApiConfigCard.tsx`
+- **Thin community `Community 378`** (2 nodes): `async()`, `App.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `BackendStatusCard()`, `BackendStatusCard.tsx`
+- **Thin community `Community 379`** (2 nodes): `PublicLayout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `ProtectedSystemInfoCard.tsx`, `ProtectedSystemInfoCard()`
+- **Thin community `Community 380`** (2 nodes): `ApiConfigCard()`, `ApiConfigCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `SystemStatusHero.tsx`, `SystemStatusHero()`
+- **Thin community `Community 381`** (2 nodes): `BackendStatusCard()`, `BackendStatusCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `UserMenu.tsx`, `UserMenu()`
+- **Thin community `Community 382`** (2 nodes): `ProtectedSystemInfoCard.tsx`, `ProtectedSystemInfoCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `AuthProbe()`, `AuthProvider.test.tsx`
+- **Thin community `Community 383`** (2 nodes): `SystemStatusHero.tsx`, `SystemStatusHero()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `AuthProvider()`, `AuthProvider.tsx`
+- **Thin community `Community 384`** (2 nodes): `UserMenu.tsx`, `UserMenu()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `RequireAuth.tsx`, `RequireAuth()`
+- **Thin community `Community 385`** (2 nodes): `AuthProbe()`, `AuthProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `RequireRole.tsx`, `RequireRole()`
+- **Thin community `Community 386`** (2 nodes): `AuthProvider()`, `AuthProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `CalendarLoadingRow()`, `CalendarLoadingRow.tsx`
+- **Thin community `Community 387`** (2 nodes): `RequireAuth.tsx`, `RequireAuth()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `CalendarWeekDayHeader()`, `CalendarWeekDayHeader.tsx`
+- **Thin community `Community 388`** (2 nodes): `RequireRole.tsx`, `RequireRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `handleToggleSelectedInterval()`, `CompletedWorkoutDetailModal.tsx`
+- **Thin community `Community 389`** (2 nodes): `CalendarLoadingRow()`, `CalendarLoadingRow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `handleKeyDown()`, `DayItemsModal.tsx`
+- **Thin community `Community 390`** (2 nodes): `CalendarWeekDayHeader()`, `CalendarWeekDayHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `RaceDayDetailModal.tsx`, `handleKeyDown()`
+- **Thin community `Community 391`** (2 nodes): `handleToggleSelectedInterval()`, `CompletedWorkoutDetailModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `WorkoutDetailModal.interaction.test.tsx`, `renderActivityModal()`
+- **Thin community `Community 392`** (2 nodes): `handleKeyDown()`, `DayItemsModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `ChatHeader()`, `ChatHeader.tsx`
+- **Thin community `Community 393`** (2 nodes): `RaceDayDetailModal.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `handleSend()`, `ChatInput.tsx`
+- **Thin community `Community 394`** (2 nodes): `WorkoutDetailModal.interaction.test.tsx`, `renderActivityModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `ChatMessageList()`, `ChatMessageList.tsx`
+- **Thin community `Community 395`** (2 nodes): `ChatHeader()`, `ChatHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `ChatTypingIndicator()`, `ChatTypingIndicator.tsx`
+- **Thin community `Community 396`** (2 nodes): `handleSend()`, `ChatInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `handleKeyDown()`, `ConfirmWithoutChatModal.tsx`
+- **Thin community `Community 397`** (2 nodes): `ChatMessageList()`, `ChatMessageList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `RpeButton.tsx`, `RpeButton()`
+- **Thin community `Community 398`** (2 nodes): `ChatTypingIndicator()`, `ChatTypingIndicator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `WorkoutActionButtons.tsx`, `WorkoutActionButtons()`
+- **Thin community `Community 399`** (2 nodes): `handleKeyDown()`, `ConfirmWithoutChatModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `WorkoutCategoryTag.tsx`, `WorkoutCategoryTag()`
+- **Thin community `Community 400`** (2 nodes): `RpeButton.tsx`, `RpeButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `useWorkoutList.test.tsx`, `formatWeekLabel()`
+- **Thin community `Community 401`** (2 nodes): `WorkoutActionButtons.tsx`, `WorkoutActionButtons()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `BackgroundGlow()`, `BackgroundGlow.tsx`
+- **Thin community `Community 402`** (2 nodes): `WorkoutCategoryTag.tsx`, `WorkoutCategoryTag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `RaceCard.tsx`, `switch()`
+- **Thin community `Community 403`** (2 nodes): `useWorkoutList.test.tsx`, `formatWeekLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `RacesPageLayout.test.tsx`, `makeRace()`
+- **Thin community `Community 404`** (2 nodes): `loadTrainingLoadDashboard()`, `dashboard.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `buildSettings()`, `AiAgentsCard.test.tsx`
+- **Thin community `Community 405`** (2 nodes): `BackgroundGlow()`, `BackgroundGlow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `ApiKeyInput()`, `ApiKeyInput.tsx`
+- **Thin community `Community 406`** (2 nodes): `LoginPanel.tsx`, `handleJoinWhitelist()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `buildSettings()`, `AthleteSummaryCard.test.tsx`
+- **Thin community `Community 407`** (2 nodes): `RaceCard.tsx`, `switch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `buildSettings()`, `AvailabilityCard.test.tsx`
+- **Thin community `Community 408`** (2 nodes): `RacesPageLayout.test.tsx`, `makeRace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `IntervalsCard.test.tsx`, `buildSettings()`
+- **Thin community `Community 409`** (2 nodes): `buildSettings()`, `AiAgentsCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `OptionsCard.tsx`, `handleToggle()`
+- **Thin community `Community 410`** (2 nodes): `ApiKeyInput()`, `ApiKeyInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `AdminSystemInfoPage()`, `AdminSystemInfoPage.tsx`
+- **Thin community `Community 411`** (2 nodes): `buildSettings()`, `AthleteSummaryCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `AICoachPage()`, `AICoachPage.tsx`
+- **Thin community `Community 412`** (2 nodes): `buildSettings()`, `AvailabilityCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `AppHomePage()`, `AppHomePage.tsx`
+- **Thin community `Community 413`** (2 nodes): `IntervalsCard.test.tsx`, `buildSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `CalendarPage()`, `CalendarPage.tsx`
+- **Thin community `Community 414`** (2 nodes): `OptionsCard.tsx`, `handleToggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `LandingPage.tsx`, `LandingPage()`
+- **Thin community `Community 415`** (2 nodes): `AdminSystemInfoPage()`, `AdminSystemInfoPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `RacesPage.tsx`, `RacesPage()`
+- **Thin community `Community 416`** (2 nodes): `AICoachPage()`, `AICoachPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `main()`, `main.rs`
+- **Thin community `Community 417`** (2 nodes): `buildResponse()`, `AppHomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `workout_summary_completed_target.rs`, `CompletedWorkoutTargetAdapter`
+- **Thin community `Community 418`** (2 nodes): `CalendarPage()`, `CalendarPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `workout_summary_latest_activity.rs`, `LatestCompletedActivityAdapter`
+- **Thin community `Community 419`** (2 nodes): `LandingPage.tsx`, `LandingPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `IntervalsIcuClient`, `.test_connection()`
+- **Thin community `Community 420`** (2 nodes): `RacesPage.tsx`, `RacesPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `non_empty_context_parts()`, `context_prelude.rs`
+- **Thin community `Community 421`** (2 nodes): `main()`, `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `context_hash()`, `cache.rs`
+- **Thin community `Community 422`** (2 nodes): `workout_summary_completed_target.rs`, `CompletedWorkoutTargetAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `is_duplicate_key_error()`, `error.rs`
+- **Thin community `Community 423`** (2 nodes): `workout_summary_latest_activity.rs`, `LatestCompletedActivityAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `read_cookie()`, `cookies.rs`
+- **Thin community `Community 424`** (2 nodes): `IntervalsIcuClient`, `.test_connection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `AthleteSummaryDto`, `dto.rs`
+- **Thin community `Community 425`** (2 nodes): `non_empty_context_parts()`, `context_prelude.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `map_summary_state_to_dto()`, `mapping.rs`
+- **Thin community `Community 426`** (2 nodes): `context_hash()`, `cache.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `status_class.rs`, `status_class()`
+- **Thin community `Community 427`** (2 nodes): `is_duplicate_key_error()`, `error.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `CreateRace`, `.from()`
+- **Thin community `Community 428`** (2 nodes): `read_cookie()`, `cookies.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `map_race_to_dto()`, `mapping.rs`
+- **Thin community `Community 429`** (2 nodes): `AthleteSummaryDto`, `dto.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `ProviderPollingService<
+- **Thin community `Community 430`** (2 nodes): `map_summary_state_to_dto()`, `mapping.rs`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 431`** (2 nodes): `status_class.rs`, `status_class()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 432`** (2 nodes): `CreateRace`, `.from()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 433`** (2 nodes): `map_race_to_dto()`, `mapping.rs`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 434`** (2 nodes): `ProviderPollingService<
         Api,
         Settings,
         PollStates,
@@ -3698,11 +3806,11 @@ Nodes (1): Outdoor road training context
         NoopCalendarEntryViewRefresh,
     >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `poll_due_once_persists_attempt_before_calling_intervals()`, `persistence.rs`
+- **Thin community `Community 435`** (2 nodes): `poll_due_once_persists_attempt_before_calling_intervals()`, `persistence.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `CalendarService`, `mod.rs`
+- **Thin community `Community 436`** (2 nodes): `CalendarService`, `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `CalendarService<
+- **Thin community `Community 437`** (2 nodes): `CalendarService<
         Intervals,
         Entries,
         Projections,
@@ -3714,9 +3822,9 @@ Nodes (1): Outdoor road training context
         (),
     >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `CalendarLabelsService`, `service.rs`
+- **Thin community `Community 438`** (2 nodes): `CalendarLabelsService`, `service.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `IntervalsService<
+- **Thin community `Community 439`** (2 nodes): `IntervalsService<
         Api,
         Settings,
         Activities,
@@ -3727,227 +3835,201 @@ Nodes (1): Outdoor road training context
         NoopCalendarEntryViewRefresh,
     >`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>`, `.get_enriched_event_impl()`
+- **Thin community `Community 440`** (2 nodes): `IntervalsService<Api, Settings, Activities, UploadOperations, Extractor, PocRepo, Time, Refresh>`, `.get_enriched_event_impl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `PlannedCompletedWorkoutLinkRepository`, `ports.rs`
+- **Thin community `Community 441`** (2 nodes): `PlannedCompletedWorkoutLinkRepository`, `ports.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `UserSettingsRepository`, `ports.rs`
+- **Thin community `Community 442`** (2 nodes): `UserSettingsRepository`, `ports.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `SpecialDayService`, `service.rs`
+- **Thin community `Community 443`** (2 nodes): `SpecialDayService`, `service.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `SpecialDayService<Repository>`, `.new()`
+- **Thin community `Community 444`** (2 nodes): `SpecialDayService<Repository>`, `.new()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `CompactRace<'a>`, `.from_race()`
+- **Thin community `Community 445`** (2 nodes): `CompactRace<'a>`, `.from_race()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `CompactFuturePlannedEvent<'a>`, `.from_event()`
+- **Thin community `Community 446`** (2 nodes): `CompactFuturePlannedEvent<'a>`, `.from_event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `CompactAvailabilityDay<'a>`, `.from_day()`
+- **Thin community `Community 447`** (2 nodes): `CompactAvailabilityDay<'a>`, `.from_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `CompactHistoricalLoadTrend<'a>`, `.from_point()`
+- **Thin community `Community 448`** (2 nodes): `CompactHistoricalLoadTrend<'a>`, `.from_point()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `CompactHistoricalWorkout<'a>`, `.from_workout()`
+- **Thin community `Community 449`** (2 nodes): `CompactHistoricalWorkout<'a>`, `.from_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `VolatilePayload<'a>`, `.from_context()`
+- **Thin community `Community 450`** (2 nodes): `VolatilePayload<'a>`, `.from_context()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `CompactRecentDay<'a>`, `.from_recent_day()`
+- **Thin community `Community 451`** (2 nodes): `CompactRecentDay<'a>`, `.from_recent_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `CompactRecentWorkout<'a>`, `.from_workout()`
+- **Thin community `Community 452`** (2 nodes): `CompactRecentWorkout<'a>`, `.from_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `CompactPlannedWorkoutRef<'a>`, `.from_reference()`
+- **Thin community `Community 453`** (2 nodes): `CompactPlannedWorkoutRef<'a>`, `.from_reference()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `CompactPlannedWorkout<'a>`, `.from_planned()`
+- **Thin community `Community 454`** (2 nodes): `CompactPlannedWorkout<'a>`, `.from_planned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `CompactSpecialDay<'a>`, `.from_special()`
+- **Thin community `Community 455`** (2 nodes): `CompactSpecialDay<'a>`, `.from_special()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `CompactUpcomingDay<'a>`, `.from_upcoming_day()`
+- **Thin community `Community 456`** (2 nodes): `CompactUpcomingDay<'a>`, `.from_upcoming_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `CompactProjectedDay<'a>`, `.from_projected_day()`
+- **Thin community `Community 457`** (2 nodes): `CompactProjectedDay<'a>`, `.from_projected_day()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `CompactProjectedWorkout<'a>`, `.from_projected_workout()`
+- **Thin community `Community 458`** (2 nodes): `CompactProjectedWorkout<'a>`, `.from_projected_workout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `settings_request_logs_authenticated_user_id_on_request_span()`, `observability.rs`
+- **Thin community `Community 459`** (2 nodes): `settings_request_logs_authenticated_user_id_on_request_span()`, `observability.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `ttl_validation.rs`, `validate_session_ttl_against_current_time_rejects_bson_overflowing_ttl()`
+- **Thin community `Community 460`** (2 nodes): `ttl_validation.rs`, `validate_session_ttl_against_current_time_rejects_bson_overflowing_ttl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `assert_valid_traceparent()`, `assertions.rs`
+- **Thin community `Community 461`** (2 nodes): `assert_valid_traceparent()`, `assertions.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `assert_log_entry_contains()`, `test_support.rs`
+- **Thin community `Community 462`** (2 nodes): `assert_log_entry_contains()`, `test_support.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `assert_log_entry_contains()`, `mod.rs`
+- **Thin community `Community 463`** (2 nodes): `assert_log_entry_contains()`, `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `assert_event_order()`, `assertions.rs`
+- **Thin community `Community 464`** (2 nodes): `assert_event_order()`, `assertions.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (1 nodes): `vite.config.ts`
+- **Thin community `Community 465`** (1 nodes): `vite.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (1 nodes): `App.test.tsx`
+- **Thin community `Community 466`** (1 nodes): `i18n.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (1 nodes): `App.tsx`
+- **Thin community `Community 467`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (1 nodes): `i18n.ts`
+- **Thin community `Community 468`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (1 nodes): `main.tsx`
+- **Thin community `Community 469`** (1 nodes): `AuthenticatedLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 470`** (1 nodes): `env.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (1 nodes): `AuthenticatedLayout.tsx`
+- **Thin community `Community 471`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (1 nodes): `env.test.ts`
+- **Thin community `Community 472`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (1 nodes): `types.ts`
+- **Thin community `Community 473`** (1 nodes): `RequireAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 474`** (1 nodes): `RequireRole.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (1 nodes): `RequireAuth.test.tsx`
+- **Thin community `Community 475`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (1 nodes): `RequireRole.test.tsx`
+- **Thin community `Community 476`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (1 nodes): `constants.ts`
+- **Thin community `Community 477`** (1 nodes): `workoutDetails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (1 nodes): `types.ts`
+- **Thin community `Community 478`** (1 nodes): `calendar.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (1 nodes): `workoutDetails.test.ts`
+- **Thin community `Community 479`** (1 nodes): `CalendarDayCell.charts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (1 nodes): `calendar.test.ts`
+- **Thin community `Community 480`** (1 nodes): `CalendarDayCell.content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (1 nodes): `CalendarDayCell.charts.test.tsx`
+- **Thin community `Community 481`** (1 nodes): `CalendarErrorRow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (1 nodes): `CalendarDayCell.content.test.tsx`
+- **Thin community `Community 482`** (1 nodes): `CalendarErrorRow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (1 nodes): `CalendarErrorRow.test.tsx`
+- **Thin community `Community 483`** (1 nodes): `CalendarGrid.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (1 nodes): `CalendarErrorRow.tsx`
+- **Thin community `Community 484`** (1 nodes): `CalendarLoadingRow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (1 nodes): `CalendarGrid.tsx`
+- **Thin community `Community 485`** (1 nodes): `CalendarMiniChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (1 nodes): `CalendarLoadingRow.test.tsx`
+- **Thin community `Community 486`** (1 nodes): `CalendarPerformanceCards.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (1 nodes): `CalendarMiniChart.tsx`
+- **Thin community `Community 487`** (1 nodes): `CalendarPerformanceCards.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (1 nodes): `CalendarPerformanceCards.test.tsx`
+- **Thin community `Community 488`** (1 nodes): `CalendarWeekSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (1 nodes): `CalendarPerformanceCards.tsx`
+- **Thin community `Community 489`** (1 nodes): `CalendarWeekSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (1 nodes): `CalendarWeekSection.tsx`
+- **Thin community `Community 490`** (1 nodes): `DayItemsModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (1 nodes): `CalendarWeekSummary.tsx`
+- **Thin community `Community 491`** (1 nodes): `RaceDayDetailModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (1 nodes): `DayItemsModal.test.tsx`
+- **Thin community `Community 492`** (1 nodes): `WorkoutDetailModal.actions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (1 nodes): `RaceDayDetailModal.test.tsx`
+- **Thin community `Community 493`** (1 nodes): `WorkoutDetailModal.charts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (1 nodes): `WorkoutDetailModal.actions.test.tsx`
+- **Thin community `Community 494`** (1 nodes): `WorkoutDetailModal.completed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (1 nodes): `WorkoutDetailModal.charts.test.tsx`
+- **Thin community `Community 495`** (1 nodes): `WorkoutDetailModal.intervals.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (1 nodes): `WorkoutDetailModal.completed.test.tsx`
+- **Thin community `Community 496`** (1 nodes): `WorkoutDetailModal.planned.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (1 nodes): `WorkoutDetailModal.intervals.test.tsx`
+- **Thin community `Community 497`** (1 nodes): `WorkoutDetailModalPanels.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (1 nodes): `WorkoutDetailModal.planned.test.tsx`
+- **Thin community `Community 498`** (1 nodes): `WorkoutDetailPanelPrimitives.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (1 nodes): `WorkoutDetailModalPanels.tsx`
+- **Thin community `Community 499`** (1 nodes): `dateUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (1 nodes): `WorkoutDetailPanelPrimitives.tsx`
+- **Thin community `Community 500`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (1 nodes): `dateUtils.test.ts`
+- **Thin community `Community 501`** (1 nodes): `workoutSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (1 nodes): `types.ts`
+- **Thin community `Community 502`** (1 nodes): `ChatWindow.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (1 nodes): `workoutSummary.test.ts`
+- **Thin community `Community 503`** (1 nodes): `ChatWindow.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (1 nodes): `ChatWindow.test.tsx`
+- **Thin community `Community 504`** (1 nodes): `ConfirmWithoutChatModal.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (1 nodes): `ChatWindow.tsx`
+- **Thin community `Community 505`** (1 nodes): `EmptyWorkoutState.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (1 nodes): `ConfirmWithoutChatModal.test.tsx`
+- **Thin community `Community 506`** (1 nodes): `RpeScaleLabels.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (1 nodes): `EmptyWorkoutState.tsx`
+- **Thin community `Community 507`** (1 nodes): `RpeSelector.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (1 nodes): `RpeScaleLabels.tsx`
+- **Thin community `Community 508`** (1 nodes): `RpeSelector.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (1 nodes): `RpeSelector.test.tsx`
+- **Thin community `Community 509`** (1 nodes): `WorkoutActionButtons.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (1 nodes): `RpeSelector.tsx`
+- **Thin community `Community 510`** (1 nodes): `WorkoutHistoryPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (1 nodes): `WorkoutActionButtons.test.tsx`
+- **Thin community `Community 511`** (1 nodes): `WorkoutHistorySidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (1 nodes): `WorkoutHistoryPagination.tsx`
+- **Thin community `Community 512`** (1 nodes): `WorkoutHistorySidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (1 nodes): `WorkoutHistorySidebar.test.tsx`
+- **Thin community `Community 513`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (1 nodes): `WorkoutHistorySidebar.tsx`
+- **Thin community `Community 514`** (1 nodes): `dashboard.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (1 nodes): `types.ts`
+- **Thin community `Community 515`** (1 nodes): `TrainingLoadEmptyState.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (1 nodes): `intervals.activities.test.ts`
+- **Thin community `Community 516`** (1 nodes): `TrainingLoadInsightCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (1 nodes): `intervals.events.test.ts`
+- **Thin community `Community 517`** (1 nodes): `TrainingLoadLoadChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (1 nodes): `LoginPanel.tsx`
+- **Thin community `Community 518`** (1 nodes): `TrainingLoadRangeSwitch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (1 nodes): `types.ts`
+- **Thin community `Community 519`** (1 nodes): `TrainingLoadReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (1 nodes): `races.test.ts`
+- **Thin community `Community 520`** (1 nodes): `TrainingLoadTsbChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (1 nodes): `RacesPageLayout.tsx`
+- **Thin community `Community 521`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (1 nodes): `useRaces.test.tsx`
+- **Thin community `Community 522`** (1 nodes): `intervals.activities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (1 nodes): `mockData.ts`
+- **Thin community `Community 523`** (1 nodes): `intervals.events.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (1 nodes): `settings.test.ts`
+- **Thin community `Community 524`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (1 nodes): `statusUi.test.ts`
+- **Thin community `Community 525`** (1 nodes): `races.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (1 nodes): `system.test.ts`
+- **Thin community `Community 526`** (1 nodes): `RacesPageLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (1 nodes): `AdminSystemInfoPage.test.tsx`
+- **Thin community `Community 527`** (1 nodes): `useRaces.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (1 nodes): `LandingPage.test.tsx`
+- **Thin community `Community 528`** (1 nodes): `mockData.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (1 nodes): `SettingsPage.test.tsx`
+- **Thin community `Community 529`** (1 nodes): `settings.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (1 nodes): `setup.ts`
+- **Thin community `Community 530`** (1 nodes): `statusUi.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (1 nodes): `lib.rs`
+- **Thin community `Community 531`** (1 nodes): `system.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (1 nodes): `mod.rs`
+- **Thin community `Community 532`** (1 nodes): `AdminSystemInfoPage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (1 nodes): `mod.rs`
+- **Thin community `Community 533`** (1 nodes): `AppHomePage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (1 nodes): `mod.rs`
+- **Thin community `Community 534`** (1 nodes): `LandingPage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (1 nodes): `api.rs`
+- **Thin community `Community 535`** (1 nodes): `SettingsPage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (1 nodes): `connection.rs`
+- **Thin community `Community 536`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (1 nodes): `details.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (1 nodes): `calendar.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (1 nodes): `completed_workouts.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (1 nodes): `intervals.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (1 nodes): `races.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (1 nodes): `mod.rs`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (1 nodes): `mod.rs`
+- **Thin community `Community 537`** (1 nodes): `lib.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 538`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -3955,15 +4037,15 @@ Nodes (1): Outdoor road training context
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 540`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (1 nodes): `mod.rs`
+- **Thin community `Community 541`** (1 nodes): `api.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (1 nodes): `activities.rs`
+- **Thin community `Community 542`** (1 nodes): `connection.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (1 nodes): `enriched.rs`
+- **Thin community `Community 543`** (1 nodes): `details.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (1 nodes): `events.rs`
+- **Thin community `Community 544`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (1 nodes): `upload.rs`
+- **Thin community `Community 545`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 546`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -3971,277 +4053,317 @@ Nodes (1): Outdoor road training context
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 548`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (1 nodes): `mod.rs`
+- **Thin community `Community 549`** (1 nodes): `calendar.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (1 nodes): `parsing.rs`
+- **Thin community `Community 550`** (1 nodes): `completed_workouts.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (1 nodes): `snapshot.rs`
+- **Thin community `Community 551`** (1 nodes): `dashboard.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (1 nodes): `main.rs`
+- **Thin community `Community 552`** (1 nodes): `intervals.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (1 nodes): `main.rs`
+- **Thin community `Community 553`** (1 nodes): `races.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (1 nodes): `main.rs`
+- **Thin community `Community 554`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (1 nodes): `main.rs`
+- **Thin community `Community 555`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 556`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (1 nodes): `event_queries.rs`
+- **Thin community `Community 557`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (1 nodes): `intervals_fakes.rs`
+- **Thin community `Community 558`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (1 nodes): `main.rs`
+- **Thin community `Community 559`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (1 nodes): `main.rs`
+- **Thin community `Community 560`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 561`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (1 nodes): `main.rs`
+- **Thin community `Community 562`** (1 nodes): `activities.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (1 nodes): `main.rs`
+- **Thin community `Community 563`** (1 nodes): `enriched.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (1 nodes): `mod.rs`
+- **Thin community `Community 564`** (1 nodes): `events.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (1 nodes): `main.rs`
+- **Thin community `Community 565`** (1 nodes): `upload.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 566`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (1 nodes): `main.rs`
+- **Thin community `Community 567`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (1 nodes): `constants.rs`
+- **Thin community `Community 568`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (1 nodes): `main.rs`
+- **Thin community `Community 569`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (1 nodes): `mod.rs`
+- **Thin community `Community 570`** (1 nodes): `parsing.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (1 nodes): `main.rs`
+- **Thin community `Community 571`** (1 nodes): `snapshot.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (1 nodes): `mod.rs`
+- **Thin community `Community 572`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (1 nodes): `Hexagonal Architecture Rules`
+- **Thin community `Community 573`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (1 nodes): `Persist Local State Before Side Effects`
+- **Thin community `Community 574`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (1 nodes): `Single Container API And SPA Deployment`
+- **Thin community `Community 575`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (1 nodes): `Operational Health And Readiness Endpoints`
+- **Thin community `Community 576`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (1 nodes): `Coach Reply Operation`
+- **Thin community `Community 577`** (1 nodes): `event_queries.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (1 nodes): `Pending Durable Coach Reply State`
+- **Thin community `Community 578`** (1 nodes): `intervals_fakes.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (1 nodes): `Coach Reply Recovery Rules`
+- **Thin community `Community 579`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (1 nodes): `Same Request Local Write Retries`
+- **Thin community `Community 580`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (1 nodes): `Compare And Swap Pending Operation Reclaim`
+- **Thin community `Community 581`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (1 nodes): `Bootstrap Architecture`
+- **Thin community `Community 582`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (1 nodes): `REST Adapter`
+- **Thin community `Community 583`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (1 nodes): `Mongo Adapter`
+- **Thin community `Community 584`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `Planned Mongo Collections`
+- **Thin community `Community 585`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `Backend Bootstrap Foundation`
+- **Thin community `Community 586`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `Project Obsidian Handbook`
+- **Thin community `Community 587`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `Manual Tag Based Release Flow`
+- **Thin community `Community 588`** (1 nodes): `constants.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `Manual Coolify Deployment Path`
+- **Thin community `Community 589`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `Frontend Application Shell`
+- **Thin community `Community 590`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `Frontend Backend Connectivity`
+- **Thin community `Community 591`** (1 nodes): `main.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `Identity Domain`
+- **Thin community `Community 592`** (1 nodes): `mod.rs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `Google OAuth Login Flow`
+- **Thin community `Community 593`** (1 nodes): `Hexagonal Architecture Rules`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `Server Side Sessions`
+- **Thin community `Community 594`** (1 nodes): `Persist Local State Before Side Effects`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `RBAC Policy`
+- **Thin community `Community 595`** (1 nodes): `Single Container API And SPA Deployment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `Draft Driven Intervals Settings Actions`
+- **Thin community `Community 596`** (1 nodes): `Operational Health And Readiness Endpoints`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `Synthetic Trace Parent Fix`
+- **Thin community `Community 597`** (1 nodes): `Coach Reply Operation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `Atomic Tracing Capture Writes`
+- **Thin community `Community 598`** (1 nodes): `Pending Durable Coach Reply State`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `Structured Mini Chart Bars`
+- **Thin community `Community 599`** (1 nodes): `Coach Reply Recovery Rules`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `Completed Activity Enrichment`
+- **Thin community `Community 600`** (1 nodes): `Same Request Local Write Retries`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `Partial Enrichment Fail Open`
+- **Thin community `Community 601`** (1 nodes): `Compare And Swap Pending Operation Reclaim`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `Workout Detail Modal Flow`
+- **Thin community `Community 602`** (1 nodes): `Bootstrap Architecture`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `Event FIT Download Action`
+- **Thin community `Community 603`** (1 nodes): `REST Adapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `Intervals Service Enrichment Placement`
+- **Thin community `Community 604`** (1 nodes): `Mongo Adapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `Partial Modal Resilience`
+- **Thin community `Community 605`** (1 nodes): `Planned Mongo Collections`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `Intervals Service Workout Enrichment`
+- **Thin community `Community 606`** (1 nodes): `Backend Bootstrap Foundation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `Partial Workout Detail Failure Resilience`
+- **Thin community `Community 607`** (1 nodes): `Project Obsidian Handbook`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `Completed Workout Mode UI Cleanup`
+- **Thin community `Community 608`** (1 nodes): `Manual Tag Based Release Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `Remove Workout Detail Auto Scroll Side Effect`
+- **Thin community `Community 609`** (1 nodes): `Manual Coolify Deployment Path`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `Preserve Workout Detail Selection Synchronization`
+- **Thin community `Community 610`** (1 nodes): `Frontend Application Shell`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `Workout Detail ScrollIntoView Removal`
+- **Thin community `Community 611`** (1 nodes): `Frontend Backend Connectivity`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `Workout Detail Interaction Test Updates`
+- **Thin community `Community 612`** (1 nodes): `Identity Domain`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `Durable Recoverable Coach Replies`
+- **Thin community `Community 613`** (1 nodes): `Google OAuth Login Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `LLM Context Cache Invalidation`
+- **Thin community `Community 614`** (1 nodes): `Server Side Sessions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `Provider Observability And Cost Tracing`
+- **Thin community `Community 615`** (1 nodes): `RBAC Policy`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `AI Settings UX Hardening`
+- **Thin community `Community 616`** (1 nodes): `Draft Driven Intervals Settings Actions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `Coach Reply Operation As Durable Workflow Record`
+- **Thin community `Community 617`** (1 nodes): `Synthetic Trace Parent Fix`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `Idempotent Coach Reply Finalization`
+- **Thin community `Community 618`** (1 nodes): `Atomic Tracing Capture Writes`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `Partial Persistence Failure Recovery For Finalization`
+- **Thin community `Community 619`** (1 nodes): `Structured Mini Chart Bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `Coach Reply State Machine Documentation Update`
+- **Thin community `Community 620`** (1 nodes): `Completed Activity Enrichment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `Debug Level Successful Health Logs`
+- **Thin community `Community 621`** (1 nodes): `Partial Enrichment Fail Open`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `Preserve Health Failure Visibility`
+- **Thin community `Community 622`** (1 nodes): `Workout Detail Modal Flow`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `Reduce Health Endpoint Success Log Noise`
+- **Thin community `Community 623`** (1 nodes): `Event FIT Download Action`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `Curated Provider Model Suggestion Refresh`
+- **Thin community `Community 624`** (1 nodes): `Intervals Service Enrichment Placement`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `Preserve Freeform Model Input`
+- **Thin community `Community 625`** (1 nodes): `Partial Modal Resilience`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `Refresh AI Agent Model Suggestions`
+- **Thin community `Community 626`** (1 nodes): `Intervals Service Workout Enrichment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `Lower Mongo Local Development Verbosity`
+- **Thin community `Community 627`** (1 nodes): `Partial Workout Detail Failure Resilience`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `Quiet Docker Compose Mongo Startup Logs`
+- **Thin community `Community 628`** (1 nodes): `Completed Workout Mode UI Cleanup`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `Safe Structured OpenRouter Diagnostics`
+- **Thin community `Community 629`** (1 nodes): `Remove Workout Detail Auto Scroll Side Effect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `Redacted Provider Request Metadata Logging`
+- **Thin community `Community 630`** (1 nodes): `Preserve Workout Detail Selection Synchronization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `OpenRouter Transport And Response Diagnostics`
+- **Thin community `Community 631`** (1 nodes): `Workout Detail ScrollIntoView Removal`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `Multi Provider Logging Pattern Rollout`
+- **Thin community `Community 632`** (1 nodes): `Workout Detail Interaction Test Updates`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `OpenAI And Gemini Diagnostic Logging`
+- **Thin community `Community 633`** (1 nodes): `Durable Recoverable Coach Replies`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `Persisted Athlete Summary Feature`
+- **Thin community `Community 634`** (1 nodes): `LLM Context Cache Invalidation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `Athlete Summary Prompt Context Integration`
+- **Thin community `Community 635`** (1 nodes): `Provider Observability And Cost Tracing`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `Athlete Summary Generation System Message`
+- **Thin community `Community 636`** (1 nodes): `AI Settings UX Hardening`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `OpenRouter Stable Prefix Prompt Caching`
+- **Thin community `Community 637`** (1 nodes): `Coach Reply Operation As Durable Workflow Record`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `Uncached Conversation Tail`
+- **Thin community `Community 638`** (1 nodes): `Idempotent Coach Reply Finalization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `Single WebSocket Control Loop`
+- **Thin community `Community 639`** (1 nodes): `Partial Persistence Failure Recovery For Finalization`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `Drop Queued Messages After Disconnect`
+- **Thin community `Community 640`** (1 nodes): `Coach Reply State Machine Documentation Update`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `Full Workout Summary Builder Request Logging`
+- **Thin community `Community 641`** (1 nodes): `Debug Level Successful Health Logs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `Athlete Summary Durable Generation Operation`
+- **Thin community `Community 642`** (1 nodes): `Preserve Health Failure Visibility`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `Athlete Summary Stale Work Reclaim`
+- **Thin community `Community 643`** (1 nodes): `Reduce Health Endpoint Success Log Noise`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `Distinct Athlete Summary System Message Rendering`
+- **Thin community `Community 644`** (1 nodes): `Curated Provider Model Suggestion Refresh`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `Compressed Raw Power Segments`
+- **Thin community `Community 645`** (1 nodes): `Preserve Freeform Model Input`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `Compact Training Context Power Field`
+- **Thin community `Community 646`** (1 nodes): `Refresh AI Agent Model Suggestions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `Power Compression Prompt Encoding Legend`
+- **Thin community `Community 647`** (1 nodes): `Lower Mongo Local Development Verbosity`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `2026-04-04-power-compression-llm.md`
+- **Thin community `Community 648`** (1 nodes): `Quiet Docker Compose Mongo Startup Logs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `Replace LLM workout power arrays with compressed raw-power segments`
+- **Thin community `Community 649`** (1 nodes): `Safe Structured OpenRouter Diagnostics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly`
+- **Thin community `Community 650`** (1 nodes): `Redacted Provider Request Metadata Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `RecentWorkoutContext.compressed_power_levels: Vec<String>`
+- **Thin community `Community 651`** (1 nodes): `OpenRouter Transport And Response Diagnostics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `Add power compression tests and implementation in training_context service`
+- **Thin community `Community 652`** (1 nodes): `Multi Provider Logging Pattern Rollout`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `Pack pc instead of p5`
+- **Thin community `Community 653`** (1 nodes): `OpenAI And Gemini Diagnostic Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `Update the workout coach prompt with power-compression semantics`
+- **Thin community `Community 654`** (1 nodes): `Persisted Athlete Summary Feature`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `Update LLM flow assertions to expect pc in live requests`
+- **Thin community `Community 655`** (1 nodes): `Athlete Summary Prompt Context Integration`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `Run full formatting, lint, Rust tests, and repo verification`
+- **Thin community `Community 656`** (1 nodes): `Athlete Summary Generation System Message`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `2026-04-06-backend-slice-size-refactor-design.md`
+- **Thin community `Community 657`** (1 nodes): `OpenRouter Stable Prefix Prompt Caching`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior`
+- **Thin community `Community 658`** (1 nodes): `Uncached Conversation Tail`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged`
+- **Thin community `Community 659`** (1 nodes): `Single WebSocket Control Loop`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `Split training_context service into focused service/ siblings`
+- **Thin community `Community 660`** (1 nodes): `Drop Queued Messages After Disconnect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `Split workout_summary service into focused service/ siblings`
+- **Thin community `Community 661`** (1 nodes): `Full Workout Summary Builder Request Logging`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `Split training_context packing into focused packing/ siblings`
+- **Thin community `Community 662`** (1 nodes): `Athlete Summary Durable Generation Operation`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `Split Mongo workout-summary adapter tests first and helper concerns only if still oversized`
+- **Thin community `Community 663`** (1 nodes): `Athlete Summary Stale Work Reclaim`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `Split bulky current-slice shared helpers and integration suites into directory-based test modules`
+- **Thin community `Community 664`** (1 nodes): `Distinct Athlete Summary System Message Rendering`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `2026-04-06-backend-slice-size-refactor.md`
+- **Thin community `Community 665`** (1 nodes): `Compressed Raw Power Segments`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `Split training_context service into focused directory modules`
+- **Thin community `Community 666`** (1 nodes): `Compact Training Context Power Field`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `Split workout_summary service while keeping WorkoutSummaryService as the entrypoint`
+- **Thin community `Community 667`** (1 nodes): `Power Compression Prompt Encoding Legend`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `Split training_context packing into focused payload and rendering modules`
+- **Thin community `Community 668`** (1 nodes): `2026-04-04-power-compression-llm.md`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `Split the Mongo workout-summary adapter by moving tests first and helpers only if needed`
+- **Thin community `Community 669`** (1 nodes): `Replace LLM workout power arrays with compressed raw-power segments`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `Split bulky workout-summary shared helpers and remaining oversized current-slice tests`
+- **Thin community `Community 670`** (1 nodes): `Keep compression in domain/training_context and keep the LLM adapter limited to prompt assembly`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `Run broader backend verification after the refactor`
+- **Thin community `Community 671`** (1 nodes): `RecentWorkoutContext.compressed_power_levels: Vec<String>`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `2026-04-06-review-followups.md`
+- **Thin community `Community 672`** (1 nodes): `Add power compression tests and implementation in training_context service`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits`
+- **Thin community `Community 673`** (1 nodes): `Pack pc instead of p5`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `Make projection replay heal partial same-operation inserts`
+- **Thin community `Community 674`** (1 nodes): `Update the workout coach prompt with power-compression semantics`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `Make workout-summary legacy fallback deterministic`
+- **Thin community `Community 675`** (1 nodes): `Update LLM flow assertions to expect pc in live requests`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `Preserve correction retry budget across reclaim`
+- **Thin community `Community 676`** (1 nodes): `Run full formatting, lint, Rust tests, and repo verification`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `Close low-level test and docs nits`
+- **Thin community `Community 677`** (1 nodes): `2026-04-06-backend-slice-size-refactor-design.md`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `Run targeted tests, fmt, and clippy for the follow-up batch`
+- **Thin community `Community 678`** (1 nodes): `Reduce the training-plan and workout-summary backend slice by splitting oversized files without changing behavior`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `cyclist-bg.jpg`
+- **Thin community `Community 679`** (1 nodes): `Keep behavior, public APIs, durable workflow ordering, idempotency behavior, and adapter boundaries unchanged`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `Cyclist athlete`
+- **Thin community `Community 680`** (1 nodes): `Split training_context service into focused service/ siblings`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `Endurance cycling performance`
+- **Thin community `Community 681`** (1 nodes): `Split workout_summary service into focused service/ siblings`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `Hero background imagery`
+- **Thin community `Community 682`** (1 nodes): `Split training_context packing into focused packing/ siblings`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `Performance coaching brand tone`
+- **Thin community `Community 683`** (1 nodes): `Split Mongo workout-summary adapter tests first and helper concerns only if still oversized`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `Outdoor road training context`
+- **Thin community `Community 684`** (1 nodes): `Split bulky current-slice shared helpers and integration suites into directory-based test modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 685`** (1 nodes): `2026-04-06-backend-slice-size-refactor.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 686`** (1 nodes): `Split training_context service into focused directory modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 687`** (1 nodes): `Split workout_summary service while keeping WorkoutSummaryService as the entrypoint`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 688`** (1 nodes): `Split training_context packing into focused payload and rendering modules`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 689`** (1 nodes): `Split the Mongo workout-summary adapter by moving tests first and helpers only if needed`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 690`** (1 nodes): `Split bulky workout-summary shared helpers and remaining oversized current-slice tests`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 691`** (1 nodes): `Run broader backend verification after the refactor`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 692`** (1 nodes): `2026-04-06-review-followups.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 693`** (1 nodes): `Close final-review findings around projection replay healing, workout-summary legacy identifiers, correction retry budget, and test/doc nits`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 694`** (1 nodes): `Make projection replay heal partial same-operation inserts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 695`** (1 nodes): `Make workout-summary legacy fallback deterministic`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 696`** (1 nodes): `Preserve correction retry budget across reclaim`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 697`** (1 nodes): `Close low-level test and docs nits`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 698`** (1 nodes): `Run targeted tests, fmt, and clippy for the follow-up batch`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 699`** (1 nodes): `cyclist-bg.jpg`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 700`** (1 nodes): `Cyclist athlete`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 701`** (1 nodes): `Endurance cycling performance`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 702`** (1 nodes): `Hero background imagery`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 703`** (1 nodes): `Performance coaching brand tone`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 704`** (1 nodes): `Outdoor road training context`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -4249,15 +4371,15 @@ _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `FixedClock` connect `Community 0` to `Community 10`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
-- **Why does `sample_completed_workout()` connect `Community 2` to `Community 1`?**
+- **Why does `sample_completed_workout()` connect `Community 2` to `Community 4`?**
   _High betweenness centrality (0.001) - this node is a cross-community bridge._
+- **Why does `RecordingCalendarRefresh` connect `Community 6` to `Community 4`?**
+  _High betweenness centrality (0.000) - this node is a cross-community bridge._
 - **What connects `TrainingPlanWorkoutSummaryAdapter`, `CompletedWorkoutTargetAdapter`, `LatestCompletedActivityAdapter` to the rest of the system?**
-  _623 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _641 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.02 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.03 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.07 - nodes in this community are weakly interconnected._

--- a/src/adapters/mongo/training_load_daily_snapshots.rs
+++ b/src/adapters/mongo/training_load_daily_snapshots.rs
@@ -1,5 +1,9 @@
 use futures::TryStreamExt;
-use mongodb::{bson::doc, options::IndexOptions, Collection, IndexModel};
+use mongodb::{
+    bson::doc,
+    options::{FindOneOptions, IndexOptions},
+    Collection, IndexModel,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::training_load::{
@@ -29,6 +33,11 @@ struct TrainingLoadDailySnapshotDocument {
     recomputed_at_epoch_seconds: i64,
     created_at_epoch_seconds: i64,
     updated_at_epoch_seconds: i64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TrainingLoadDailySnapshotDateOnlyDocument {
+    date: String,
 }
 
 impl MongoTrainingLoadDailySnapshotRepository {
@@ -122,18 +131,21 @@ impl TrainingLoadDailySnapshotRepository for MongoTrainingLoadDailySnapshotRepos
         &self,
         user_id: &str,
     ) -> BoxFuture<Result<Option<String>, TrainingLoadError>> {
-        let collection = self.collection.clone();
+        let collection = self
+            .collection
+            .clone_with_type::<TrainingLoadDailySnapshotDateOnlyDocument>();
         let user_id = user_id.to_string();
         Box::pin(async move {
             let oldest = collection
-                .find(doc! {
+                .find_one(doc! {
                     "user_id": &user_id,
                 })
-                .sort(doc! { "date": 1 })
-                .limit(1)
-                .await
-                .map_err(|error| TrainingLoadError::Repository(error.to_string()))?
-                .try_next()
+                .with_options(
+                    FindOneOptions::builder()
+                        .sort(doc! { "date": 1 })
+                        .projection(doc! { "_id": 0, "date": 1 })
+                        .build(),
+                )
                 .await
                 .map_err(|error| TrainingLoadError::Repository(error.to_string()))?
                 .map(|document| document.date);

--- a/src/adapters/mongo/training_load_daily_snapshots.rs
+++ b/src/adapters/mongo/training_load_daily_snapshots.rs
@@ -118,6 +118,29 @@ impl TrainingLoadDailySnapshotRepository for MongoTrainingLoadDailySnapshotRepos
         })
     }
 
+    fn find_oldest_date_by_user_id(
+        &self,
+        user_id: &str,
+    ) -> BoxFuture<Result<Option<String>, TrainingLoadError>> {
+        let collection = self.collection.clone();
+        let user_id = user_id.to_string();
+        Box::pin(async move {
+            let oldest = collection
+                .find(doc! {
+                    "user_id": &user_id,
+                })
+                .sort(doc! { "date": 1 })
+                .limit(1)
+                .await
+                .map_err(|error| TrainingLoadError::Repository(error.to_string()))?
+                .try_next()
+                .await
+                .map_err(|error| TrainingLoadError::Repository(error.to_string()))?
+                .map(|document| document.date);
+            Ok(oldest)
+        })
+    }
+
     fn delete_by_user_id_from_date(
         &self,
         user_id: &str,

--- a/src/adapters/rest/dashboard.rs
+++ b/src/adapters/rest/dashboard.rs
@@ -1,0 +1,5 @@
+mod dto;
+mod handlers;
+mod mapping;
+
+pub(crate) use handlers::get_training_load_dashboard;

--- a/src/adapters/rest/dashboard/dto.rs
+++ b/src/adapters/rest/dashboard/dto.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub(crate) struct TrainingLoadDashboardQuery {
+    pub range: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct TrainingLoadDashboardPointDto {
+    pub date: String,
+    #[serde(rename = "dailyTss")]
+    pub daily_tss: Option<i32>,
+    #[serde(rename = "currentCtl")]
+    pub ctl: Option<f64>,
+    #[serde(rename = "currentAtl")]
+    pub atl: Option<f64>,
+    #[serde(rename = "currentTsb")]
+    pub tsb: Option<f64>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct TrainingLoadDashboardSummaryDto {
+    #[serde(rename = "currentCtl")]
+    pub current_ctl: Option<f64>,
+    #[serde(rename = "currentAtl")]
+    pub current_atl: Option<f64>,
+    #[serde(rename = "currentTsb")]
+    pub current_tsb: Option<f64>,
+    #[serde(rename = "ftpWatts")]
+    pub ftp_watts: Option<i32>,
+    #[serde(rename = "averageIf28d")]
+    pub average_if_28d: Option<f64>,
+    #[serde(rename = "averageEf28d")]
+    pub average_ef_28d: Option<f64>,
+    #[serde(rename = "loadDeltaCtl14d")]
+    pub load_delta_ctl_14d: Option<f64>,
+    #[serde(rename = "tsbZone")]
+    pub tsb_zone: &'static str,
+}
+
+#[derive(Serialize)]
+pub(crate) struct TrainingLoadDashboardResponseDto {
+    pub range: &'static str,
+    #[serde(rename = "windowStart")]
+    pub window_start: String,
+    #[serde(rename = "windowEnd")]
+    pub window_end: String,
+    #[serde(rename = "hasTrainingLoad")]
+    pub has_training_load: bool,
+    pub summary: TrainingLoadDashboardSummaryDto,
+    pub points: Vec<TrainingLoadDashboardPointDto>,
+}

--- a/src/adapters/rest/dashboard/handlers.rs
+++ b/src/adapters/rest/dashboard/handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 
 use crate::{config::AppState, domain::training_load::TrainingLoadDashboardRange};
 
@@ -27,14 +27,7 @@ pub(crate) async fn get_training_load_dashboard(
         Some(range) => range,
         None => return StatusCode::BAD_REQUEST.into_response(),
     };
-    let today = DateTime::<Utc>::from_timestamp(Utc::now().timestamp(), 0)
-        .map(|value| value.date_naive().format("%Y-%m-%d").to_string())
-        .unwrap_or_else(|| {
-            DateTime::<Utc>::UNIX_EPOCH
-                .date_naive()
-                .format("%Y-%m-%d")
-                .to_string()
-        });
+    let today = Utc::now().date_naive().format("%Y-%m-%d").to_string();
 
     match service.build_report(&user_id, range, &today).await {
         Ok(report) => Json(map_dashboard_report_to_dto(report)).into_response(),

--- a/src/adapters/rest/dashboard/handlers.rs
+++ b/src/adapters/rest/dashboard/handlers.rs
@@ -1,0 +1,52 @@
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::{DateTime, Utc};
+
+use crate::{config::AppState, domain::training_load::TrainingLoadDashboardRange};
+
+use super::{dto::TrainingLoadDashboardQuery, mapping::map_dashboard_report_to_dto};
+
+pub(crate) async fn get_training_load_dashboard(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<TrainingLoadDashboardQuery>,
+) -> Response {
+    let user_id = match super::super::user_auth::resolve_user_id(&state, &headers).await {
+        Ok(user_id) => user_id,
+        Err(response) => return response,
+    };
+    let service = match state.training_load_dashboard_service.as_deref() {
+        Some(service) => service,
+        None => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    };
+    let range = match parse_range(&query.range) {
+        Some(range) => range,
+        None => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    let today = DateTime::<Utc>::from_timestamp(Utc::now().timestamp(), 0)
+        .map(|value| value.date_naive().format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| {
+            DateTime::<Utc>::UNIX_EPOCH
+                .date_naive()
+                .format("%Y-%m-%d")
+                .to_string()
+        });
+
+    match service.build_report(&user_id, range, &today).await {
+        Ok(report) => Json(map_dashboard_report_to_dto(report)).into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+fn parse_range(value: &str) -> Option<TrainingLoadDashboardRange> {
+    match value {
+        "90d" => Some(TrainingLoadDashboardRange::Last90Days),
+        "season" => Some(TrainingLoadDashboardRange::Season),
+        "all-time" => Some(TrainingLoadDashboardRange::AllTime),
+        _ => None,
+    }
+}

--- a/src/adapters/rest/dashboard/mapping.rs
+++ b/src/adapters/rest/dashboard/mapping.rs
@@ -1,0 +1,61 @@
+use crate::domain::training_load::{
+    TrainingLoadDashboardPoint, TrainingLoadDashboardRange, TrainingLoadDashboardReport,
+    TrainingLoadDashboardSummary, TrainingLoadTsbZone,
+};
+
+use super::dto::{
+    TrainingLoadDashboardPointDto, TrainingLoadDashboardResponseDto,
+    TrainingLoadDashboardSummaryDto,
+};
+
+pub(crate) fn map_dashboard_report_to_dto(
+    report: TrainingLoadDashboardReport,
+) -> TrainingLoadDashboardResponseDto {
+    TrainingLoadDashboardResponseDto {
+        range: map_range(report.range),
+        window_start: report.window_start,
+        window_end: report.window_end,
+        has_training_load: report.has_training_load,
+        summary: map_summary(report.summary),
+        points: report.points.into_iter().map(map_point).collect(),
+    }
+}
+
+fn map_range(range: TrainingLoadDashboardRange) -> &'static str {
+    match range {
+        TrainingLoadDashboardRange::Last90Days => "90d",
+        TrainingLoadDashboardRange::Season => "season",
+        TrainingLoadDashboardRange::AllTime => "all-time",
+    }
+}
+
+fn map_summary(summary: TrainingLoadDashboardSummary) -> TrainingLoadDashboardSummaryDto {
+    TrainingLoadDashboardSummaryDto {
+        current_ctl: summary.current_ctl,
+        current_atl: summary.current_atl,
+        current_tsb: summary.current_tsb,
+        ftp_watts: summary.ftp_watts,
+        average_if_28d: summary.average_if_28d,
+        average_ef_28d: summary.average_ef_28d,
+        load_delta_ctl_14d: summary.load_delta_ctl_14d,
+        tsb_zone: map_tsb_zone(summary.tsb_zone),
+    }
+}
+
+fn map_point(point: TrainingLoadDashboardPoint) -> TrainingLoadDashboardPointDto {
+    TrainingLoadDashboardPointDto {
+        date: point.date,
+        daily_tss: point.daily_tss,
+        ctl: point.ctl,
+        atl: point.atl,
+        tsb: point.tsb,
+    }
+}
+
+fn map_tsb_zone(zone: TrainingLoadTsbZone) -> &'static str {
+    match zone {
+        TrainingLoadTsbZone::FreshnessPeak => "freshness_peak",
+        TrainingLoadTsbZone::OptimalTraining => "optimal_training",
+        TrainingLoadTsbZone::HighRisk => "high_risk",
+    }
+}

--- a/src/adapters/rest/mod.rs
+++ b/src/adapters/rest/mod.rs
@@ -4,6 +4,7 @@ mod auth;
 mod calendar;
 mod completed_workouts;
 mod cookies;
+mod dashboard;
 mod health;
 mod intervals;
 mod logging;
@@ -125,6 +126,10 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
         .route(
             "/api/completed-workouts/{activity_id}",
             get(completed_workouts::get_completed_workout),
+        )
+        .route(
+            "/api/dashboard/training-load",
+            get(dashboard::get_training_load_dashboard),
         )
         .route(
             "/api/calendar/planned-workouts/{operation_key}/{date}/sync",

--- a/src/config/app_state.rs
+++ b/src/config/app_state.rs
@@ -17,6 +17,7 @@ use crate::domain::intervals::{IntervalsConnectionTester, IntervalsUseCases};
 use crate::domain::llm::{LlmChatPort, UserLlmConfigProvider};
 use crate::domain::races::RaceUseCases;
 use crate::domain::settings::UserSettingsUseCases;
+use crate::domain::training_load::TrainingLoadDashboardReadUseCases;
 use crate::domain::workout_summary::WorkoutSummaryUseCases;
 
 #[derive(Clone)]
@@ -33,6 +34,7 @@ pub struct AppState {
     pub intervals_service: Option<Arc<dyn IntervalsUseCases>>,
     pub race_service: Option<Arc<dyn RaceUseCases>>,
     pub settings_service: Option<Arc<dyn UserSettingsUseCases>>,
+    pub training_load_dashboard_service: Option<Arc<dyn TrainingLoadDashboardReadUseCases>>,
     pub athlete_summary_service: Option<Arc<dyn AthleteSummaryUseCases>>,
     pub workout_summary_service: Option<Arc<dyn WorkoutSummaryUseCases>>,
     pub llm_chat_service: Option<Arc<dyn LlmChatPort>>,
@@ -108,6 +110,7 @@ impl AppState {
             intervals_service: None,
             race_service: None,
             settings_service: None,
+            training_load_dashboard_service: None,
             athlete_summary_service: None,
             workout_summary_service: None,
             llm_chat_service: None,
@@ -143,6 +146,14 @@ impl AppState {
         settings_service: Arc<dyn UserSettingsUseCases>,
     ) -> Self {
         self.settings_service = Some(settings_service);
+        self
+    }
+
+    pub fn with_training_load_dashboard_service(
+        mut self,
+        training_load_dashboard_service: Arc<dyn TrainingLoadDashboardReadUseCases>,
+    ) -> Self {
+        self.training_load_dashboard_service = Some(training_load_dashboard_service);
         self
     }
 

--- a/src/domain/training_load/mod.rs
+++ b/src/domain/training_load/mod.rs
@@ -7,8 +7,9 @@ mod use_cases;
 mod tests;
 
 pub use model::{
-    FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadError,
-    TrainingLoadSnapshotRange,
+    FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadDashboardPoint,
+    TrainingLoadDashboardRange, TrainingLoadDashboardReport, TrainingLoadDashboardSummary,
+    TrainingLoadError, TrainingLoadSnapshotRange, TrainingLoadTsbZone,
 };
 pub use ports::{
     BoxFuture, FtpHistoryRepository, NoopFtpHistoryRepository,
@@ -17,4 +18,7 @@ pub use ports::{
 #[cfg(test)]
 pub use ports::{InMemoryFtpHistoryRepository, InMemoryTrainingLoadDailySnapshotRepository};
 pub use service::build_daily_training_load_snapshots;
-pub use use_cases::{TrainingLoadRecomputeService, TrainingLoadRecomputeUseCases};
+pub use use_cases::{
+    TrainingLoadDashboardReadService, TrainingLoadDashboardReadUseCases,
+    TrainingLoadRecomputeService, TrainingLoadRecomputeUseCases,
+};

--- a/src/domain/training_load/model.rs
+++ b/src/domain/training_load/model.rs
@@ -3,6 +3,20 @@ pub enum TrainingLoadError {
     Repository(String),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TrainingLoadDashboardRange {
+    Last90Days,
+    Season,
+    AllTime,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrainingLoadTsbZone {
+    FreshnessPeak,
+    OptimalTraining,
+    HighRisk,
+}
+
 impl std::fmt::Display for TrainingLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -52,4 +66,35 @@ pub struct TrainingLoadDailySnapshot {
     pub recomputed_at_epoch_seconds: i64,
     pub created_at_epoch_seconds: i64,
     pub updated_at_epoch_seconds: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrainingLoadDashboardPoint {
+    pub date: String,
+    pub daily_tss: Option<i32>,
+    pub ctl: Option<f64>,
+    pub atl: Option<f64>,
+    pub tsb: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrainingLoadDashboardSummary {
+    pub current_ctl: Option<f64>,
+    pub current_atl: Option<f64>,
+    pub current_tsb: Option<f64>,
+    pub ftp_watts: Option<i32>,
+    pub average_if_28d: Option<f64>,
+    pub average_ef_28d: Option<f64>,
+    pub load_delta_ctl_14d: Option<f64>,
+    pub tsb_zone: TrainingLoadTsbZone,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrainingLoadDashboardReport {
+    pub range: TrainingLoadDashboardRange,
+    pub window_start: String,
+    pub window_end: String,
+    pub has_training_load: bool,
+    pub summary: TrainingLoadDashboardSummary,
+    pub points: Vec<TrainingLoadDashboardPoint>,
 }

--- a/src/domain/training_load/ports.rs
+++ b/src/domain/training_load/ports.rs
@@ -34,6 +34,13 @@ pub trait TrainingLoadDailySnapshotRepository: Clone + Send + Sync + 'static {
         range: &TrainingLoadSnapshotRange,
     ) -> BoxFuture<Result<Vec<TrainingLoadDailySnapshot>, TrainingLoadError>>;
 
+    fn find_oldest_date_by_user_id(
+        &self,
+        _user_id: &str,
+    ) -> BoxFuture<Result<Option<String>, TrainingLoadError>> {
+        Box::pin(async { Ok(None) })
+    }
+
     fn upsert(
         &self,
         snapshot: TrainingLoadDailySnapshot,
@@ -235,6 +242,24 @@ impl TrainingLoadDailySnapshotRepository for InMemoryTrainingLoadDailySnapshotRe
             });
             snapshots.push(snapshot.clone());
             Ok(snapshot)
+        })
+    }
+
+    fn find_oldest_date_by_user_id(
+        &self,
+        user_id: &str,
+    ) -> BoxFuture<Result<Option<String>, TrainingLoadError>> {
+        let snapshots = self.snapshots.clone();
+        let user_id = user_id.to_string();
+        Box::pin(async move {
+            let oldest = snapshots
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|snapshot| snapshot.user_id == user_id)
+                .map(|snapshot| snapshot.date.clone())
+                .min();
+            Ok(oldest)
         })
     }
 

--- a/src/domain/training_load/tests.rs
+++ b/src/domain/training_load/tests.rs
@@ -309,7 +309,7 @@ async fn dashboard_report_for_last_90_days_uses_latest_snapshot_summary() {
     repository
         .upsert(sample_snapshot_with_values(
             "user-1",
-            "2026-04-05",
+            "2026-04-04",
             SnapshotValues {
                 daily_tss: Some(82),
                 ctl: Some(49.5),
@@ -404,6 +404,54 @@ async fn dashboard_report_for_season_starts_on_first_day_of_year() {
     assert_eq!(report.window_start, "2026-01-01");
     assert_eq!(report.points.len(), 1);
     assert_eq!(report.points[0].date, "2026-01-01");
+}
+
+#[tokio::test]
+async fn dashboard_report_requires_full_14_day_history_for_ctl_delta() {
+    let repository = InMemoryTrainingLoadDailySnapshotRepository::default();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-04-16",
+            SnapshotValues {
+                daily_tss: Some(55),
+                ctl: Some(30.0),
+                atl: Some(42.0),
+                tsb: Some(-12.0),
+                ftp_effective_watts: Some(285),
+                average_if_28d: Some(0.84),
+                average_ef_28d: Some(1.22),
+            },
+        ))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-04-18",
+            SnapshotValues {
+                daily_tss: Some(70),
+                ctl: Some(33.0),
+                atl: Some(45.0),
+                tsb: Some(-12.0),
+                ftp_effective_watts: Some(290),
+                average_if_28d: Some(0.86),
+                average_ef_28d: Some(1.25),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let report = TrainingLoadDashboardReadService::new(repository)
+        .build_report(
+            "user-1",
+            TrainingLoadDashboardRange::Last90Days,
+            "2026-04-18",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.summary.load_delta_ctl_14d, None);
 }
 
 #[tokio::test]

--- a/src/domain/training_load/tests.rs
+++ b/src/domain/training_load/tests.rs
@@ -1,6 +1,8 @@
 use super::{
-    FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadError,
+    FtpHistoryEntry, FtpSource, TrainingLoadDailySnapshot, TrainingLoadDashboardRange,
+    TrainingLoadDashboardReadService, TrainingLoadDashboardReadUseCases, TrainingLoadError,
     TrainingLoadRecomputeService, TrainingLoadRecomputeUseCases, TrainingLoadSnapshotRange,
+    TrainingLoadTsbZone,
 };
 use crate::domain::{
     completed_workouts::{
@@ -14,7 +16,7 @@ use crate::domain::{
     },
     training_load::{
         build_daily_training_load_snapshots, FtpHistoryRepository, InMemoryFtpHistoryRepository,
-        InMemoryTrainingLoadDailySnapshotRepository,
+        InMemoryTrainingLoadDailySnapshotRepository, TrainingLoadDailySnapshotRepository,
     },
 };
 
@@ -220,6 +222,250 @@ fn training_load_snapshot_range_uses_inclusive_boundaries() {
 
     assert_eq!(range.oldest, "2026-04-01");
     assert_eq!(range.newest, "2026-04-30");
+}
+
+#[test]
+fn in_memory_training_load_daily_snapshot_repository_finds_oldest_date_for_user() {
+    let repository = InMemoryTrainingLoadDailySnapshotRepository::default();
+
+    futures::executor::block_on(async {
+        repository
+            .upsert(sample_snapshot_with_values(
+                "user-1",
+                "2026-04-05",
+                SnapshotValues {
+                    daily_tss: Some(40),
+                    ctl: Some(30.0),
+                    atl: Some(45.0),
+                    tsb: Some(-15.0),
+                    ftp_effective_watts: Some(280),
+                    average_if_28d: Some(0.82),
+                    average_ef_28d: Some(1.25),
+                },
+            ))
+            .await
+            .unwrap();
+        repository
+            .upsert(sample_snapshot_with_values(
+                "user-1",
+                "2026-04-01",
+                SnapshotValues {
+                    daily_tss: Some(50),
+                    ctl: Some(28.0),
+                    atl: Some(50.0),
+                    tsb: Some(-22.0),
+                    ftp_effective_watts: Some(280),
+                    average_if_28d: None,
+                    average_ef_28d: None,
+                },
+            ))
+            .await
+            .unwrap();
+        repository
+            .upsert(sample_snapshot_with_values(
+                "user-2",
+                "2026-03-20",
+                SnapshotValues {
+                    daily_tss: Some(60),
+                    ctl: Some(40.0),
+                    atl: Some(55.0),
+                    tsb: Some(-15.0),
+                    ftp_effective_watts: Some(300),
+                    average_if_28d: Some(0.91),
+                    average_ef_28d: Some(1.31),
+                },
+            ))
+            .await
+            .unwrap();
+
+        let oldest = repository
+            .find_oldest_date_by_user_id("user-1")
+            .await
+            .unwrap();
+
+        assert_eq!(oldest.as_deref(), Some("2026-04-01"));
+    });
+}
+
+#[tokio::test]
+async fn dashboard_report_for_last_90_days_uses_latest_snapshot_summary() {
+    let repository = InMemoryTrainingLoadDailySnapshotRepository::default();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-01-15",
+            SnapshotValues {
+                daily_tss: Some(65),
+                ctl: Some(40.0),
+                atl: Some(55.0),
+                tsb: Some(-15.0),
+                ftp_effective_watts: Some(290),
+                average_if_28d: Some(0.86),
+                average_ef_28d: Some(1.28),
+            },
+        ))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-04-05",
+            SnapshotValues {
+                daily_tss: Some(82),
+                ctl: Some(49.5),
+                atl: Some(63.4),
+                tsb: Some(-13.9),
+                ftp_effective_watts: Some(300),
+                average_if_28d: Some(0.89),
+                average_ef_28d: Some(1.33),
+            },
+        ))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-04-18",
+            SnapshotValues {
+                daily_tss: Some(97),
+                ctl: Some(62.0),
+                atl: Some(37.0),
+                tsb: Some(25.0),
+                ftp_effective_watts: Some(340),
+                average_if_28d: Some(0.92),
+                average_ef_28d: Some(1.41),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let report = TrainingLoadDashboardReadService::new(repository)
+        .build_report(
+            "user-1",
+            TrainingLoadDashboardRange::Last90Days,
+            "2026-04-18",
+        )
+        .await
+        .unwrap();
+
+    assert!(report.has_training_load);
+    assert_eq!(report.window_start, "2026-01-19");
+    assert_eq!(report.window_end, "2026-04-18");
+    assert_eq!(report.points.len(), 2);
+    assert_eq!(report.summary.current_ctl, Some(62.0));
+    assert_eq!(report.summary.current_atl, Some(37.0));
+    assert_eq!(report.summary.current_tsb, Some(25.0));
+    assert_eq!(report.summary.ftp_watts, Some(340));
+    assert_eq!(report.summary.load_delta_ctl_14d, Some(12.5));
+    assert_eq!(report.summary.tsb_zone, TrainingLoadTsbZone::FreshnessPeak);
+}
+
+#[tokio::test]
+async fn dashboard_report_for_season_starts_on_first_day_of_year() {
+    let repository = InMemoryTrainingLoadDailySnapshotRepository::default();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2025-12-31",
+            SnapshotValues {
+                daily_tss: Some(50),
+                ctl: Some(25.0),
+                atl: Some(40.0),
+                tsb: Some(-15.0),
+                ftp_effective_watts: Some(280),
+                average_if_28d: None,
+                average_ef_28d: None,
+            },
+        ))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-01-01",
+            SnapshotValues {
+                daily_tss: Some(55),
+                ctl: Some(26.0),
+                atl: Some(38.0),
+                tsb: Some(-12.0),
+                ftp_effective_watts: Some(282),
+                average_if_28d: None,
+                average_ef_28d: None,
+            },
+        ))
+        .await
+        .unwrap();
+
+    let report = TrainingLoadDashboardReadService::new(repository)
+        .build_report("user-1", TrainingLoadDashboardRange::Season, "2026-04-18")
+        .await
+        .unwrap();
+
+    assert_eq!(report.window_start, "2026-01-01");
+    assert_eq!(report.points.len(), 1);
+    assert_eq!(report.points[0].date, "2026-01-01");
+}
+
+#[tokio::test]
+async fn dashboard_report_for_all_time_uses_oldest_snapshot_date() {
+    let repository = InMemoryTrainingLoadDailySnapshotRepository::default();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2025-12-03",
+            SnapshotValues {
+                daily_tss: Some(0),
+                ctl: Some(0.0),
+                atl: Some(0.0),
+                tsb: Some(0.0),
+                ftp_effective_watts: None,
+                average_if_28d: None,
+                average_ef_28d: None,
+            },
+        ))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot_with_values(
+            "user-1",
+            "2026-04-18",
+            SnapshotValues {
+                daily_tss: Some(97),
+                ctl: Some(29.9),
+                atl: Some(53.4),
+                tsb: Some(-23.5),
+                ftp_effective_watts: Some(340),
+                average_if_28d: Some(72.95),
+                average_ef_28d: None,
+            },
+        ))
+        .await
+        .unwrap();
+
+    let report = TrainingLoadDashboardReadService::new(repository)
+        .build_report("user-1", TrainingLoadDashboardRange::AllTime, "2026-04-18")
+        .await
+        .unwrap();
+
+    assert_eq!(report.window_start, "2025-12-03");
+    assert_eq!(report.points.len(), 2);
+}
+
+#[tokio::test]
+async fn dashboard_report_returns_empty_state_when_user_has_no_snapshots() {
+    let report = TrainingLoadDashboardReadService::new(
+        InMemoryTrainingLoadDailySnapshotRepository::default(),
+    )
+    .build_report("user-1", TrainingLoadDashboardRange::AllTime, "2026-04-18")
+    .await
+    .unwrap();
+
+    assert!(!report.has_training_load);
+    assert!(report.points.is_empty());
+    assert_eq!(
+        report.summary.tsb_zone,
+        TrainingLoadTsbZone::OptimalTraining
+    );
 }
 
 #[test]
@@ -766,4 +1012,38 @@ fn sample_workout(
         },
         None,
     )
+}
+
+struct SnapshotValues {
+    daily_tss: Option<i32>,
+    ctl: Option<f64>,
+    atl: Option<f64>,
+    tsb: Option<f64>,
+    ftp_effective_watts: Option<i32>,
+    average_if_28d: Option<f64>,
+    average_ef_28d: Option<f64>,
+}
+
+fn sample_snapshot_with_values(
+    user_id: &str,
+    date: &str,
+    values: SnapshotValues,
+) -> TrainingLoadDailySnapshot {
+    TrainingLoadDailySnapshot {
+        user_id: user_id.to_string(),
+        date: date.to_string(),
+        daily_tss: values.daily_tss,
+        rolling_tss_7d: None,
+        rolling_tss_28d: None,
+        ctl: values.ctl,
+        atl: values.atl,
+        tsb: values.tsb,
+        average_if_28d: values.average_if_28d,
+        average_ef_28d: values.average_ef_28d,
+        ftp_effective_watts: values.ftp_effective_watts,
+        ftp_source: values.ftp_effective_watts.map(|_| FtpSource::Settings),
+        recomputed_at_epoch_seconds: 100,
+        created_at_epoch_seconds: 100,
+        updated_at_epoch_seconds: 100,
+    }
 }

--- a/src/domain/training_load/use_cases.rs
+++ b/src/domain/training_load/use_cases.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc};
 
 use crate::domain::{
     completed_workouts::CompletedWorkoutRepository, settings::UserSettingsRepository,
@@ -6,7 +6,9 @@ use crate::domain::{
 
 use super::{
     build_daily_training_load_snapshots, BoxFuture, FtpHistoryRepository,
-    TrainingLoadDailySnapshotRepository, TrainingLoadError, TrainingLoadSnapshotRange,
+    TrainingLoadDailySnapshotRepository, TrainingLoadDashboardPoint, TrainingLoadDashboardRange,
+    TrainingLoadDashboardReport, TrainingLoadDashboardSummary, TrainingLoadError,
+    TrainingLoadSnapshotRange, TrainingLoadTsbZone,
 };
 
 pub trait TrainingLoadRecomputeUseCases: Send + Sync {
@@ -16,6 +18,32 @@ pub trait TrainingLoadRecomputeUseCases: Send + Sync {
         oldest_date: &str,
         now_epoch_seconds: i64,
     ) -> BoxFuture<Result<(), TrainingLoadError>>;
+}
+
+pub trait TrainingLoadDashboardReadUseCases: Send + Sync {
+    fn build_report(
+        &self,
+        user_id: &str,
+        range: TrainingLoadDashboardRange,
+        today: &str,
+    ) -> BoxFuture<Result<TrainingLoadDashboardReport, TrainingLoadError>>;
+}
+
+#[derive(Clone)]
+pub struct TrainingLoadDashboardReadService<Snapshots>
+where
+    Snapshots: TrainingLoadDailySnapshotRepository,
+{
+    snapshots: Snapshots,
+}
+
+impl<Snapshots> TrainingLoadDashboardReadService<Snapshots>
+where
+    Snapshots: TrainingLoadDailySnapshotRepository,
+{
+    pub fn new(snapshots: Snapshots) -> Self {
+        Self { snapshots }
+    }
 }
 
 #[derive(Clone)]
@@ -132,4 +160,100 @@ where
             Ok(())
         })
     }
+}
+
+impl<Snapshots> TrainingLoadDashboardReadUseCases for TrainingLoadDashboardReadService<Snapshots>
+where
+    Snapshots: TrainingLoadDailySnapshotRepository,
+{
+    fn build_report(
+        &self,
+        user_id: &str,
+        range: TrainingLoadDashboardRange,
+        today: &str,
+    ) -> BoxFuture<Result<TrainingLoadDashboardReport, TrainingLoadError>> {
+        let service = self.clone();
+        let user_id = user_id.to_string();
+        let today = today.to_string();
+        Box::pin(async move {
+            let today = NaiveDate::parse_from_str(&today, "%Y-%m-%d").map_err(|_| {
+                TrainingLoadError::Repository(format!(
+                    "invalid dashboard report date '{today}'; expected format %Y-%m-%d"
+                ))
+            })?;
+            let window_start = match range {
+                TrainingLoadDashboardRange::Last90Days => {
+                    (today - Duration::days(89)).format("%Y-%m-%d").to_string()
+                }
+                TrainingLoadDashboardRange::Season => format!("{:04}-01-01", today.year()),
+                TrainingLoadDashboardRange::AllTime => service
+                    .snapshots
+                    .find_oldest_date_by_user_id(&user_id)
+                    .await?
+                    .unwrap_or_else(|| today.format("%Y-%m-%d").to_string()),
+            };
+            let window_end = today.format("%Y-%m-%d").to_string();
+            let snapshots = service
+                .snapshots
+                .list_by_user_id_and_range(
+                    &user_id,
+                    &TrainingLoadSnapshotRange {
+                        oldest: window_start.clone(),
+                        newest: window_end.clone(),
+                    },
+                )
+                .await?;
+            let latest_snapshot = snapshots.last();
+            let reference_ctl = snapshots
+                .iter()
+                .rev()
+                .find(|snapshot| {
+                    snapshot.date <= (today - Duration::days(14)).format("%Y-%m-%d").to_string()
+                })
+                .or_else(|| snapshots.first())
+                .and_then(|snapshot| snapshot.ctl);
+
+            Ok(TrainingLoadDashboardReport {
+                range,
+                window_start,
+                window_end,
+                has_training_load: !snapshots.is_empty(),
+                summary: TrainingLoadDashboardSummary {
+                    current_ctl: latest_snapshot.and_then(|snapshot| snapshot.ctl),
+                    current_atl: latest_snapshot.and_then(|snapshot| snapshot.atl),
+                    current_tsb: latest_snapshot.and_then(|snapshot| snapshot.tsb),
+                    ftp_watts: latest_snapshot.and_then(|snapshot| snapshot.ftp_effective_watts),
+                    average_if_28d: latest_snapshot.and_then(|snapshot| snapshot.average_if_28d),
+                    average_ef_28d: latest_snapshot.and_then(|snapshot| snapshot.average_ef_28d),
+                    load_delta_ctl_14d: latest_snapshot
+                        .and_then(|snapshot| snapshot.ctl)
+                        .zip(reference_ctl)
+                        .map(|(current, previous)| round_to_2(current - previous)),
+                    tsb_zone: classify_tsb_zone(latest_snapshot.and_then(|snapshot| snapshot.tsb)),
+                },
+                points: snapshots
+                    .into_iter()
+                    .map(|snapshot| TrainingLoadDashboardPoint {
+                        date: snapshot.date,
+                        daily_tss: snapshot.daily_tss,
+                        ctl: snapshot.ctl,
+                        atl: snapshot.atl,
+                        tsb: snapshot.tsb,
+                    })
+                    .collect(),
+            })
+        })
+    }
+}
+
+fn classify_tsb_zone(tsb: Option<f64>) -> TrainingLoadTsbZone {
+    match tsb {
+        Some(value) if value > 0.0 => TrainingLoadTsbZone::FreshnessPeak,
+        Some(value) if value < -30.0 => TrainingLoadTsbZone::HighRisk,
+        _ => TrainingLoadTsbZone::OptimalTraining,
+    }
+}
+
+fn round_to_2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
 }

--- a/src/domain/training_load/use_cases.rs
+++ b/src/domain/training_load/use_cases.rs
@@ -244,10 +244,13 @@ where
     }
 }
 
+const TSB_FRESHNESS_PEAK_THRESHOLD: f64 = 0.0;
+const TSB_HIGH_RISK_THRESHOLD: f64 = -30.0;
+
 fn classify_tsb_zone(tsb: Option<f64>) -> TrainingLoadTsbZone {
     match tsb {
-        Some(value) if value > 0.0 => TrainingLoadTsbZone::FreshnessPeak,
-        Some(value) if value < -30.0 => TrainingLoadTsbZone::HighRisk,
+        Some(value) if value > TSB_FRESHNESS_PEAK_THRESHOLD => TrainingLoadTsbZone::FreshnessPeak,
+        Some(value) if value < TSB_HIGH_RISK_THRESHOLD => TrainingLoadTsbZone::HighRisk,
         _ => TrainingLoadTsbZone::OptimalTraining,
     }
 }

--- a/src/domain/training_load/use_cases.rs
+++ b/src/domain/training_load/use_cases.rs
@@ -204,13 +204,11 @@ where
                 )
                 .await?;
             let latest_snapshot = snapshots.last();
+            let reference_ctl_cutoff = (today - Duration::days(14)).format("%Y-%m-%d").to_string();
             let reference_ctl = snapshots
                 .iter()
                 .rev()
-                .find(|snapshot| {
-                    snapshot.date <= (today - Duration::days(14)).format("%Y-%m-%d").to_string()
-                })
-                .or_else(|| snapshots.first())
+                .find(|snapshot| snapshot.date <= reference_ctl_cutoff)
                 .and_then(|snapshot| snapshot.ctl);
 
             Ok(TrainingLoadDashboardReport {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ use aiwattcoach::{
     domain::races::RaceService,
     domain::settings::UserSettingsService,
     domain::training_context::DefaultTrainingContextBuilder,
-    domain::training_load::TrainingLoadRecomputeService,
+    domain::training_load::{TrainingLoadDashboardReadService, TrainingLoadRecomputeService},
     domain::training_plan::TrainingPlanGenerationService,
     domain::workout_summary::WorkoutSummaryService,
     telemetry::setup_telemetry,
@@ -249,6 +249,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         ftp_history_repository.clone(),
         training_load_daily_snapshot_repository.clone(),
         settings_repository.clone(),
+    ));
+    let training_load_dashboard_service = Arc::new(TrainingLoadDashboardReadService::new(
+        training_load_daily_snapshot_repository.clone(),
     ));
     let settings_service = Arc::new(
         UserSettingsService::new(settings_repository, SystemClock)
@@ -463,6 +466,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 auth.session.ttl_hours,
             )
             .with_settings_service(settings_service)
+            .with_training_load_dashboard_service(training_load_dashboard_service)
             .with_calendar_service(calendar_service)
             .with_calendar_labels_service(calendar_labels_service)
             .with_completed_workout_service(completed_workout_service)

--- a/tests/dashboard_rest.rs
+++ b/tests/dashboard_rest.rs
@@ -1,0 +1,340 @@
+#[path = "dashboard_rest/support.rs"]
+mod dashboard_rest_support;
+
+use aiwattcoach::domain::identity::{
+    AppUser, AuthSession, GoogleLoginOutcome, GoogleLoginStart, GoogleLoginSuccess, IdentityError,
+    IdentityUseCases, Role, WhitelistEntry,
+};
+use aiwattcoach::domain::training_load::TrainingLoadDailySnapshotRepository;
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use tower::util::ServiceExt;
+
+use dashboard_rest_support::{dashboard_test_app, sample_snapshot};
+
+const RESPONSE_LIMIT_BYTES: usize = 4 * 1024;
+
+type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'static>>;
+
+#[derive(Clone, Default)]
+struct TestIdentityServiceWithSession {
+    sessions: std::collections::HashMap<String, (String, String)>,
+}
+
+impl TestIdentityServiceWithSession {
+    fn with_sessions(sessions: Vec<(&str, &str, &str)>) -> Self {
+        Self {
+            sessions: sessions
+                .into_iter()
+                .map(|(session_id, user_id, email)| {
+                    (
+                        session_id.to_string(),
+                        (user_id.to_string(), email.to_string()),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl IdentityUseCases for TestIdentityServiceWithSession {
+    fn begin_google_login(
+        &self,
+        _return_to: Option<String>,
+    ) -> BoxFuture<Result<GoogleLoginStart, IdentityError>> {
+        Box::pin(async {
+            Ok(GoogleLoginStart {
+                state: "state-1".to_string(),
+                redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?state=state-1"
+                    .to_string(),
+            })
+        })
+    }
+
+    fn join_whitelist(&self, email: String) -> BoxFuture<Result<WhitelistEntry, IdentityError>> {
+        Box::pin(async move { Ok(WhitelistEntry::new(email, false, 100, 100)) })
+    }
+
+    fn handle_google_callback(
+        &self,
+        _state: &str,
+        _code: &str,
+    ) -> BoxFuture<Result<GoogleLoginOutcome, IdentityError>> {
+        Box::pin(async {
+            Ok(GoogleLoginOutcome::SignedIn(Box::new(GoogleLoginSuccess {
+                user: AppUser::new(
+                    "user-1".to_string(),
+                    "google-subject-1".to_string(),
+                    "athlete@example.com".to_string(),
+                    vec![Role::User],
+                    Some("Test User".to_string()),
+                    None,
+                    true,
+                ),
+                session: AuthSession::new(
+                    "session-1".to_string(),
+                    "user-1".to_string(),
+                    999999,
+                    100,
+                ),
+                redirect_to: "/app".to_string(),
+            })))
+        })
+    }
+
+    fn get_current_user(
+        &self,
+        session_id: &str,
+    ) -> BoxFuture<Result<Option<AppUser>, IdentityError>> {
+        let sessions = self.sessions.clone();
+        let session_id = session_id.to_string();
+        Box::pin(async move {
+            Ok(sessions.get(&session_id).map(|(user_id, email)| {
+                AppUser::new(
+                    user_id.clone(),
+                    format!("google-subject-{user_id}"),
+                    email.clone(),
+                    vec![Role::User],
+                    Some("Test User".to_string()),
+                    None,
+                    true,
+                )
+            }))
+        })
+    }
+
+    fn logout(&self, _session_id: &str) -> BoxFuture<Result<(), IdentityError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn require_admin(&self, _session_id: &str) -> BoxFuture<Result<AppUser, IdentityError>> {
+        Box::pin(async { Err(IdentityError::Forbidden) })
+    }
+}
+
+#[derive(Clone, Default)]
+struct InMemoryTrainingLoadDailySnapshotRepository {
+    snapshots: std::sync::Arc<
+        std::sync::Mutex<Vec<aiwattcoach::domain::training_load::TrainingLoadDailySnapshot>>,
+    >,
+}
+
+impl TrainingLoadDailySnapshotRepository for InMemoryTrainingLoadDailySnapshotRepository {
+    fn list_by_user_id_and_range(
+        &self,
+        user_id: &str,
+        range: &aiwattcoach::domain::training_load::TrainingLoadSnapshotRange,
+    ) -> aiwattcoach::domain::training_load::BoxFuture<
+        Result<
+            Vec<aiwattcoach::domain::training_load::TrainingLoadDailySnapshot>,
+            aiwattcoach::domain::training_load::TrainingLoadError,
+        >,
+    > {
+        let snapshots = self.snapshots.clone();
+        let user_id = user_id.to_string();
+        let oldest = range.oldest.clone();
+        let newest = range.newest.clone();
+        Box::pin(async move {
+            let mut values = snapshots
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|snapshot| snapshot.user_id == user_id)
+                .filter(|snapshot| snapshot.date >= oldest && snapshot.date <= newest)
+                .cloned()
+                .collect::<Vec<_>>();
+            values.sort_by(|left, right| left.date.cmp(&right.date));
+            Ok(values)
+        })
+    }
+
+    fn find_oldest_date_by_user_id(
+        &self,
+        user_id: &str,
+    ) -> aiwattcoach::domain::training_load::BoxFuture<
+        Result<Option<String>, aiwattcoach::domain::training_load::TrainingLoadError>,
+    > {
+        let snapshots = self.snapshots.clone();
+        let user_id = user_id.to_string();
+        Box::pin(async move {
+            Ok(snapshots
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|snapshot| snapshot.user_id == user_id)
+                .map(|snapshot| snapshot.date.clone())
+                .min())
+        })
+    }
+
+    fn upsert(
+        &self,
+        snapshot: aiwattcoach::domain::training_load::TrainingLoadDailySnapshot,
+    ) -> aiwattcoach::domain::training_load::BoxFuture<
+        Result<
+            aiwattcoach::domain::training_load::TrainingLoadDailySnapshot,
+            aiwattcoach::domain::training_load::TrainingLoadError,
+        >,
+    > {
+        let snapshots = self.snapshots.clone();
+        Box::pin(async move {
+            let mut snapshots = snapshots.lock().unwrap();
+            snapshots.retain(|existing| {
+                !(existing.user_id == snapshot.user_id && existing.date == snapshot.date)
+            });
+            snapshots.push(snapshot.clone());
+            Ok(snapshot)
+        })
+    }
+
+    fn delete_by_user_id_from_date(
+        &self,
+        user_id: &str,
+        from_date: &str,
+    ) -> aiwattcoach::domain::training_load::BoxFuture<
+        Result<(), aiwattcoach::domain::training_load::TrainingLoadError>,
+    > {
+        let snapshots = self.snapshots.clone();
+        let user_id = user_id.to_string();
+        let from_date = from_date.to_string();
+        Box::pin(async move {
+            snapshots
+                .lock()
+                .unwrap()
+                .retain(|existing| !(existing.user_id == user_id && existing.date >= from_date));
+            Ok(())
+        })
+    }
+}
+
+#[tokio::test]
+async fn training_load_dashboard_returns_points_for_authenticated_user_only() {
+    let snapshots = InMemoryTrainingLoadDailySnapshotRepository::default();
+    snapshots
+        .upsert(sample_snapshot(
+            "user-1",
+            "2026-04-01",
+            Some(44),
+            Some(20.0),
+            Some(30.0),
+            Some(-10.0),
+        ))
+        .await
+        .unwrap();
+    snapshots
+        .upsert(sample_snapshot(
+            "user-1",
+            "2026-04-18",
+            Some(97),
+            Some(29.9),
+            Some(53.4),
+            Some(-23.5),
+        ))
+        .await
+        .unwrap();
+    snapshots
+        .upsert(sample_snapshot(
+            "user-2",
+            "2026-04-18",
+            Some(11),
+            Some(10.0),
+            Some(12.0),
+            Some(-2.0),
+        ))
+        .await
+        .unwrap();
+
+    let app = dashboard_test_app(
+        TestIdentityServiceWithSession::with_sessions(vec![(
+            "session-1",
+            "user-1",
+            "athlete@example.com",
+        )]),
+        snapshots,
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/dashboard/training-load?range=all-time")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT_BYTES)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["windowStart"], "2026-04-01");
+    assert_eq!(json["points"].as_array().unwrap().len(), 2);
+    assert_eq!(json["summary"]["currentCtl"], 29.9);
+}
+
+#[tokio::test]
+async fn training_load_dashboard_rejects_unknown_range() {
+    let app = dashboard_test_app(
+        TestIdentityServiceWithSession::with_sessions(vec![(
+            "session-1",
+            "user-1",
+            "athlete@example.com",
+        )]),
+        InMemoryTrainingLoadDailySnapshotRepository::default(),
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/dashboard/training-load?range=nope")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn training_load_dashboard_returns_empty_payload_when_user_has_no_snapshots() {
+    let app = dashboard_test_app(
+        TestIdentityServiceWithSession::with_sessions(vec![(
+            "session-1",
+            "user-1",
+            "athlete@example.com",
+        )]),
+        InMemoryTrainingLoadDailySnapshotRepository::default(),
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/dashboard/training-load?range=all-time")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT_BYTES)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["hasTrainingLoad"], false);
+    assert_eq!(json["points"].as_array().unwrap().len(), 0);
+}

--- a/tests/dashboard_rest/support.rs
+++ b/tests/dashboard_rest/support.rs
@@ -2,7 +2,7 @@ use std::{
     fs,
     path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
-    sync::Arc,
+    sync::{Arc, Mutex, OnceLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -21,30 +21,40 @@ use aiwattcoach::{
 use mongodb::Client;
 
 static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static KEPT_FRONTEND_FIXTURES: OnceLock<Mutex<Vec<FrontendFixture>>> = OnceLock::new();
 
 pub(crate) async fn dashboard_test_app(
     identity_service: impl IdentityUseCases + 'static,
     snapshots: impl TrainingLoadDailySnapshotRepository + 'static,
 ) -> axum::Router {
     let settings = Settings::test_defaults();
+    let app_name = settings.app_name.clone();
+    let mongo_database = settings.mongo.database.clone();
+    let mongo_uri = settings.mongo.uri.clone();
+    let session_name = settings.auth.session.cookie_name.clone();
+    let session_same_site = settings.auth.session.same_site.clone();
+    let session_secure = settings.auth.session.secure;
+    let session_ttl_hours = settings.auth.session.ttl_hours;
     let fixture = frontend_fixture();
+    let dist_dir = fixture.dist_dir();
+    keep_frontend_fixture(fixture);
     let dashboard_service = Arc::new(TrainingLoadDashboardReadService::new(snapshots));
 
     build_app_with_frontend_dist(
         AppState::new(
-            settings.app_name,
-            settings.mongo.database,
-            test_mongo_client(&settings.mongo.uri).await,
+            app_name,
+            mongo_database,
+            test_mongo_client(&mongo_uri).await,
         )
         .with_identity_service(
             Arc::new(identity_service),
-            "aiwattcoach_session",
-            "lax",
-            false,
-            24,
+            session_name,
+            session_same_site,
+            session_secure,
+            session_ttl_hours,
         )
         .with_training_load_dashboard_service(dashboard_service),
-        fixture.dist_dir(),
+        dist_dir,
     )
 }
 
@@ -110,6 +120,14 @@ impl FrontendFixture {
     fn dist_dir(&self) -> PathBuf {
         self.root.join("dist")
     }
+}
+
+fn keep_frontend_fixture(fixture: FrontendFixture) {
+    KEPT_FRONTEND_FIXTURES
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap()
+        .push(fixture);
 }
 
 async fn test_mongo_client(uri: &str) -> Client {

--- a/tests/dashboard_rest/support.rs
+++ b/tests/dashboard_rest/support.rs
@@ -1,0 +1,119 @@
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use aiwattcoach::{
+    build_app_with_frontend_dist,
+    config::AppState,
+    domain::{
+        identity::IdentityUseCases,
+        training_load::{
+            FtpSource, TrainingLoadDailySnapshot, TrainingLoadDailySnapshotRepository,
+            TrainingLoadDashboardReadService,
+        },
+    },
+    Settings,
+};
+use mongodb::Client;
+
+static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) async fn dashboard_test_app(
+    identity_service: impl IdentityUseCases + 'static,
+    snapshots: impl TrainingLoadDailySnapshotRepository + 'static,
+) -> axum::Router {
+    let settings = Settings::test_defaults();
+    let fixture = frontend_fixture();
+    let dashboard_service = Arc::new(TrainingLoadDashboardReadService::new(snapshots));
+
+    build_app_with_frontend_dist(
+        AppState::new(
+            settings.app_name,
+            settings.mongo.database,
+            test_mongo_client(&settings.mongo.uri).await,
+        )
+        .with_identity_service(
+            Arc::new(identity_service),
+            "aiwattcoach_session",
+            "lax",
+            false,
+            24,
+        )
+        .with_training_load_dashboard_service(dashboard_service),
+        fixture.dist_dir(),
+    )
+}
+
+pub(crate) fn sample_snapshot(
+    user_id: &str,
+    date: &str,
+    daily_tss: Option<i32>,
+    ctl: Option<f64>,
+    atl: Option<f64>,
+    tsb: Option<f64>,
+) -> TrainingLoadDailySnapshot {
+    TrainingLoadDailySnapshot {
+        user_id: user_id.to_string(),
+        date: date.to_string(),
+        daily_tss,
+        rolling_tss_7d: None,
+        rolling_tss_28d: None,
+        ctl,
+        atl,
+        tsb,
+        average_if_28d: None,
+        average_ef_28d: None,
+        ftp_effective_watts: Some(340),
+        ftp_source: Some(FtpSource::Settings),
+        recomputed_at_epoch_seconds: 100,
+        created_at_epoch_seconds: 100,
+        updated_at_epoch_seconds: 100,
+    }
+}
+
+struct FrontendFixture {
+    root: PathBuf,
+}
+
+fn frontend_fixture() -> FrontendFixture {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let counter = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "aiwattcoach-dashboard-spa-fixture-{}-{unique}-{counter}",
+        std::process::id()
+    ));
+    let dist_dir = root.join("dist");
+    fs::create_dir_all(&dist_dir).unwrap();
+    fs::write(
+        dist_dir.join("index.html"),
+        "<!doctype html><html><body><div id=\"root\">fixture</div></body></html>",
+    )
+    .unwrap();
+
+    FrontendFixture { root }
+}
+
+impl Drop for FrontendFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+impl FrontendFixture {
+    fn dist_dir(&self) -> PathBuf {
+        self.root.join("dist")
+    }
+}
+
+async fn test_mongo_client(uri: &str) -> Client {
+    Client::with_uri_str(uri)
+        .await
+        .expect("test mongo client should be created")
+}

--- a/tests/training_load_mongo.rs
+++ b/tests/training_load_mongo.rs
@@ -116,6 +116,38 @@ async fn training_load_daily_snapshot_repository_replaces_days_and_deletes_from_
     fixture.cleanup().await;
 }
 
+#[tokio::test]
+async fn training_load_daily_snapshot_repository_finds_oldest_date_for_user() {
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository =
+        MongoTrainingLoadDailySnapshotRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    repository
+        .upsert(sample_snapshot("user-1", "2026-04-03", Some(80), Some(285)))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot("user-1", "2026-04-01", Some(50), Some(280)))
+        .await
+        .unwrap();
+    repository
+        .upsert(sample_snapshot("user-2", "2026-03-20", Some(60), Some(300)))
+        .await
+        .unwrap();
+
+    let oldest = repository
+        .find_oldest_date_by_user_id("user-1")
+        .await
+        .unwrap();
+
+    assert_eq!(oldest.as_deref(), Some("2026-04-01"));
+
+    fixture.cleanup().await;
+}
+
 #[test]
 fn redact_uri_credentials_hides_mongo_userinfo() {
     assert_eq!(


### PR DESCRIPTION
Expose snapshot-based dashboard data and render the /app training load view so athletes can inspect CTL, ATL, and TSB trends without leaving the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a redesigned Training Load dashboard with interactive CTL/ATL and TSB charts, visible latest-snapshot marker, and a 90d/Season/All‑time range selector.
  * Adds an informational right‑hand coach insight panel and a dedicated empty state when no data exists.
  * Adds English and Polish translations for dashboard UI and accessibility text.

* **Tests**
  * Adds comprehensive frontend and backend tests covering dashboard API, UI flows, interactions, and i18n.

* **Documentation**
  * Adds design and implementation plans describing the prototype‑close layout and i18n/refactor roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->