### PR TITLE
Invalidate cache for calendar and completed workouts after plan generation

### DIFF
--- a/frontend/src/features/calendar/hooks/useCalendarData.test.tsx
+++ b/frontend/src/features/calendar/hooks/useCalendarData.test.tsx
@@ -570,5 +570,4 @@ describe('useCalendarData', () => {
       expect(raceDay.labels[0].payload.priority).toBe('A');
     }
   });
-
 });

--- a/frontend/src/features/calendar/hooks/useCalendarData.ts
+++ b/frontend/src/features/calendar/hooks/useCalendarData.ts
@@ -421,12 +421,9 @@ function pruneWeekKeySet(weekKeys: Set<string>, retainedWeekKeys: Set<string>): 
   return next.size === weekKeys.size ? weekKeys : next;
 }
 
-export function __resetCachesForTesting() {
-  eventsCacheRef.clear();
-  labelsCacheRef.clear();
-}
-
 export function invalidateCalendarCache() {
   eventsCacheRef.clear();
   labelsCacheRef.clear();
 }
+
+export const __resetCachesForTesting = invalidateCalendarCache;

--- a/frontend/src/features/calendar/hooks/useCalendarData.ts
+++ b/frontend/src/features/calendar/hooks/useCalendarData.ts
@@ -425,3 +425,8 @@ export function __resetCachesForTesting() {
   eventsCacheRef.clear();
   labelsCacheRef.clear();
 }
+
+export function invalidateCalendarCache() {
+  eventsCacheRef.clear();
+  labelsCacheRef.clear();
+}

