### PR TITLE
fix: schedule saved-workout plan generation on shared worker

### DIFF
--- a/src/domain/training_plan/mod.rs
+++ b/src/domain/training_plan/mod.rs
@@ -13,4 +13,7 @@ pub use ports::{
     TrainingPlanProjectionRepository, TrainingPlanSnapshotRepository,
     TrainingPlanWorkoutSummaryPort,
 };
-pub use service::{TrainingPlanGenerationService, TrainingPlanUseCases};
+pub use service::{
+    training_plan_generate_task_handler, SchedulerBackedTrainingPlanService,
+    TrainingPlanGenerationService, TrainingPlanUseCases,
+};

--- a/src/domain/training_plan/service/mod.rs
+++ b/src/domain/training_plan/service/mod.rs
@@ -1,5 +1,6 @@
 mod correction;
 mod parsing;
+mod scheduler;
 mod snapshot;
 
 use chrono::{TimeZone, Utc};
@@ -20,6 +21,8 @@ use super::{
     TrainingPlanProjectionRepository, TrainingPlanSnapshot, TrainingPlanSnapshotRepository,
     TrainingPlanWorkoutSummaryPort,
 };
+
+pub use scheduler::{training_plan_generate_task_handler, SchedulerBackedTrainingPlanService};
 
 pub trait TrainingPlanUseCases: Send + Sync {
     fn generate_recap_for_saved_workout(

--- a/src/domain/training_plan/service/scheduler.rs
+++ b/src/domain/training_plan/service/scheduler.rs
@@ -1,0 +1,477 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{
+    calendar_view::CalendarEntryViewRefreshPort,
+    identity::{Clock, IdGenerator},
+    llm::LLM_REQUEST_TIMEOUT_SECONDS,
+    task_scheduler::{
+        BoxFuture as TaskSchedulerBoxFuture, NewTask, ResultTaskHandler, RetryStrategy,
+        ScheduledTask, SharedTaskHandler, TaskHandler, TaskRepository, TaskRunOutcome,
+        TaskSchedulerError, TaskSchedulerService, TaskWorkerRepository,
+    },
+    workout_summary::WorkoutRecap,
+};
+
+use super::{
+    BoxFuture, GeneratedTrainingPlan, TrainingPlanError, TrainingPlanGenerationOperationRepository,
+    TrainingPlanGenerationService, TrainingPlanGenerator, TrainingPlanProjectionRepository,
+    TrainingPlanSnapshotRepository, TrainingPlanUseCases, TrainingPlanWorkoutSummaryPort,
+};
+
+pub(crate) const TRAINING_PLAN_GENERATE_TASK_TYPE: &str =
+    "training_plan.generate_for_saved_workout";
+pub(crate) const TRAINING_PLAN_EXECUTION_TIMEOUT_BUFFER_SECONDS: i64 = 30;
+pub(crate) const TRAINING_PLAN_EXECUTION_TIMEOUT_SECONDS: i64 =
+    (LLM_REQUEST_TIMEOUT_SECONDS as i64 * 4) + TRAINING_PLAN_EXECUTION_TIMEOUT_BUFFER_SECONDS;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct TrainingPlanTaskPayload {
+    user_id: String,
+    workout_id: String,
+    saved_at_epoch_seconds: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum SerializedTrainingPlanError {
+    Unavailable { message: String },
+    Repository { message: String },
+    Validation { message: String },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct CompletedTrainingPlanTaskCheckpoint {
+    operation_key: String,
+    was_generated: bool,
+}
+
+trait TrainingPlanSchedulerExecutor: TrainingPlanUseCases + Send + Sync + 'static {
+    fn operation_key_for_saved_workout(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> String;
+
+    fn load_generated_plan_from_state(
+        &self,
+        operation_key: &str,
+    ) -> TaskSchedulerBoxFuture<Result<Option<GeneratedTrainingPlan>, TrainingPlanError>>;
+}
+
+impl<Snapshots, Projections, Operations, Generator, WorkoutSummary, Time, Refresh>
+    TrainingPlanSchedulerExecutor
+    for TrainingPlanGenerationService<
+        Snapshots,
+        Projections,
+        Operations,
+        Generator,
+        WorkoutSummary,
+        Time,
+        Refresh,
+    >
+where
+    Snapshots: TrainingPlanSnapshotRepository + Clone + 'static,
+    Projections: TrainingPlanProjectionRepository + Clone + 'static,
+    Operations: TrainingPlanGenerationOperationRepository + Clone + 'static,
+    Generator: TrainingPlanGenerator + Clone + 'static,
+    WorkoutSummary: TrainingPlanWorkoutSummaryPort + Clone + 'static,
+    Time: Clock + Clone + 'static,
+    Refresh: CalendarEntryViewRefreshPort + Clone + 'static,
+{
+    fn operation_key_for_saved_workout(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> String {
+        self.operation_key(user_id, workout_id, saved_at_epoch_seconds)
+    }
+
+    fn load_generated_plan_from_state(
+        &self,
+        operation_key: &str,
+    ) -> TaskSchedulerBoxFuture<Result<Option<GeneratedTrainingPlan>, TrainingPlanError>> {
+        let service = self.clone();
+        let operation_key = operation_key.to_string();
+        Box::pin(async move {
+            service
+                .existing_generated_plan_with_healed_operation(&operation_key)
+                .await
+        })
+    }
+}
+
+fn parse_task_payload(task: &ScheduledTask) -> Result<TrainingPlanTaskPayload, TrainingPlanError> {
+    serde_json::from_value(task.payload.clone()).map_err(|error| {
+        TrainingPlanError::Repository(format!(
+            "invalid training plan generate task payload: {error}"
+        ))
+    })
+}
+
+fn map_task_scheduler_error(error: TaskSchedulerError) -> TrainingPlanError {
+    match error {
+        TaskSchedulerError::Validation(message)
+        | TaskSchedulerError::Conflict(message)
+        | TaskSchedulerError::Repository(message) => TrainingPlanError::Repository(message),
+    }
+}
+
+fn serialize_training_plan_error(error: &TrainingPlanError) -> SerializedTrainingPlanError {
+    match error {
+        TrainingPlanError::Unavailable(message) => SerializedTrainingPlanError::Unavailable {
+            message: message.clone(),
+        },
+        TrainingPlanError::Repository(message) => SerializedTrainingPlanError::Repository {
+            message: message.clone(),
+        },
+        TrainingPlanError::Validation(message) => SerializedTrainingPlanError::Validation {
+            message: message.clone(),
+        },
+    }
+}
+
+fn deserialize_training_plan_error(error: SerializedTrainingPlanError) -> TrainingPlanError {
+    match error {
+        SerializedTrainingPlanError::Unavailable { message } => {
+            TrainingPlanError::Unavailable(message)
+        }
+        SerializedTrainingPlanError::Repository { message } => {
+            TrainingPlanError::Repository(message)
+        }
+        SerializedTrainingPlanError::Validation { message } => {
+            TrainingPlanError::Validation(message)
+        }
+    }
+}
+
+fn parse_completed_checkpoint(
+    task: &ScheduledTask,
+) -> Result<Option<CompletedTrainingPlanTaskCheckpoint>, TrainingPlanError> {
+    task.checkpoint
+        .clone()
+        .map(|value| {
+            serde_json::from_value(value).map_err(|error| {
+                TrainingPlanError::Repository(format!(
+                    "invalid completed training plan checkpoint: {error}"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn parse_failed_checkpoint(
+    task: &ScheduledTask,
+) -> Result<Option<TrainingPlanError>, TrainingPlanError> {
+    task.checkpoint
+        .clone()
+        .map(|value| {
+            serde_json::from_value::<SerializedTrainingPlanError>(value)
+                .map(deserialize_training_plan_error)
+                .map_err(|error| {
+                    TrainingPlanError::Repository(format!(
+                        "invalid failed training plan checkpoint: {error}"
+                    ))
+                })
+        })
+        .transpose()
+}
+
+struct TrainingPlanGenerateTaskHandler<Base> {
+    base: Arc<Base>,
+}
+
+impl<Base> TaskHandler for TrainingPlanGenerateTaskHandler<Base>
+where
+    Base: TrainingPlanSchedulerExecutor,
+{
+    fn task_type(&self) -> &'static str {
+        TRAINING_PLAN_GENERATE_TASK_TYPE
+    }
+
+    fn run(&self, task: ScheduledTask) -> BoxFuture<TaskRunOutcome> {
+        let base = self.base.clone();
+        Box::pin(async move {
+            let payload = match parse_task_payload(&task) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return TaskRunOutcome::Failed {
+                        checkpoint: None,
+                        error_message: error.to_string(),
+                        retryable: false,
+                        retry_delay_seconds: None,
+                    };
+                }
+            };
+
+            match base
+                .generate_for_saved_workout(
+                    &payload.user_id,
+                    &payload.workout_id,
+                    payload.saved_at_epoch_seconds,
+                )
+                .await
+            {
+                Ok(generated) => TaskRunOutcome::Completed {
+                    checkpoint: serde_json::to_value(CompletedTrainingPlanTaskCheckpoint {
+                        operation_key: generated.snapshot.operation_key,
+                        was_generated: generated.was_generated,
+                    })
+                    .ok(),
+                },
+                Err(error) => TaskRunOutcome::Failed {
+                    checkpoint: serde_json::to_value(serialize_training_plan_error(&error)).ok(),
+                    error_message: error.to_string(),
+                    retryable: false,
+                    retry_delay_seconds: None,
+                },
+            }
+        })
+    }
+}
+
+#[allow(private_bounds)]
+pub fn training_plan_generate_task_handler<Base>(base: Arc<Base>) -> SharedTaskHandler
+where
+    Base: TrainingPlanSchedulerExecutor,
+{
+    Arc::new(TrainingPlanGenerateTaskHandler { base })
+}
+
+#[derive(Clone)]
+struct TrainingPlanTaskResultHandler<Base> {
+    base: Arc<Base>,
+}
+
+impl<Base> ResultTaskHandler for TrainingPlanTaskResultHandler<Base>
+where
+    Base: TrainingPlanSchedulerExecutor,
+{
+    type Completed = CompletedTrainingPlanTaskCheckpoint;
+    type Output = GeneratedTrainingPlan;
+    type Error = TrainingPlanError;
+
+    fn task_disappeared(&self, _task_id: &str) -> Self::Error {
+        TrainingPlanError::Repository(
+            "training plan task disappeared before completion".to_string(),
+        )
+    }
+
+    fn task_timed_out(&self, _task_id: &str) -> Self::Error {
+        TrainingPlanError::Repository("training plan task timed out".to_string())
+    }
+
+    fn parse_completed(&self, task: &ScheduledTask) -> Result<Self::Completed, Self::Error> {
+        parse_completed_checkpoint(task)?.ok_or_else(|| {
+            TrainingPlanError::Repository(
+                "completed training plan task missing persisted checkpoint".to_string(),
+            )
+        })
+    }
+
+    fn parse_failed(&self, task: &ScheduledTask) -> Result<Self::Error, Self::Error> {
+        Ok(parse_failed_checkpoint(task)?.unwrap_or_else(|| {
+            task.error_message
+                .clone()
+                .map(TrainingPlanError::Repository)
+                .unwrap_or_else(|| {
+                    TrainingPlanError::Repository(
+                        "training plan task failed without an error message".to_string(),
+                    )
+                })
+        }))
+    }
+
+    fn finish(&self, completed: Self::Completed) -> BoxFuture<Result<Self::Output, Self::Error>> {
+        let base = self.base.clone();
+        Box::pin(async move {
+            let generated = base
+                .load_generated_plan_from_state(&completed.operation_key)
+                .await?
+                .ok_or_else(|| {
+                    TrainingPlanError::Repository(
+                        "completed training plan task missing persisted snapshot".to_string(),
+                    )
+                })?;
+            Ok(GeneratedTrainingPlan {
+                snapshot: generated.snapshot,
+                active_projected_days: generated.active_projected_days,
+                was_generated: completed.was_generated,
+            })
+        })
+    }
+}
+
+pub struct SchedulerBackedTrainingPlanService<Base, Tasks, Workers, Time, Ids>
+where
+    Tasks: TaskRepository,
+    Workers: TaskWorkerRepository,
+    Time: Clock,
+{
+    base: Arc<Base>,
+    scheduler: TaskSchedulerService<Tasks, Workers, Time>,
+    ids: Ids,
+}
+
+impl<Base, Tasks, Workers, Time, Ids> Clone
+    for SchedulerBackedTrainingPlanService<Base, Tasks, Workers, Time, Ids>
+where
+    Tasks: TaskRepository,
+    Workers: TaskWorkerRepository,
+    Time: Clock,
+    Ids: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base.clone(),
+            scheduler: self.scheduler.clone(),
+            ids: self.ids.clone(),
+        }
+    }
+}
+
+impl<Base, Tasks, Workers, Time, Ids>
+    SchedulerBackedTrainingPlanService<Base, Tasks, Workers, Time, Ids>
+where
+    Base: TrainingPlanUseCases + 'static,
+    Tasks: TaskRepository,
+    Workers: TaskWorkerRepository,
+    Time: Clock,
+    Ids: IdGenerator,
+{
+    pub fn new(
+        base: Arc<Base>,
+        scheduler: TaskSchedulerService<Tasks, Workers, Time>,
+        ids: Ids,
+    ) -> Self {
+        Self {
+            base,
+            scheduler,
+            ids,
+        }
+    }
+}
+
+#[allow(private_bounds)]
+impl<Base, Tasks, Workers, Time, Ids>
+    SchedulerBackedTrainingPlanService<Base, Tasks, Workers, Time, Ids>
+where
+    Base: TrainingPlanSchedulerExecutor,
+    Tasks: TaskRepository,
+    Workers: TaskWorkerRepository,
+    Time: Clock,
+    Ids: IdGenerator,
+{
+    fn build_generate_task(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> Result<ScheduledTask, TrainingPlanError> {
+        let dedupe_key =
+            self.base
+                .operation_key_for_saved_workout(user_id, workout_id, saved_at_epoch_seconds);
+        ScheduledTask::new(
+            NewTask {
+                id: self.ids.new_id("task"),
+                user_id: user_id.to_string(),
+                task_type: TRAINING_PLAN_GENERATE_TASK_TYPE.to_string(),
+                payload: serde_json::to_value(TrainingPlanTaskPayload {
+                    user_id: user_id.to_string(),
+                    workout_id: workout_id.to_string(),
+                    saved_at_epoch_seconds,
+                })
+                .map_err(|error| {
+                    TrainingPlanError::Repository(format!(
+                        "failed to serialize training plan task payload: {error}"
+                    ))
+                })?,
+                retry_strategy: RetryStrategy::Never,
+                dedupe_key,
+                execution_timeout_seconds: TRAINING_PLAN_EXECUTION_TIMEOUT_SECONDS,
+                leader_only: false,
+            },
+            self.scheduler.now_epoch_seconds(),
+        )
+        .map_err(map_task_scheduler_error)
+    }
+
+    async fn existing_generated_plan(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> Result<Option<GeneratedTrainingPlan>, TrainingPlanError> {
+        let operation_key =
+            self.base
+                .operation_key_for_saved_workout(user_id, workout_id, saved_at_epoch_seconds);
+        self.base
+            .load_generated_plan_from_state(&operation_key)
+            .await
+    }
+
+    async fn wait_for_generated_plan(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> Result<GeneratedTrainingPlan, TrainingPlanError> {
+        if let Some(existing) = self
+            .existing_generated_plan(user_id, workout_id, saved_at_epoch_seconds)
+            .await?
+        {
+            return Ok(existing);
+        }
+
+        let task = self.build_generate_task(user_id, workout_id, saved_at_epoch_seconds)?;
+        self.scheduler
+            .enqueue_result_task(
+                task,
+                map_task_scheduler_error,
+                TrainingPlanTaskResultHandler {
+                    base: self.base.clone(),
+                },
+            )
+            .await
+    }
+}
+
+#[allow(private_bounds)]
+impl<Base, Tasks, Workers, Time, Ids> TrainingPlanUseCases
+    for SchedulerBackedTrainingPlanService<Base, Tasks, Workers, Time, Ids>
+where
+    Base: TrainingPlanSchedulerExecutor,
+    Tasks: TaskRepository,
+    Workers: TaskWorkerRepository,
+    Time: Clock,
+    Ids: IdGenerator,
+{
+    fn generate_recap_for_saved_workout(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> BoxFuture<Result<WorkoutRecap, TrainingPlanError>> {
+        self.base
+            .generate_recap_for_saved_workout(user_id, workout_id, saved_at_epoch_seconds)
+    }
+
+    fn generate_for_saved_workout(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> BoxFuture<Result<GeneratedTrainingPlan, TrainingPlanError>> {
+        let service = (*self).clone();
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        Box::pin(async move {
+            service
+                .wait_for_generated_plan(&user_id, &workout_id, saved_at_epoch_seconds)
+                .await
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,10 @@ use aiwattcoach::{
     domain::task_scheduler::{TaskSchedulerService, TaskWorkerConfig},
     domain::training_context::DefaultTrainingContextBuilder,
     domain::training_load::{TrainingLoadDashboardReadService, TrainingLoadRecomputeService},
-    domain::training_plan::TrainingPlanGenerationService,
+    domain::training_plan::{
+        training_plan_generate_task_handler, SchedulerBackedTrainingPlanService,
+        TrainingPlanGenerationService,
+    },
     domain::workout_summary::{
         workout_summary_coach_reply_task_handler, SchedulerBackedWorkoutSummaryService,
         WorkoutSummaryService,
@@ -177,6 +180,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let task_worker_repository =
         MongoTaskWorkerRepository::new(mongo_client.clone(), &mongo_database);
     task_worker_repository.ensure_indexes().await?;
+    let shared_task_scheduler = TaskSchedulerService::new(
+        task_repository.clone(),
+        task_worker_repository.clone(),
+        SystemClock,
+    );
     let llm_http_client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(5))
         .build()?;
@@ -404,7 +412,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             LatestCompletedActivityAdapter::new(completed_workout_repository.clone()),
         )),
     );
-    let training_plan_service = Arc::new(
+    let training_plan_direct_service = Arc::new(
         TrainingPlanGenerationService::new(
             training_plan_snapshot_repository,
             training_plan_projection_repository.clone(),
@@ -420,6 +428,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         )
         .with_calendar_view_refresh(calendar_entry_view_refresh_service.clone()),
     );
+    let training_plan_service = Arc::new(SchedulerBackedTrainingPlanService::new(
+        training_plan_direct_service.clone(),
+        shared_task_scheduler.clone(),
+        UuidIdGenerator,
+    ));
     let race_service = Arc::new(
         RaceService::new(
             race_repository.clone(),
@@ -464,20 +477,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let workout_summary_direct_service = Arc::new(
         (*workout_summary_direct_service)
             .clone()
-            .with_training_plan_service(training_plan_service),
-    );
-    let workout_summary_task_scheduler = TaskSchedulerService::new(
-        task_repository.clone(),
-        task_worker_repository.clone(),
-        SystemClock,
+            .with_training_plan_service(training_plan_service.clone()),
     );
     let athlete_summary_service = Arc::new(SchedulerBackedAthleteSummaryService::new(
         athlete_summary_direct_service.clone(),
-        workout_summary_task_scheduler.clone(),
+        shared_task_scheduler.clone(),
         UuidIdGenerator,
     ));
     let workout_summary_task_worker = spawn_task_worker(
-        workout_summary_task_scheduler.clone(),
+        shared_task_scheduler.clone(),
         format!("{}-workout-summary", default_task_scheduler_worker_id()),
         TaskWorkerConfig {
             is_leader: false,
@@ -488,12 +496,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         },
         vec![
             workout_summary_coach_reply_task_handler(workout_summary_direct_service.clone()),
-            athlete_summary_generate_task_handler(athlete_summary_direct_service),
+            athlete_summary_generate_task_handler(athlete_summary_direct_service.clone()),
+            training_plan_generate_task_handler(training_plan_direct_service),
         ],
     )?;
     let workout_summary_service = Arc::new(SchedulerBackedWorkoutSummaryService::new(
         workout_summary_direct_service,
-        workout_summary_task_scheduler,
+        shared_task_scheduler,
         UuidIdGenerator,
     ));
 

--- a/tests/training_plan_service/main.rs
+++ b/tests/training_plan_service/main.rs
@@ -1,4 +1,11 @@
 mod generation;
 mod recovery;
+mod scheduler;
 mod support;
 mod validation;
+
+#[path = "../task_scheduler/support/clock.rs"]
+mod task_scheduler_clock_support;
+
+#[path = "../task_scheduler/support/repository.rs"]
+mod task_scheduler_repository_support;

--- a/tests/training_plan_service/scheduler.rs
+++ b/tests/training_plan_service/scheduler.rs
@@ -1,0 +1,458 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use aiwattcoach::{
+    config::spawn_task_worker,
+    domain::{
+        calendar_view::{
+            CalendarEntryView, CalendarEntryViewError, CalendarEntryViewRefreshPort,
+            NoopCalendarEntryViewRefresh,
+        },
+        identity::IdGenerator,
+        task_scheduler::{
+            ScheduledTask, TaskListFilter, TaskSchedulerService, TaskStatus, TaskWorkerConfig,
+        },
+        training_plan::{
+            training_plan_generate_task_handler, SchedulerBackedTrainingPlanService,
+            TrainingPlanError, TrainingPlanGenerationService, TrainingPlanGenerator,
+            TrainingPlanPlanningContext, TrainingPlanUseCases,
+        },
+        workout_summary::WorkoutRecap,
+    },
+};
+use tokio::sync::Notify;
+
+use crate::{
+    task_scheduler_clock_support::TestClock as SchedulerClock,
+    task_scheduler_repository_support::{InMemoryTaskRepository, InMemoryTaskWorkerRepository},
+};
+
+use super::support::*;
+
+type Scheduler =
+    TaskSchedulerService<InMemoryTaskRepository, InMemoryTaskWorkerRepository, SchedulerClock>;
+type DirectService<Generator, Refresh = NoopCalendarEntryViewRefresh> =
+    TrainingPlanGenerationService<
+        InMemoryTrainingPlanSnapshotRepository,
+        InMemoryTrainingPlanProjectedDayRepository,
+        InMemoryTrainingPlanOperationRepository,
+        Generator,
+        StubWorkoutSummaryPort,
+        SchedulerClock,
+        Refresh,
+    >;
+type WrappedService<Generator, Refresh = NoopCalendarEntryViewRefresh> =
+    SchedulerBackedTrainingPlanService<
+        DirectService<Generator, Refresh>,
+        InMemoryTaskRepository,
+        InMemoryTaskWorkerRepository,
+        SchedulerClock,
+        TestIdGenerator,
+    >;
+
+struct SchedulerFixture<Generator, Refresh = NoopCalendarEntryViewRefresh>
+where
+    Generator: TrainingPlanGenerator + Clone + 'static,
+    Refresh: CalendarEntryViewRefreshPort + Clone + 'static,
+{
+    direct: Arc<DirectService<Generator, Refresh>>,
+    wrapped: WrappedService<Generator, Refresh>,
+    scheduler: Scheduler,
+    clock: SchedulerClock,
+    projected_days: InMemoryTrainingPlanProjectedDayRepository,
+    operations: InMemoryTrainingPlanOperationRepository,
+}
+
+#[tokio::test]
+async fn scheduler_backed_generate_for_saved_workout_runs_through_shared_worker_and_replays() {
+    let call_log = new_call_log();
+    let generator = StubTrainingPlanGenerator::new(
+        call_log.clone(),
+        vec![Ok(workout_recap())],
+        vec![Ok(valid_plan_window(FIRST_DAY))],
+        vec![],
+    );
+    let fixture = build_fixture_with_generator(
+        date_epoch(FIRST_DAY),
+        call_log,
+        generator.clone(),
+        NoopCalendarEntryViewRefresh,
+    );
+    let worker = spawn_worker(&fixture, "worker-1");
+
+    let first = fixture
+        .wrapped
+        .generate_for_saved_workout(USER_ID, WORKOUT_ID, date_epoch(FIRST_DAY))
+        .await
+        .unwrap();
+    let replay = fixture
+        .wrapped
+        .generate_for_saved_workout(USER_ID, WORKOUT_ID, date_epoch(FIRST_DAY))
+        .await
+        .unwrap();
+    let task = only_task(&fixture.scheduler).await;
+
+    assert!(first.was_generated);
+    assert!(!replay.was_generated);
+    assert_eq!(first.snapshot.operation_key, replay.snapshot.operation_key);
+    assert_eq!(generator.recap_call_count(), 1);
+    assert_eq!(generator.initial_plan_call_count(), 1);
+    assert_eq!(task.status, TaskStatus::Completed);
+    assert_eq!(task.attempt_count, 1);
+    worker.shutdown().await;
+}
+
+#[tokio::test]
+async fn scheduler_backed_generate_for_saved_workout_preserves_training_plan_error_category() {
+    let call_log = new_call_log();
+    let generator = StubTrainingPlanGenerator::new(
+        call_log.clone(),
+        vec![Err(TrainingPlanError::Validation(
+            "recap generation failed".to_string(),
+        ))],
+        vec![],
+        vec![],
+    );
+    let fixture = build_fixture_with_generator(
+        date_epoch(FIRST_DAY),
+        call_log,
+        generator,
+        NoopCalendarEntryViewRefresh,
+    );
+    let worker = spawn_worker(&fixture, "worker-1");
+
+    let error = fixture
+        .wrapped
+        .generate_for_saved_workout(USER_ID, WORKOUT_ID, date_epoch(FIRST_DAY))
+        .await
+        .unwrap_err();
+    let task = only_task(&fixture.scheduler).await;
+
+    assert_eq!(
+        error,
+        TrainingPlanError::Validation("recap generation failed".to_string())
+    );
+    assert_eq!(task.status, TaskStatus::Failed);
+    assert_eq!(task.attempt_count, 1);
+    worker.shutdown().await;
+}
+
+#[tokio::test]
+async fn scheduler_backed_generate_for_saved_workout_recovers_after_worker_restart() {
+    let generator = BlockingTrainingPlanGenerator::default();
+    let fixture = build_fixture_with_generator(
+        date_epoch(FIRST_DAY),
+        new_call_log(),
+        generator.clone(),
+        NoopCalendarEntryViewRefresh,
+    );
+    let worker = spawn_worker(&fixture, "worker-1");
+    let wrapped = fixture.wrapped.clone();
+    let result_future = tokio::spawn(async move {
+        wrapped
+            .generate_for_saved_workout(USER_ID, WORKOUT_ID, date_epoch(FIRST_DAY))
+            .await
+    });
+
+    wait_for_only_task_status(&fixture.scheduler, TaskStatus::Running, Some(1)).await;
+    worker.shutdown().await;
+
+    fixture.clock.set_now(date_epoch(FIRST_DAY) + 600);
+    fixture
+        .scheduler
+        .touch_worker_heartbeat(
+            "worker-1",
+            false,
+            vec!["training_plan.generate_for_saved_workout".to_string()],
+        )
+        .await
+        .unwrap();
+    let recovered = fixture
+        .scheduler
+        .sweep_timed_out_tasks(30, 100)
+        .await
+        .unwrap();
+    let worker = spawn_worker(&fixture, "worker-1");
+    generator.release_recap();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), result_future)
+        .await
+        .expect("scheduler-backed training plan should finish after recovery")
+        .expect("training plan join should succeed")
+        .expect("training plan should succeed after recovery");
+    let task = wait_for_only_task_status(&fixture.scheduler, TaskStatus::Completed, Some(2)).await;
+
+    assert_eq!(recovered, 1);
+    assert_eq!(
+        result.snapshot.operation_key,
+        format!(
+            "training-plan:{USER_ID}:{WORKOUT_ID}:{}",
+            date_epoch(FIRST_DAY)
+        )
+    );
+    assert_eq!(task.attempt_count, 2);
+    assert!(generator.recap_call_count() >= 1);
+    worker.shutdown().await;
+}
+
+#[tokio::test]
+async fn manual_retry_of_failed_task_does_not_duplicate_projected_days() {
+    let call_log = new_call_log();
+    let generator = StubTrainingPlanGenerator::new(
+        call_log.clone(),
+        vec![Ok(workout_recap())],
+        vec![Ok(valid_plan_window(FIRST_DAY))],
+        vec![],
+    );
+    let fixture = build_fixture_with_generator(
+        date_epoch(FIRST_DAY),
+        call_log,
+        generator,
+        FailingCalendarRefresh,
+    );
+    let worker = spawn_worker(&fixture, "worker-1");
+
+    let error = fixture
+        .wrapped
+        .generate_for_saved_workout(USER_ID, WORKOUT_ID, date_epoch(FIRST_DAY))
+        .await
+        .unwrap_err();
+    let failed_task =
+        wait_for_only_task_status(&fixture.scheduler, TaskStatus::Failed, Some(1)).await;
+    let projected_day_count_before_retry = fixture.projected_days.stored_days().len();
+
+    assert_eq!(
+        error,
+        TrainingPlanError::Repository("refresh unavailable".to_string())
+    );
+
+    fixture.scheduler.retry_task(&failed_task.id).await.unwrap();
+
+    let completed_task =
+        wait_for_only_task_status(&fixture.scheduler, TaskStatus::Completed, Some(2)).await;
+    let projected_day_count_after_retry = fixture.projected_days.stored_days().len();
+    let operation = fixture.operations.stored_operation();
+
+    assert_eq!(completed_task.status, TaskStatus::Completed);
+    assert_eq!(projected_day_count_before_retry, 14);
+    assert_eq!(
+        projected_day_count_after_retry,
+        projected_day_count_before_retry
+    );
+    assert_eq!(operation.status, WorkflowStatus::Completed);
+    worker.shutdown().await;
+}
+
+fn build_fixture_with_generator<Generator, Refresh>(
+    clock_now: i64,
+    call_log: CallLog,
+    generator: Generator,
+    refresh: Refresh,
+) -> SchedulerFixture<Generator, Refresh>
+where
+    Generator: TrainingPlanGenerator + Clone + 'static,
+    Refresh: CalendarEntryViewRefreshPort + Clone + 'static,
+{
+    let clock = SchedulerClock::new(clock_now);
+    let snapshots = InMemoryTrainingPlanSnapshotRepository::new();
+    let projected_days =
+        InMemoryTrainingPlanProjectedDayRepository::new(snapshots.snapshots.clone());
+    let operations = InMemoryTrainingPlanOperationRepository::new(call_log.clone());
+    let workout_summary = StubWorkoutSummaryPort::new(call_log);
+    let direct = Arc::new(
+        TrainingPlanGenerationService::new(
+            snapshots,
+            projected_days.clone(),
+            operations.clone(),
+            generator,
+            workout_summary,
+            clock.clone(),
+        )
+        .with_calendar_view_refresh(refresh),
+    );
+    let scheduler = TaskSchedulerService::new(
+        InMemoryTaskRepository::default(),
+        InMemoryTaskWorkerRepository::default(),
+        clock.clone(),
+    );
+    let wrapped = SchedulerBackedTrainingPlanService::new(
+        direct.clone(),
+        scheduler.clone(),
+        TestIdGenerator::default(),
+    );
+
+    SchedulerFixture {
+        direct,
+        wrapped,
+        scheduler,
+        clock,
+        projected_days,
+        operations,
+    }
+}
+
+fn spawn_worker<Generator, Refresh>(
+    fixture: &SchedulerFixture<Generator, Refresh>,
+    worker_id: &str,
+) -> aiwattcoach::BackgroundTaskHandle
+where
+    Generator: TrainingPlanGenerator + Clone + 'static,
+    Refresh: CalendarEntryViewRefreshPort + Clone + 'static,
+{
+    spawn_task_worker(
+        fixture.scheduler.clone(),
+        worker_id.to_string(),
+        TaskWorkerConfig {
+            is_leader: false,
+            lease_duration_seconds: 30,
+            heartbeat_interval: Duration::from_secs(10),
+            idle_poll_interval: Duration::from_millis(10),
+            max_concurrency: 2,
+        },
+        vec![training_plan_generate_task_handler(fixture.direct.clone())],
+    )
+    .unwrap()
+}
+
+async fn wait_for_only_task_status(
+    scheduler: &Scheduler,
+    expected_status: TaskStatus,
+    expected_attempt_count: Option<u32>,
+) -> ScheduledTask {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let tasks = scheduler
+                .list_tasks(TaskListFilter::default())
+                .await
+                .unwrap();
+            let Some(task) = tasks.into_iter().next() else {
+                tokio::task::yield_now().await;
+                continue;
+            };
+
+            if task.status == expected_status
+                && expected_attempt_count
+                    .map(|attempt_count| task.attempt_count == attempt_count)
+                    .unwrap_or(true)
+            {
+                return task;
+            }
+
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("task should reach expected state")
+}
+
+async fn only_task(scheduler: &Scheduler) -> ScheduledTask {
+    scheduler
+        .list_tasks(TaskListFilter::default())
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("expected scheduled training plan task")
+}
+
+#[derive(Clone, Default)]
+struct TestIdGenerator {
+    next_id: Arc<AtomicUsize>,
+}
+
+impl IdGenerator for TestIdGenerator {
+    fn new_id(&self, prefix: &str) -> String {
+        let next_id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        format!("{prefix}-{next_id}")
+    }
+}
+
+#[derive(Clone, Default)]
+struct BlockingTrainingPlanGenerator {
+    recap_calls: Arc<AtomicUsize>,
+    recap_released: Arc<AtomicBool>,
+    recap_notify: Arc<Notify>,
+}
+
+impl BlockingTrainingPlanGenerator {
+    fn release_recap(&self) {
+        self.recap_released.store(true, Ordering::SeqCst);
+        self.recap_notify.notify_waiters();
+    }
+
+    fn recap_call_count(&self) -> usize {
+        self.recap_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl TrainingPlanGenerator for BlockingTrainingPlanGenerator {
+    fn generate_workout_recap(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        _saved_at_epoch_seconds: i64,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<Result<WorkoutRecap, TrainingPlanError>>
+    {
+        let recap_calls = self.recap_calls.clone();
+        let recap_released = self.recap_released.clone();
+        let recap_notify = self.recap_notify.clone();
+        Box::pin(async move {
+            recap_calls.fetch_add(1, Ordering::SeqCst);
+            while !recap_released.load(Ordering::SeqCst) {
+                recap_notify.notified().await;
+            }
+            Ok(workout_recap())
+        })
+    }
+
+    fn generate_initial_plan_window(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        _saved_at_epoch_seconds: i64,
+        _workout_recap: &WorkoutRecap,
+        _planning_context: Option<&TrainingPlanPlanningContext>,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<Result<String, TrainingPlanError>> {
+        Box::pin(async move { Ok(valid_plan_window(FIRST_DAY)) })
+    }
+
+    fn correct_invalid_days(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        _saved_at_epoch_seconds: i64,
+        _workout_recap: &WorkoutRecap,
+        _planning_context: Option<&TrainingPlanPlanningContext>,
+        _invalid_day_sections: &str,
+        _issues: Vec<ValidationIssue>,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<Result<String, TrainingPlanError>> {
+        Box::pin(
+            async move { unreachable!("correction should not run in blocking generator test") },
+        )
+    }
+}
+
+#[derive(Clone)]
+struct FailingCalendarRefresh;
+
+impl CalendarEntryViewRefreshPort for FailingCalendarRefresh {
+    fn refresh_range_for_user(
+        &self,
+        _user_id: &str,
+        _oldest: &str,
+        _newest: &str,
+    ) -> aiwattcoach::domain::calendar_view::BoxFuture<
+        Result<Vec<CalendarEntryView>, CalendarEntryViewError>,
+    > {
+        Box::pin(async {
+            Err(CalendarEntryViewError::Repository(
+                "refresh unavailable".to_string(),
+            ))
+        })
+    }
+}

--- a/tests/workout_summary_service/create_and_get.rs
+++ b/tests/workout_summary_service/create_and_get.rs
@@ -5,9 +5,9 @@ use aiwattcoach::domain::workout_summary::{
 use std::sync::{Arc, Mutex};
 
 use crate::shared::{
-    existing_summary, existing_summary_with_finished_conversation, test_service,
-    test_service_with_settings, test_service_with_training_plan,
-    test_service_with_training_plan_and_latest_activity,
+    existing_summary, existing_summary_with_finished_conversation,
+    scheduler_backed_training_plan_service, test_service, test_service_with_settings,
+    test_service_with_training_plan, test_service_with_training_plan_and_latest_activity,
     test_service_with_training_plan_latest_activity_and_completed_target,
     InMemoryWorkoutSummaryRepository, PersistCheckingTrainingPlanService,
     RecordingCompletedWorkoutTargetService, RecordingLatestCompletedActivityService,
@@ -337,6 +337,35 @@ async fn mark_saved_generates_recap_and_plan_for_latest_completed_activity() {
             "generate_for_saved_workout:user-1:workout-1:1700000000".to_string(),
         ]
     );
+}
+
+#[tokio::test]
+async fn mark_saved_preserves_visible_workflow_with_scheduler_backed_training_plan_service() {
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(
+        existing_summary_with_finished_conversation(),
+    );
+    let training_plan = scheduler_backed_training_plan_service(
+        InMemoryWorkoutSummaryRepository::with_summary(existing_summary()),
+    );
+    let latest_activity = RecordingLatestCompletedActivityService::new(Some("workout-1"));
+    let service = test_service_with_training_plan_and_latest_activity(
+        repository,
+        training_plan.service.clone(),
+        std::sync::Arc::new(latest_activity),
+    );
+
+    let result = service.mark_saved("user-1", "workout-1").await.unwrap();
+
+    assert_eq!(result.workflow.recap_status.as_str(), "generated");
+    assert_eq!(result.workflow.plan_status.as_str(), "generated");
+    assert_eq!(
+        result.workflow.messages,
+        vec![
+            "Workout recap generated.".to_string(),
+            "14-day schedule generated.".to_string(),
+        ]
+    );
+    training_plan.worker.shutdown().await;
 }
 
 #[tokio::test]

--- a/tests/workout_summary_service/main.rs
+++ b/tests/workout_summary_service/main.rs
@@ -2,5 +2,12 @@ mod create_and_get;
 mod messaging;
 mod shared;
 
+#[allow(dead_code)]
+#[path = "../task_scheduler/support/clock.rs"]
+mod task_scheduler_clock_support;
+
+#[path = "../task_scheduler/support/repository.rs"]
+mod task_scheduler_repository_support;
+
 #[path = "../support/mod.rs"]
 mod support;

--- a/tests/workout_summary_service/shared/mod.rs
+++ b/tests/workout_summary_service/shared/mod.rs
@@ -27,6 +27,7 @@ mod identity;
 mod reply_operations;
 mod services;
 mod summary_repository;
+mod training_plan_scheduler;
 
 pub(crate) use identity::{TestClock, TestIdGenerator};
 pub(crate) use reply_operations::InMemoryCoachReplyOperationRepository;
@@ -41,3 +42,4 @@ pub(crate) use services::{
     RefreshingTrainingPlanService, StubAthleteSummaryService, TestAvailabilitySettingsService,
 };
 pub(crate) use summary_repository::InMemoryWorkoutSummaryRepository;
+pub(crate) use training_plan_scheduler::scheduler_backed_training_plan_service;

--- a/tests/workout_summary_service/shared/services.rs
+++ b/tests/workout_summary_service/shared/services.rs
@@ -1,6 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use aiwattcoach::domain::settings::Weekday;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::*;
 

--- a/tests/workout_summary_service/shared/training_plan_scheduler.rs
+++ b/tests/workout_summary_service/shared/training_plan_scheduler.rs
@@ -1,0 +1,320 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use aiwattcoach::{
+    config::spawn_task_worker,
+    domain::{
+        ai_workflow::ValidationIssue,
+        task_scheduler::{TaskSchedulerService, TaskWorkerConfig},
+        training_plan::{
+            training_plan_generate_task_handler, SchedulerBackedTrainingPlanService,
+            TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation,
+            TrainingPlanGenerationOperationRepository, TrainingPlanGenerationService,
+            TrainingPlanGenerator, TrainingPlanPlanningContext, TrainingPlanProjectedDay,
+            TrainingPlanProjectionRepository, TrainingPlanSnapshot, TrainingPlanSnapshotRepository,
+            TrainingPlanUseCases,
+        },
+        workout_summary::WorkoutRecap,
+    },
+    BackgroundTaskHandle,
+};
+
+use super::{test_service, InMemoryWorkoutSummaryRepository, TestIdGenerator};
+use crate::{
+    task_scheduler_clock_support::TestClock as SchedulerClock,
+    task_scheduler_repository_support::{InMemoryTaskRepository, InMemoryTaskWorkerRepository},
+};
+
+pub(crate) struct SchedulerBackedTrainingPlanHarness {
+    pub(crate) service: Arc<dyn TrainingPlanUseCases>,
+    pub(crate) worker: BackgroundTaskHandle,
+}
+
+pub(crate) fn scheduler_backed_training_plan_service(
+    training_plan_repo: InMemoryWorkoutSummaryRepository,
+) -> SchedulerBackedTrainingPlanHarness {
+    let snapshot_store = Arc::new(Mutex::new(None));
+    let direct_training_plan = Arc::new(TrainingPlanGenerationService::new(
+        SaveFlowSnapshotRepository::new(snapshot_store.clone()),
+        SaveFlowProjectionRepository::new(snapshot_store),
+        SaveFlowOperationRepository::default(),
+        SaveFlowTrainingPlanGenerator,
+        aiwattcoach::main_runtime::TrainingPlanWorkoutSummaryAdapter::new(Arc::new(test_service(
+            training_plan_repo,
+        ))),
+        SchedulerClock::new(1_700_000_000),
+    ));
+    let scheduler = TaskSchedulerService::new(
+        InMemoryTaskRepository::default(),
+        InMemoryTaskWorkerRepository::default(),
+        SchedulerClock::new(1_700_000_000),
+    );
+    let worker = spawn_task_worker(
+        scheduler.clone(),
+        "training-plan-worker".to_string(),
+        TaskWorkerConfig {
+            is_leader: false,
+            lease_duration_seconds: 30,
+            heartbeat_interval: Duration::from_secs(10),
+            idle_poll_interval: Duration::from_millis(10),
+            max_concurrency: 2,
+        },
+        vec![training_plan_generate_task_handler(
+            direct_training_plan.clone(),
+        )],
+    )
+    .expect("training plan test worker should spawn");
+
+    SchedulerBackedTrainingPlanHarness {
+        service: Arc::new(SchedulerBackedTrainingPlanService::new(
+            direct_training_plan,
+            scheduler,
+            TestIdGenerator::default(),
+        )),
+        worker,
+    }
+}
+
+#[derive(Clone, Default)]
+struct SaveFlowSnapshotRepository {
+    snapshot: Arc<Mutex<Option<TrainingPlanSnapshot>>>,
+}
+
+impl SaveFlowSnapshotRepository {
+    fn new(snapshot: Arc<Mutex<Option<TrainingPlanSnapshot>>>) -> Self {
+        Self { snapshot }
+    }
+}
+
+impl TrainingPlanSnapshotRepository for SaveFlowSnapshotRepository {
+    fn find_by_operation_key(
+        &self,
+        operation_key: &str,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<Option<TrainingPlanSnapshot>, aiwattcoach::domain::training_plan::TrainingPlanError>,
+    > {
+        let snapshot = self
+            .snapshot
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(|snapshot| snapshot.operation_key == operation_key);
+        Box::pin(async move { Ok(snapshot) })
+    }
+}
+
+#[derive(Clone, Default)]
+struct SaveFlowProjectionRepository {
+    days: Arc<Mutex<Vec<TrainingPlanProjectedDay>>>,
+    snapshot: Arc<Mutex<Option<TrainingPlanSnapshot>>>,
+}
+
+impl SaveFlowProjectionRepository {
+    fn new(snapshot: Arc<Mutex<Option<TrainingPlanSnapshot>>>) -> Self {
+        Self {
+            days: Arc::new(Mutex::new(Vec::new())),
+            snapshot,
+        }
+    }
+}
+
+impl TrainingPlanProjectionRepository for SaveFlowProjectionRepository {
+    fn list_active_by_user_id(
+        &self,
+        _user_id: &str,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            Vec<TrainingPlanProjectedDay>,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let days = self.days.lock().unwrap().clone();
+        Box::pin(async move { Ok(days) })
+    }
+
+    fn find_active_by_operation_key(
+        &self,
+        operation_key: &str,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            Vec<TrainingPlanProjectedDay>,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let operation_key = operation_key.to_string();
+        let days = self
+            .days
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|day| day.operation_key == operation_key)
+            .cloned()
+            .collect::<Vec<_>>();
+        Box::pin(async move { Ok(days) })
+    }
+
+    fn find_active_by_user_id_and_operation_key(
+        &self,
+        user_id: &str,
+        operation_key: &str,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            Vec<TrainingPlanProjectedDay>,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let user_id = user_id.to_string();
+        let operation_key = operation_key.to_string();
+        let days = self
+            .days
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|day| day.user_id == user_id && day.operation_key == operation_key)
+            .cloned()
+            .collect::<Vec<_>>();
+        Box::pin(async move { Ok(days) })
+    }
+
+    fn replace_window(
+        &self,
+        snapshot: TrainingPlanSnapshot,
+        projected_days: Vec<TrainingPlanProjectedDay>,
+        _today: &str,
+        _replaced_at_epoch_seconds: i64,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            (TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>),
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let days = self.days.clone();
+        let snapshot_store = self.snapshot.clone();
+        Box::pin(async move {
+            *days.lock().unwrap() = projected_days.clone();
+            *snapshot_store.lock().unwrap() = Some(snapshot.clone());
+            Ok((snapshot, projected_days))
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+struct SaveFlowOperationRepository {
+    operation: Arc<Mutex<Option<TrainingPlanGenerationOperation>>>,
+}
+
+impl TrainingPlanGenerationOperationRepository for SaveFlowOperationRepository {
+    fn find_by_operation_key(
+        &self,
+        operation_key: &str,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            Option<TrainingPlanGenerationOperation>,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let operation = self
+            .operation
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(|operation| operation.operation_key == operation_key);
+        Box::pin(async move { Ok(operation) })
+    }
+
+    fn claim_pending(
+        &self,
+        operation: TrainingPlanGenerationOperation,
+        _stale_before_epoch_seconds: i64,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            TrainingPlanGenerationClaimResult,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let store = self.operation.clone();
+        Box::pin(async move {
+            let mut store = store.lock().unwrap();
+            if let Some(existing) = store.clone() {
+                return Ok(TrainingPlanGenerationClaimResult::Existing(existing));
+            }
+            *store = Some(operation.clone());
+            Ok(TrainingPlanGenerationClaimResult::Claimed(operation))
+        })
+    }
+
+    fn upsert(
+        &self,
+        operation: TrainingPlanGenerationOperation,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<
+            TrainingPlanGenerationOperation,
+            aiwattcoach::domain::training_plan::TrainingPlanError,
+        >,
+    > {
+        let store = self.operation.clone();
+        Box::pin(async move {
+            *store.lock().unwrap() = Some(operation.clone());
+            Ok(operation)
+        })
+    }
+}
+
+#[derive(Clone)]
+struct SaveFlowTrainingPlanGenerator;
+
+impl TrainingPlanGenerator for SaveFlowTrainingPlanGenerator {
+    fn generate_workout_recap(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        saved_at_epoch_seconds: i64,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<WorkoutRecap, aiwattcoach::domain::training_plan::TrainingPlanError>,
+    > {
+        Box::pin(async move {
+            Ok(WorkoutRecap::generated(
+                "Saved workout recap".to_string(),
+                "openrouter".to_string(),
+                "google/gemini-3-flash-preview".to_string(),
+                saved_at_epoch_seconds,
+            ))
+        })
+    }
+
+    fn generate_initial_plan_window(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        _saved_at_epoch_seconds: i64,
+        _workout_recap: &WorkoutRecap,
+        _planning_context: Option<&TrainingPlanPlanningContext>,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<String, aiwattcoach::domain::training_plan::TrainingPlanError>,
+    > {
+        Box::pin(async {
+            Ok((0..14)
+                .map(|offset| {
+                    let day = 15 + offset;
+                    format!("2023-11-{day:02}\nRest Day")
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"))
+        })
+    }
+
+    fn correct_invalid_days(
+        &self,
+        _user_id: &str,
+        _workout_id: &str,
+        _saved_at_epoch_seconds: i64,
+        _workout_recap: &WorkoutRecap,
+        _planning_context: Option<&TrainingPlanPlanningContext>,
+        _invalid_day_sections: &str,
+        _issues: Vec<ValidationIssue>,
+    ) -> aiwattcoach::domain::training_plan::BoxFuture<
+        Result<String, aiwattcoach::domain::training_plan::TrainingPlanError>,
+    > {
+        Box::pin(async { unreachable!("save-flow test does not use corrections") })
+    }
+}


### PR DESCRIPTION
Keep the direct training-plan service as the durable executor while moving saved-workout plan generation onto the shared scheduler. Preserve mark_saved workflow responses, replay semantics, and worker-restart recovery.