### PR TITLE
fix(release): skip tests and push image to GHCR in manual release

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -22,14 +23,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
-        with:
-          toolchain: stable
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Validate version format
         env:
@@ -59,11 +52,24 @@ jobs:
             exit 1
           fi
 
-      - name: Run tests
-        run: cargo test
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4fd846a5fdb9584d32694ef523cf08bff47366d9
 
-      - name: Build Docker image
-        run: docker build -t aiwattcoach:release .
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed25e0003133720d797434d
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198f377371188b
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ inputs.version }}
+            ghcr.io/${{ github.repository }}:latest
 
       - name: Create and push tag
         env:


### PR DESCRIPTION
- Remove cargo test step (already run in CI)
- Remove Rust toolchain/cache steps (not needed for Docker build)
- Add GHCR login and docker/build-push-action
- Push tagged and latest images to ghcr.io
- Add packages:write permission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to publish Docker images to the container registry with version and latest tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->