--- a/frontend/src/features/coach/components/CoachPageLayout.test.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.test.tsx
@@ -1,0 +1,251 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../../../i18n';
+import * as calendarHooks from '../../calendar/hooks/useCalendarData';
+import * as useWorkoutListModule from '../hooks/useWorkoutList';
+import * as useCoachChatModule from '../hooks/useCoachChat';
+import type { CoachWorkoutListItem, WorkoutSummary } from '../types';
+import { CoachPageLayout } from './CoachPageLayout';
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+vi.mock('../../intervals/context', () => ({
+  useCompletedWorkouts: vi.fn(),
+  CompletedWorkoutsProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../calendar/hooks/useCalendarData', () => ({
+  invalidateCalendarCache: vi.fn(),
+}));
+
+vi.mock('../hooks/useWorkoutList', () => ({
+  useWorkoutList: vi.fn(),
+}));
+
+vi.mock('../hooks/useCoachChat', () => ({
+  useCoachChat: vi.fn(),
+  isAvailabilityRequiredChatError: vi.fn((error: string | null) => false),
+}));
+
+vi.mock('../../settings/context/SettingsContext', () => ({
+  useSettings: vi.fn(),
+}));
+
+import { useCompletedWorkouts } from '../../intervals/context';
+import { useSettings } from '../../settings/context/SettingsContext';
+
+const originalLocation = window.location;
+const originalOnUnhandledRejection = process.listeners('unhandledRejection');
+
+function createDefaultWorkoutItem(overrides?: Partial<CoachWorkoutListItem>): CoachWorkoutListItem {
+  return {
+    id: 'workout-1',
+    source: 'activity',
+    startDateLocal: '2025-03-10',
+    event: null,
+    activity: {
+      id: 'workout-1',
+      name: 'Test Workout',
+      startDateLocal: '2025-03-10',
+      activityType: 'Ride',
+      durationSeconds: 3600,
+    } as never,
+    summary: null,
+    hasSummary: false,
+    hasConversation: false,
+    ...overrides,
+  };
+}
+
+function createDefaultSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummary {
+  return {
+    id: 'summary-1',
+    workoutId: 'workout-1',
+    rpe: 6,
+    messages: [],
+    savedAtEpochSeconds: null,
+    createdAtEpochSeconds: 1710000000,
+    updatedAtEpochSeconds: 1710000000,
+    ...overrides,
+  };
+}
+
+function setupMocks(options?: {
+  planStatus?: 'generated' | 'skipped' | 'failed' | 'unchanged';
+  saveSummaryError?: Error;
+}) {
+  const invalidateCalendarCache = vi.mocked(calendarHooks.invalidateCalendarCache);
+  const invalidateAll = vi.fn();
+
+  vi.mocked(useCompletedWorkouts).mockReturnValue({
+    getActivitiesForRange: vi.fn().mockResolvedValue([]),
+    invalidateRange: vi.fn(),
+    invalidateAll,
+    isLoading: false,
+    error: null,
+  } as never);
+
+  vi.mocked(useSettings).mockReturnValue({
+    settings: {
+      availability: [
+        { weekday: 'mon', available: true, maxDurationMinutes: 60 },
+        { weekday: 'tue', available: true, maxDurationMinutes: 60 },
+        { weekday: 'wed', available: true, maxDurationMinutes: 60 },
+        { weekday: 'thu', available: true, maxDurationMinutes: 60 },
+        { weekday: 'fri', available: true, maxDurationMinutes: 60 },
+        { weekday: 'sat', available: false, maxDurationMinutes: null },
+        { weekday: 'sun', available: false, maxDurationMinutes: null },
+      ],
+    },
+    isLoading: false,
+    error: null,
+    saveSettings: vi.fn(),
+  } as never);
+
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  const replaceSummary = vi.fn();
+
+  vi.mocked(useWorkoutListModule.useWorkoutList).mockReturnValue({
+    items: [createDefaultWorkoutItem()],
+    state: 'ready',
+    error: null,
+    weekLabel: 'Mar 10 - Mar 16',
+    canGoToNewerWeek: false,
+    goToOlderWeek: vi.fn(),
+    goToNewerWeek: vi.fn(),
+    refresh,
+    replaceSummary,
+  } as never);
+
+  const planStatus = options?.planStatus ?? 'generated';
+
+  vi.mocked(useCoachChatModule.useCoachChat).mockReturnValue({
+    summary: null,
+    messages: [{ id: 'msg-1', role: 'user', content: 'Test message', createdAtEpochSeconds: 1710000000 }],
+    draftRpe: 6,
+    isLoading: false,
+    isSaving: false,
+    isConnected: true,
+    isCoachTyping: false,
+    progressState: 'idle',
+    error: null,
+    hasConversation: true,
+    isSaved: false,
+    setDraftRpe: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(true),
+    saveSummary: options?.saveSummaryError
+      ? vi.fn().mockRejectedValue(options.saveSummaryError)
+      : vi.fn().mockResolvedValue({
+          summary: createDefaultSummary({ savedAtEpochSeconds: 1710000100 }),
+          workflow: {
+            recapStatus: 'generated',
+            planStatus,
+            messages: [],
+          },
+        }),
+    reopenSummary: vi.fn().mockResolvedValue(null),
+  } as never);
+
+  return { invalidateCalendarCache, invalidateAll, refresh, replaceSummary };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  process.removeAllListeners('unhandledRejection');
+  process.on('unhandledRejection', () => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  process.removeAllListeners('unhandledRejection');
+  originalOnUnhandledRejection.forEach((listener) => {
+    process.on('unhandledRejection', listener);
+  });
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+describe('CoachPageLayout', () => {
+  it('invalidates calendar and completed workouts cache after successful save with generated plan', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'generated' });
+
+    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+
+    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(invalidateCalendarCache).toHaveBeenCalledTimes(1);
+    });
+
+    expect(invalidateAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invalidate caches when plan status is skipped', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'skipped' });
+
+    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+
+    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(invalidateCalendarCache).not.toHaveBeenCalled();
+    });
+
+    expect(invalidateAll).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate caches when plan status is failed', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'failed' });
+
+    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+
+    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(invalidateCalendarCache).not.toHaveBeenCalled();
+    });
+
+    expect(invalidateAll).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate caches when plan status is unchanged', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'unchanged' });
+
+    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+
+    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(invalidateCalendarCache).not.toHaveBeenCalled();
+    });
+
+    expect(invalidateAll).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate caches when save fails', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({
+      saveSummaryError: new Error('Network error'),
+    });
+
+    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+
+    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(invalidateCalendarCache).not.toHaveBeenCalled();
+    });
+
+    expect(invalidateAll).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+});

--- a/frontend/src/features/coach/components/CoachPageLayout.test.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.test.tsx
@@ -19,18 +19,14 @@ vi.mock('../../calendar/hooks/useCalendarData', () => ({
   invalidateCalendarCache: vi.fn(),
 }));
 
-vi.mock('../hooks/useWorkoutList', () => ({
-  useWorkoutList: vi.fn(),
-}));
+vi.mock('../hooks/useWorkoutList', () => ({ useWorkoutList: vi.fn() }));
 
 vi.mock('../hooks/useCoachChat', () => ({
   useCoachChat: vi.fn(),
-  isAvailabilityRequiredChatError: vi.fn((error: string | null) => false),
+  isAvailabilityRequiredChatError: vi.fn((_error: string | null) => false),
 }));
 
-vi.mock('../../settings/context/SettingsContext', () => ({
-  useSettings: vi.fn(),
-}));
+vi.mock('../../settings/context/SettingsContext', () => ({ useSettings: vi.fn() }));
 
 import { useCompletedWorkouts } from '../../intervals/context';
 import { useSettings } from '../../settings/context/SettingsContext';
@@ -38,43 +34,40 @@ import { useSettings } from '../../settings/context/SettingsContext';
 const originalLocation = window.location;
 const originalOnUnhandledRejection = process.listeners('unhandledRejection');
 
-function createDefaultWorkoutItem(overrides?: Partial<CoachWorkoutListItem>): CoachWorkoutListItem {
-  return {
-    id: 'workout-1',
-    source: 'activity',
-    startDateLocal: '2025-03-10',
-    event: null,
-    activity: {
-      id: 'workout-1',
-      name: 'Test Workout',
-      startDateLocal: '2025-03-10',
-      activityType: 'Ride',
-      durationSeconds: 3600,
-    } as never,
-    summary: null,
-    hasSummary: false,
-    hasConversation: false,
-    ...overrides,
-  };
-}
+const defaultWorkoutItem = (o?: Partial<CoachWorkoutListItem>): CoachWorkoutListItem => ({
+  id: 'workout-1',
+  source: 'activity',
+  startDateLocal: '2025-03-10',
+  event: null,
+  activity: { id: 'workout-1', name: 'Test Workout', startDateLocal: '2025-03-10', activityType: 'Ride', durationSeconds: 3600 } as never,
+  summary: null,
+  hasSummary: false,
+  hasConversation: false,
+  ...o,
+});
 
-function createDefaultSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummary {
-  return {
-    id: 'summary-1',
-    workoutId: 'workout-1',
-    rpe: 6,
-    messages: [],
-    savedAtEpochSeconds: null,
-    createdAtEpochSeconds: 1710000000,
-    updatedAtEpochSeconds: 1710000000,
-    ...overrides,
-  };
-}
+const defaultSummary = (o?: Partial<WorkoutSummary>): WorkoutSummary => ({
+  id: 'summary-1',
+  workoutId: 'workout-1',
+  rpe: 6,
+  messages: [],
+  savedAtEpochSeconds: null,
+  createdAtEpochSeconds: 1710000000,
+  updatedAtEpochSeconds: 1710000000,
+  ...o,
+});
 
-function setupMocks(options?: {
-  planStatus?: 'generated' | 'skipped' | 'failed' | 'unchanged';
-  saveSummaryError?: Error;
-}) {
+const availability = [
+  { weekday: 'mon', available: true, maxDurationMinutes: 60 },
+  { weekday: 'tue', available: true, maxDurationMinutes: 60 },
+  { weekday: 'wed', available: true, maxDurationMinutes: 60 },
+  { weekday: 'thu', available: true, maxDurationMinutes: 60 },
+  { weekday: 'fri', available: true, maxDurationMinutes: 60 },
+  { weekday: 'sat', available: false, maxDurationMinutes: null },
+  { weekday: 'sun', available: false, maxDurationMinutes: null },
+];
+
+function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | 'unchanged'; saveSummaryError?: Error }) {
   const invalidateCalendarCache = vi.mocked(calendarHooks.invalidateCalendarCache);
   const invalidateAll = vi.fn();
 
@@ -87,38 +80,23 @@ function setupMocks(options?: {
   } as never);
 
   vi.mocked(useSettings).mockReturnValue({
-    settings: {
-      availability: [
-        { weekday: 'mon', available: true, maxDurationMinutes: 60 },
-        { weekday: 'tue', available: true, maxDurationMinutes: 60 },
-        { weekday: 'wed', available: true, maxDurationMinutes: 60 },
-        { weekday: 'thu', available: true, maxDurationMinutes: 60 },
-        { weekday: 'fri', available: true, maxDurationMinutes: 60 },
-        { weekday: 'sat', available: false, maxDurationMinutes: null },
-        { weekday: 'sun', available: false, maxDurationMinutes: null },
-      ],
-    },
+    settings: { availability },
     isLoading: false,
     error: null,
     saveSettings: vi.fn(),
   } as never);
 
-  const refresh = vi.fn().mockResolvedValue(undefined);
-  const replaceSummary = vi.fn();
-
   vi.mocked(useWorkoutListModule.useWorkoutList).mockReturnValue({
-    items: [createDefaultWorkoutItem()],
+    items: [defaultWorkoutItem()],
     state: 'ready',
     error: null,
     weekLabel: 'Mar 10 - Mar 16',
     canGoToNewerWeek: false,
     goToOlderWeek: vi.fn(),
     goToNewerWeek: vi.fn(),
-    refresh,
-    replaceSummary,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    replaceSummary: vi.fn(),
   } as never);
-
-  const planStatus = options?.planStatus ?? 'generated';
 
   vi.mocked(useCoachChatModule.useCoachChat).mockReturnValue({
     summary: null,
@@ -134,20 +112,16 @@ function setupMocks(options?: {
     isSaved: false,
     setDraftRpe: vi.fn(),
     sendMessage: vi.fn().mockResolvedValue(true),
-    saveSummary: options?.saveSummaryError
-      ? vi.fn().mockRejectedValue(options.saveSummaryError)
+    saveSummary: opts?.saveSummaryError
+      ? vi.fn().mockRejectedValue(opts.saveSummaryError)
       : vi.fn().mockResolvedValue({
-          summary: createDefaultSummary({ savedAtEpochSeconds: 1710000100 }),
-          workflow: {
-            recapStatus: 'generated',
-            planStatus,
-            messages: [],
-          },
+          summary: defaultSummary({ savedAtEpochSeconds: 1710000100 }),
+          workflow: { recapStatus: 'generated', planStatus: opts?.planStatus ?? 'generated', messages: [] },
         }),
     reopenSummary: vi.fn().mockResolvedValue(null),
   } as never);
 
-  return { invalidateCalendarCache, invalidateAll, refresh, replaceSummary };
+  return { invalidateCalendarCache, invalidateAll };
 }
 
 beforeEach(() => {
@@ -160,92 +134,43 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   process.removeAllListeners('unhandledRejection');
-  originalOnUnhandledRejection.forEach((listener) => {
-    process.on('unhandledRejection', listener);
-  });
-  Object.defineProperty(window, 'location', {
-    configurable: true,
-    value: originalLocation,
-  });
+  originalOnUnhandledRejection.forEach(l => process.on('unhandledRejection', l));
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
 });
 
 describe('CoachPageLayout', () => {
-  it('invalidates calendar and completed workouts cache after successful save with generated plan', async () => {
+  it('invalidates caches after save with generated plan', async () => {
     const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'generated' });
 
     render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
-    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(invalidateCalendarCache).toHaveBeenCalledTimes(1);
-    });
-
+    await waitFor(() => expect(invalidateCalendarCache).toHaveBeenCalledTimes(1));
     expect(invalidateAll).toHaveBeenCalledTimes(1);
   });
 
-  it('does not invalidate caches when plan status is skipped', async () => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'skipped' });
+  it.each([
+    ['skipped'],
+    ['failed'],
+    ['unchanged'],
+  ])('does not invalidate caches when plan status is %s', async (planStatus) => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: planStatus as never });
 
     render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
-    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(invalidateCalendarCache).not.toHaveBeenCalled();
-    });
-
-    expect(invalidateAll).not.toHaveBeenCalled();
-  });
-
-  it('does not invalidate caches when plan status is failed', async () => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'failed' });
-
-    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
-
-    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(invalidateCalendarCache).not.toHaveBeenCalled();
-    });
-
-    expect(invalidateAll).not.toHaveBeenCalled();
-  });
-
-  it('does not invalidate caches when plan status is unchanged', async () => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'unchanged' });
-
-    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
-
-    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(invalidateCalendarCache).not.toHaveBeenCalled();
-    });
-
+    await waitFor(() => expect(invalidateCalendarCache).not.toHaveBeenCalled());
     expect(invalidateAll).not.toHaveBeenCalled();
   });
 
   it('does not invalidate caches when save fails', async () => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({
-      saveSummaryError: new Error('Network error'),
-    });
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ saveSummaryError: new Error('Network error') });
 
     render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
-    const saveButton = screen.getByRole('button', { name: /save as workout summary/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(invalidateCalendarCache).not.toHaveBeenCalled();
-    });
-
+    await waitFor(() => expect(invalidateCalendarCache).not.toHaveBeenCalled());
     expect(invalidateAll).not.toHaveBeenCalled();
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise(r => setTimeout(r, 50));
   });
 });

--- a/frontend/src/features/coach/components/CoachPageLayout.test.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import '../../../i18n';
@@ -12,7 +13,7 @@ window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
 vi.mock('../../intervals/context', () => ({
   useCompletedWorkouts: vi.fn(),
-  CompletedWorkoutsProvider: ({ children }: { children: React.ReactNode }) => children,
+  CompletedWorkoutsProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
 vi.mock('../../calendar/hooks/useCalendarData', () => ({
@@ -23,7 +24,7 @@ vi.mock('../hooks/useWorkoutList', () => ({ useWorkoutList: vi.fn() }));
 
 vi.mock('../hooks/useCoachChat', () => ({
   useCoachChat: vi.fn(),
-  isAvailabilityRequiredChatError: vi.fn((_error: string | null) => false),
+  isAvailabilityRequiredChatError: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock('../../settings/context/SettingsContext', () => ({ useSettings: vi.fn() }));
@@ -32,7 +33,6 @@ import { useCompletedWorkouts } from '../../intervals/context';
 import { useSettings } from '../../settings/context/SettingsContext';
 
 const originalLocation = window.location;
-const originalOnUnhandledRejection = process.listeners('unhandledRejection');
 
 const defaultWorkoutItem = (o?: Partial<CoachWorkoutListItem>): CoachWorkoutListItem => ({
   id: 'workout-1',
@@ -67,9 +67,11 @@ const availability = [
   { weekday: 'sun', available: false, maxDurationMinutes: null },
 ];
 
-function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | 'unchanged'; saveSummaryError?: Error }) {
+function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | 'unchanged'; saveSummaryResult?: unknown }) {
   const invalidateCalendarCache = vi.mocked(calendarHooks.invalidateCalendarCache);
   const invalidateAll = vi.fn();
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  const replaceSummary = vi.fn();
 
   vi.mocked(useCompletedWorkouts).mockReturnValue({
     getActivitiesForRange: vi.fn().mockResolvedValue([]),
@@ -94,8 +96,8 @@ function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | '
     canGoToNewerWeek: false,
     goToOlderWeek: vi.fn(),
     goToNewerWeek: vi.fn(),
-    refresh: vi.fn().mockResolvedValue(undefined),
-    replaceSummary: vi.fn(),
+    refresh,
+    replaceSummary,
   } as never);
 
   vi.mocked(useCoachChatModule.useCoachChat).mockReturnValue({
@@ -112,8 +114,8 @@ function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | '
     isSaved: false,
     setDraftRpe: vi.fn(),
     sendMessage: vi.fn().mockResolvedValue(true),
-    saveSummary: opts?.saveSummaryError
-      ? vi.fn().mockRejectedValue(opts.saveSummaryError)
+    saveSummary: opts?.saveSummaryResult !== undefined
+      ? vi.fn().mockResolvedValue(opts.saveSummaryResult)
       : vi.fn().mockResolvedValue({
           summary: defaultSummary({ savedAtEpochSeconds: 1710000100 }),
           workflow: { recapStatus: 'generated', planStatus: opts?.planStatus ?? 'generated', messages: [] },
@@ -121,20 +123,16 @@ function setupMocks(opts?: { planStatus?: 'generated' | 'skipped' | 'failed' | '
     reopenSummary: vi.fn().mockResolvedValue(null),
   } as never);
 
-  return { invalidateCalendarCache, invalidateAll };
+  return { invalidateCalendarCache, invalidateAll, refresh, replaceSummary };
 }
 
 beforeEach(() => {
   vi.resetModules();
-  process.removeAllListeners('unhandledRejection');
-  process.on('unhandledRejection', () => {});
 });
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
-  process.removeAllListeners('unhandledRejection');
-  originalOnUnhandledRejection.forEach(l => process.on('unhandledRejection', l));
   Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
 });
 
@@ -154,23 +152,23 @@ describe('CoachPageLayout', () => {
     ['failed'],
     ['unchanged'],
   ])('does not invalidate caches when plan status is %s', async (planStatus) => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: planStatus as never });
+    const { invalidateCalendarCache, invalidateAll, refresh } = setupMocks({ planStatus: planStatus as never });
 
     render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
     fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
-    await waitFor(() => expect(invalidateCalendarCache).not.toHaveBeenCalled());
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+    expect(invalidateCalendarCache).not.toHaveBeenCalled();
     expect(invalidateAll).not.toHaveBeenCalled();
   });
 
-  it('does not invalidate caches when save fails', async () => {
-    const { invalidateCalendarCache, invalidateAll } = setupMocks({ saveSummaryError: new Error('Network error') });
+  it('does not invalidate caches when save returns null', async () => {
+    const { invalidateCalendarCache, invalidateAll } = setupMocks({ saveSummaryResult: null });
 
     render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
     fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
     await waitFor(() => expect(invalidateCalendarCache).not.toHaveBeenCalled());
     expect(invalidateAll).not.toHaveBeenCalled();
-    await new Promise(r => setTimeout(r, 50));
   });
 });

--- a/frontend/src/features/coach/components/CoachPageLayout.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.tsx
@@ -88,7 +88,7 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
     const result = await chat.saveSummary();
 
     if (result && isCurrentSelection(workoutId)) {
-      workoutList.replaceSummary(result);
+      workoutList.replaceSummary(result.summary);
       setIsEditing(false);
       setShowConfirmWithoutChat(false);
       await workoutList.refresh();

--- a/frontend/src/features/coach/components/CoachPageLayout.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { invalidateCalendarCache } from '../../calendar/hooks/useCalendarData';
+import { useCompletedWorkouts } from '../../intervals/context';
 import { useSettings } from '../../settings/context/SettingsContext';
 import { isAvailabilityConfigured } from '../../settings/types';
 import { useWorkoutList } from '../hooks/useWorkoutList';
@@ -21,6 +23,7 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
   const { t } = useTranslation();
   const settingsContext = useSettings();
   const workoutList = useWorkoutList({ apiBaseUrl });
+  const completedWorkouts = useCompletedWorkouts();
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null);
   const [showConfirmWithoutChat, setShowConfirmWithoutChat] = useState(false);
   const [isEditing, setIsEditing] = useState(true);
@@ -89,6 +92,11 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
       setIsEditing(false);
       setShowConfirmWithoutChat(false);
       await workoutList.refresh();
+
+      if (result.workflow.planStatus === 'generated') {
+        invalidateCalendarCache();
+        completedWorkouts.invalidateAll();
+      }
     }
   }
 

--- a/frontend/src/features/coach/hooks/useCoachChat.ts
+++ b/frontend/src/features/coach/hooks/useCoachChat.ts
@@ -13,6 +13,7 @@ import {
   type CoachChatProgressState,
   serverWsMessageSchema,
   type ConversationMessage,
+  type SaveWorkoutSummaryResponse,
   type WorkoutSummary,
 } from '../types';
 
@@ -35,7 +36,7 @@ type UseCoachChatResult = {
   isSaved: boolean;
   setDraftRpe: (rpe: number) => void;
   sendMessage: (content: string) => Promise<boolean>;
-  saveSummary: () => Promise<WorkoutSummary | null>;
+  saveSummary: () => Promise<SaveWorkoutSummaryResponse | null>;
   reopenSummary: () => Promise<WorkoutSummary | null>;
 };
 
@@ -436,7 +437,7 @@ export function useCoachChat({ apiBaseUrl, workoutId }: UseCoachChatOptions): Us
           ];
         });
       }
-      return nextSummary;
+      return saveResult;
     } catch (saveError) {
       if (saveError instanceof StaleWorkoutSelectionError) {
         return null;


### PR DESCRIPTION
Add invalidateCalendarCache() export in useCalendarData hook and call it alongside completedWorkouts.invalidateAll() in CoachPageLayout after successful saveSummary() when workflow.planStatus === 'generated'.

Add CoachPageLayout.test.tsx with 5 tests covering cache invalidation for generated plan status and no invalidation for skipped/failed/unchanged statuses or save errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar and completed workouts data now automatically refresh after successfully saving a new workout summary in the coach view, ensuring users see the latest information.

* **Tests**
  * Added comprehensive test coverage for the "Save as workout summary" button, verifying proper cache refresh behavior across different workflow plan statuses and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->