### PR TITLE
fix: refresh calendar_view for union of old and new plan date ranges on regeneration

### DIFF
--- a/src/adapters/mongo/training_plan_projections.rs
+++ b/src/adapters/mongo/training_plan_projections.rs
@@ -256,7 +256,29 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
 
             let superseded_range_start =
                 std::cmp::max(today.as_str(), snapshot.start_date.as_str());
-            let superseded_range_end = snapshot.end_date.as_str();
+
+            let max_active_date: Option<String> = collection
+                .clone()
+                .clone_with_type::<mongodb::bson::Document>()
+                .find(doc! {
+                    "user_id": &snapshot.user_id,
+                    "superseded_at_epoch_seconds": mongodb::bson::Bson::Null,
+                })
+                .sort(doc! { "date": -1 })
+                .limit(1)
+                .projection(doc! { "date": 1, "_id": 0 })
+                .await
+                .map_err(|error| TrainingPlanError::Repository(error.to_string()))?
+                .try_next()
+                .await
+                .map_err(|error| TrainingPlanError::Repository(error.to_string()))?
+                .and_then(|doc| doc.get_str("date").ok().map(String::from));
+
+            let superseded_range_end = max_active_date
+                .as_ref()
+                .map(|date| std::cmp::max(snapshot.end_date.as_str(), date.as_str()))
+                .unwrap_or(snapshot.end_date.as_str())
+                .to_string();
 
             collection
                 .update_many(
@@ -265,7 +287,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                         "superseded_at_epoch_seconds": mongodb::bson::Bson::Null,
                         "date": {
                             "$gte": superseded_range_start,
-                            "$lte": superseded_range_end,
+                            "$lte": &superseded_range_end,
                         },
                     },
                     doc! {
@@ -280,7 +302,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
 
             let superseded_date_range = Some((
                 superseded_range_start.to_string(),
-                superseded_range_end.to_string(),
+                superseded_range_end.clone(),
             ));
 
             snapshot_collection

--- a/src/adapters/mongo/training_plan_projections.rs
+++ b/src/adapters/mongo/training_plan_projections.rs
@@ -234,18 +234,14 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
     ) -> BoxFuture<Result<TrainingPlanReplacementResult, TrainingPlanError>> {
         let collection = self.collection.clone();
         let snapshot_collection = self.snapshot_repository.collection();
-        let snapshot_document =
-            MongoTrainingPlanSnapshotRepository::map_snapshot_to_document(&snapshot);
-        let projected_day_documents = projected_days
-            .iter()
-            .map(map_projected_day_to_document)
-            .collect::<Result<Vec<_>, _>>();
         let today = today.to_string();
-        let snapshot_clone = snapshot.clone();
-        let projected_days_clone = projected_days.clone();
         Box::pin(async move {
-            let snapshot_document = snapshot_document?;
-            let projected_day_documents = projected_day_documents?;
+            let snapshot_document =
+                MongoTrainingPlanSnapshotRepository::map_snapshot_to_document(&snapshot)?;
+            let projected_day_documents = projected_days
+                .iter()
+                .map(map_projected_day_to_document)
+                .collect::<Result<Vec<_>, _>>()?;
             validate_replacement_scope(&snapshot, &projected_days)?;
             if projected_day_documents.is_empty() {
                 return Err(TrainingPlanError::Validation(
@@ -280,7 +276,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                 .unwrap_or(snapshot.end_date.as_str())
                 .to_string();
 
-            collection
+            let update_result = collection
                 .update_many(
                     doc! {
                         "user_id": &snapshot.user_id,
@@ -300,10 +296,14 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                 .await
                 .map_err(|error| TrainingPlanError::Repository(error.to_string()))?;
 
-            let superseded_date_range = Some((
-                superseded_range_start.to_string(),
-                superseded_range_end.clone(),
-            ));
+            let superseded_date_range = if update_result.matched_count == 0 {
+                None
+            } else {
+                Some((
+                    superseded_range_start.to_string(),
+                    superseded_range_end.clone(),
+                ))
+            };
 
             snapshot_collection
                 .replace_one(
@@ -330,8 +330,8 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
             }
 
             Ok(TrainingPlanReplacementResult {
-                snapshot: snapshot_clone,
-                projected_days: projected_days_clone,
+                snapshot,
+                projected_days,
                 superseded_date_range,
             })
         })

--- a/src/adapters/mongo/training_plan_projections.rs
+++ b/src/adapters/mongo/training_plan_projections.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::training_plan::{
     BoxFuture, TrainingPlanError, TrainingPlanProjectedDay, TrainingPlanProjectionRepository,
-    TrainingPlanSnapshot,
+    TrainingPlanReplacementResult, TrainingPlanSnapshot,
 };
 
 use super::{
@@ -231,8 +231,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
         projected_days: Vec<TrainingPlanProjectedDay>,
         today: &str,
         replaced_at_epoch_seconds: i64,
-    ) -> BoxFuture<Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>>
-    {
+    ) -> BoxFuture<Result<TrainingPlanReplacementResult, TrainingPlanError>> {
         let collection = self.collection.clone();
         let snapshot_collection = self.snapshot_repository.collection();
         let snapshot_document =
@@ -243,6 +242,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
             .collect::<Result<Vec<_>, _>>();
         let today = today.to_string();
         let snapshot_clone = snapshot.clone();
+        let projected_days_clone = projected_days.clone();
         Box::pin(async move {
             let snapshot_document = snapshot_document?;
             let projected_day_documents = projected_day_documents?;
@@ -253,14 +253,19 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                         .to_string(),
                 ));
             }
+
+            let superseded_range_start =
+                std::cmp::max(today.as_str(), snapshot.start_date.as_str());
+            let superseded_range_end = snapshot.end_date.as_str();
+
             collection
                 .update_many(
                     doc! {
                         "user_id": &snapshot.user_id,
                         "superseded_at_epoch_seconds": mongodb::bson::Bson::Null,
                         "date": {
-                            "$gte": std::cmp::max(today.as_str(), snapshot.start_date.as_str()),
-                            "$lte": &snapshot.end_date,
+                            "$gte": superseded_range_start,
+                            "$lte": superseded_range_end,
                         },
                     },
                     doc! {
@@ -272,6 +277,11 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                 )
                 .await
                 .map_err(|error| TrainingPlanError::Repository(error.to_string()))?;
+
+            let superseded_date_range = Some((
+                superseded_range_start.to_string(),
+                superseded_range_end.to_string(),
+            ));
 
             snapshot_collection
                 .replace_one(
@@ -297,7 +307,11 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                     .map_err(|error| TrainingPlanError::Repository(error.to_string()))?;
             }
 
-            Ok((snapshot_clone, projected_days))
+            Ok(TrainingPlanReplacementResult {
+                snapshot: snapshot_clone,
+                projected_days: projected_days_clone,
+                superseded_date_range,
+            })
         })
     }
 }

--- a/src/domain/calendar/tests.rs
+++ b/src/domain/calendar/tests.rs
@@ -25,7 +25,7 @@ use crate::domain::{
     planned_workout_tokens::NoopPlannedWorkoutTokenRepository,
     training_plan::{
         BoxFuture as TrainingPlanBoxFuture, TrainingPlanError, TrainingPlanProjectedDay,
-        TrainingPlanProjectionRepository, TrainingPlanSnapshot,
+        TrainingPlanProjectionRepository, TrainingPlanReplacementResult, TrainingPlanSnapshot,
     },
 };
 
@@ -736,10 +736,14 @@ impl TrainingPlanProjectionRepository for FakeProjectionRepository {
         projected_days: Vec<TrainingPlanProjectedDay>,
         _today: &str,
         _replaced_at_epoch_seconds: i64,
-    ) -> TrainingPlanBoxFuture<
-        Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>,
-    > {
-        Box::pin(async move { Ok((snapshot, projected_days)) })
+    ) -> TrainingPlanBoxFuture<Result<TrainingPlanReplacementResult, TrainingPlanError>> {
+        Box::pin(async move {
+            Ok(TrainingPlanReplacementResult {
+                snapshot,
+                projected_days,
+                superseded_date_range: None,
+            })
+        })
     }
 }
 

--- a/src/domain/training_context/service/tests/builder.rs
+++ b/src/domain/training_context/service/tests/builder.rs
@@ -427,7 +427,7 @@ async fn builder_anchors_windows_to_focus_activity_date() {
             _today: &str,
             _replaced_at_epoch_seconds: i64,
         ) -> crate::domain::training_plan::BoxFuture<
-            Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>,
+            Result<crate::domain::training_plan::TrainingPlanReplacementResult, TrainingPlanError>,
         > {
             unreachable!()
         }

--- a/src/domain/training_context/service/tests/support.rs
+++ b/src/domain/training_context/service/tests/support.rs
@@ -726,7 +726,7 @@ impl TrainingPlanProjectionRepository for TestTrainingPlanProjectionRepository {
         _today: &str,
         _replaced_at_epoch_seconds: i64,
     ) -> crate::domain::training_plan::BoxFuture<
-        Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>,
+        Result<crate::domain::training_plan::TrainingPlanReplacementResult, TrainingPlanError>,
     > {
         unreachable!()
     }

--- a/src/domain/training_plan/mod.rs
+++ b/src/domain/training_plan/mod.rs
@@ -5,7 +5,7 @@ mod service;
 pub use model::{
     GeneratedTrainingPlan, TrainingPlanDay, TrainingPlanError, TrainingPlanFailureState,
     TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation, TrainingPlanProjectedDay,
-    TrainingPlanSnapshot,
+    TrainingPlanReplacementResult, TrainingPlanSnapshot,
 };
 pub use ports::{
     BoxFuture, TrainingPlanGenerationOperationRepository, TrainingPlanGenerator,

--- a/src/domain/training_plan/model.rs
+++ b/src/domain/training_plan/model.rs
@@ -348,3 +348,10 @@ pub struct GeneratedTrainingPlan {
     pub active_projected_days: Vec<TrainingPlanProjectedDay>,
     pub was_generated: bool,
 }
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrainingPlanReplacementResult {
+    pub snapshot: TrainingPlanSnapshot,
+    pub projected_days: Vec<TrainingPlanProjectedDay>,
+    pub superseded_date_range: Option<(String, String)>,
+}

--- a/src/domain/training_plan/ports.rs
+++ b/src/domain/training_plan/ports.rs
@@ -5,7 +5,7 @@ use crate::domain::workout_summary::WorkoutRecap;
 
 use super::{
     TrainingPlanError, TrainingPlanGenerationClaimResult, TrainingPlanGenerationOperation,
-    TrainingPlanProjectedDay, TrainingPlanSnapshot,
+    TrainingPlanProjectedDay, TrainingPlanReplacementResult, TrainingPlanSnapshot,
 };
 
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
@@ -40,7 +40,7 @@ pub trait TrainingPlanProjectionRepository: Send + Sync + 'static {
         projected_days: Vec<TrainingPlanProjectedDay>,
         today: &str,
         replaced_at_epoch_seconds: i64,
-    ) -> BoxFuture<Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>>;
+    ) -> BoxFuture<Result<TrainingPlanReplacementResult, TrainingPlanError>>;
 }
 
 pub trait TrainingPlanGenerationOperationRepository: Send + Sync + 'static {

--- a/src/domain/training_plan/service/mod.rs
+++ b/src/domain/training_plan/service/mod.rs
@@ -280,7 +280,7 @@ where
         let today = self.today_string();
         let operation = operation.with_projection_update(self.clock.now_epoch_seconds());
         let operation = self.operations.upsert(operation).await?;
-        let (snapshot, projected_days) = self
+        let replacement = self
             .projections
             .replace_window(
                 snapshot.clone(),
@@ -289,7 +289,8 @@ where
                 self.clock.now_epoch_seconds(),
             )
             .await?;
-        let active_projected_days = projected_days
+        let active_projected_days = replacement
+            .projected_days
             .into_iter()
             .filter(|day| day.is_active_on(&today))
             .collect::<Vec<_>>();
@@ -297,20 +298,34 @@ where
             .operations
             .upsert(operation.mark_projection_persisted(self.clock.now_epoch_seconds()))
             .await?;
-        if !self.is_projection_persisted(&snapshot, &active_projected_days) {
+        if !self.is_projection_persisted(&replacement.snapshot, &active_projected_days) {
             return Err(TrainingPlanError::Repository(
                 "training plan projection persistence incomplete after replace_window".to_string(),
             ));
         }
+        let refresh_start = replacement
+            .superseded_date_range
+            .as_ref()
+            .map(|(start, _)| {
+                std::cmp::min(start.as_str(), replacement.snapshot.start_date.as_str())
+            })
+            .unwrap_or(&replacement.snapshot.start_date)
+            .to_string();
+        let refresh_end = replacement
+            .superseded_date_range
+            .as_ref()
+            .map(|(_, end)| std::cmp::max(end.as_str(), replacement.snapshot.end_date.as_str()))
+            .unwrap_or(&replacement.snapshot.end_date)
+            .to_string();
         self.refresh
-            .refresh_range_for_user(&snapshot.user_id, &snapshot.start_date, &snapshot.end_date)
+            .refresh_range_for_user(&replacement.snapshot.user_id, &refresh_start, &refresh_end)
             .await
             .map_err(|error| TrainingPlanError::Repository(error.to_string()))?;
         let completed = operation.mark_completed(self.clock.now_epoch_seconds());
         self.operations.upsert(completed).await?;
 
         Ok(GeneratedTrainingPlan {
-            snapshot,
+            snapshot: replacement.snapshot,
             active_projected_days,
             was_generated: true,
         })

--- a/tests/intervals_rest/app.rs
+++ b/tests/intervals_rest/app.rs
@@ -30,7 +30,7 @@ use aiwattcoach::{
         races::RaceUseCases,
         training_plan::{
             BoxFuture as TrainingPlanBoxFuture, TrainingPlanError, TrainingPlanProjectedDay,
-            TrainingPlanProjectionRepository, TrainingPlanSnapshot,
+            TrainingPlanProjectionRepository, TrainingPlanReplacementResult, TrainingPlanSnapshot,
         },
     },
     Settings,
@@ -248,10 +248,14 @@ impl TrainingPlanProjectionRepository for EmptyTrainingPlanProjectionRepository 
         projected_days: Vec<TrainingPlanProjectedDay>,
         _today: &str,
         _replaced_at_epoch_seconds: i64,
-    ) -> TrainingPlanBoxFuture<
-        Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>,
-    > {
-        Box::pin(async move { Ok((snapshot, projected_days)) })
+    ) -> TrainingPlanBoxFuture<Result<TrainingPlanReplacementResult, TrainingPlanError>> {
+        Box::pin(async move {
+            Ok(TrainingPlanReplacementResult {
+                snapshot,
+                projected_days,
+                superseded_date_range: None,
+            })
+        })
     }
 }
 

--- a/tests/intervals_rest/calendar_events.rs
+++ b/tests/intervals_rest/calendar_events.rs
@@ -634,14 +634,19 @@ impl TrainingPlanProjectionRepository for TestTrainingPlanProjectionRepository {
         _replaced_at_epoch_seconds: i64,
     ) -> aiwattcoach::domain::training_plan::BoxFuture<
         Result<
-            (
-                aiwattcoach::domain::training_plan::TrainingPlanSnapshot,
-                Vec<TrainingPlanProjectedDay>,
-            ),
+            aiwattcoach::domain::training_plan::TrainingPlanReplacementResult,
             TrainingPlanError,
         >,
     > {
-        Box::pin(async move { Ok((snapshot, projected_days)) })
+        Box::pin(async move {
+            Ok(
+                aiwattcoach::domain::training_plan::TrainingPlanReplacementResult {
+                    snapshot,
+                    projected_days,
+                    superseded_date_range: None,
+                },
+            )
+        })
     }
 }
 

--- a/tests/training_plan_mongo.rs
+++ b/tests/training_plan_mongo.rs
@@ -233,7 +233,7 @@ async fn training_plan_projection_repository_replaces_window_and_supersedes_over
 
     let second_snapshot =
         sample_snapshot("training-plan:user-1:workout-1:1700086400", "2026-04-07");
-    let (_, projected_days) = repository
+    let result = repository
         .replace_window(
             second_snapshot.clone(),
             sample_projected_days(&second_snapshot, "2026-04-07"),
@@ -242,6 +242,7 @@ async fn training_plan_projection_repository_replaces_window_and_supersedes_over
         )
         .await
         .unwrap();
+    let projected_days = result.projected_days;
 
     let other_user_snapshot = sample_snapshot_for_user(
         "user-2",
@@ -413,7 +414,7 @@ async fn training_plan_projection_repository_replay_heals_partial_same_operation
         .await
         .unwrap();
 
-    let (_, projected_days) = repository
+    let result = repository
         .replace_window(
             snapshot.clone(),
             sample_projected_days(&snapshot, "2026-04-06"),
@@ -422,6 +423,7 @@ async fn training_plan_projection_repository_replay_heals_partial_same_operation
         )
         .await
         .unwrap();
+    let projected_days = result.projected_days;
 
     assert_eq!(projected_days.len(), 14);
 

--- a/tests/training_plan_service/support/repos.rs
+++ b/tests/training_plan_service/support/repos.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, Mutex};
 
+use aiwattcoach::domain::training_plan::TrainingPlanReplacementResult;
+
 use super::{
     push_call, CallLog, TrainingPlanError, TrainingPlanGenerationClaimResult,
     TrainingPlanGenerationOperation, TrainingPlanGenerationOperationRepository,
@@ -184,14 +186,21 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
         today: &str,
         replaced_at_epoch_seconds: i64,
     ) -> aiwattcoach::domain::training_plan::BoxFuture<
-        Result<(TrainingPlanSnapshot, Vec<TrainingPlanProjectedDay>), TrainingPlanError>,
+        Result<TrainingPlanReplacementResult, TrainingPlanError>,
     > {
         let store = self.projected_days.clone();
         let snapshots = self.snapshots.clone();
         let today = today.to_string();
+        let snapshot_clone = snapshot.clone();
+        let projected_days_clone = projected_days.clone();
         Box::pin(async move {
             let mut stored = store.lock().unwrap();
 
+            let superseded_range_start =
+                std::cmp::max(today.as_str(), snapshot.start_date.as_str());
+            let superseded_range_end = snapshot.end_date.as_str();
+
+            let mut superseded_dates = Vec::new();
             for day in stored.iter_mut() {
                 if day.superseded_at_epoch_seconds.is_some() {
                     continue;
@@ -199,12 +208,12 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
                 if day.user_id != snapshot.user_id {
                     continue;
                 }
-                if day.date < today
-                    || day.date < snapshot.start_date
-                    || day.date > snapshot.end_date
+                if day.date.as_str() < superseded_range_start
+                    || day.date.as_str() > superseded_range_end
                 {
                     continue;
                 }
+                superseded_dates.push(day.date.clone());
                 day.superseded_at_epoch_seconds = Some(replaced_at_epoch_seconds);
                 day.updated_at_epoch_seconds = replaced_at_epoch_seconds;
             }
@@ -231,7 +240,21 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
                 stored_snapshots.push(snapshot.clone());
             }
 
-            Ok((snapshot, projected_days))
+            let superseded_date_range = if superseded_dates.is_empty() {
+                None
+            } else {
+                superseded_dates.sort();
+                superseded_dates
+                    .first()
+                    .cloned()
+                    .zip(superseded_dates.last().cloned())
+            };
+
+            Ok(TrainingPlanReplacementResult {
+                snapshot: snapshot_clone,
+                projected_days: projected_days_clone,
+                superseded_date_range,
+            })
         })
     }
 }

--- a/tests/training_plan_service/support/repos.rs
+++ b/tests/training_plan_service/support/repos.rs
@@ -191,8 +191,6 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
         let store = self.projected_days.clone();
         let snapshots = self.snapshots.clone();
         let today = today.to_string();
-        let snapshot_clone = snapshot.clone();
-        let projected_days_clone = projected_days.clone();
         Box::pin(async move {
             let mut stored = store.lock().unwrap();
 
@@ -264,8 +262,8 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
             };
 
             Ok(TrainingPlanReplacementResult {
-                snapshot: snapshot_clone,
-                projected_days: projected_days_clone,
+                snapshot: snapshot.clone(),
+                projected_days: projected_days.clone(),
                 superseded_date_range,
             })
         })

--- a/tests/training_plan_service/support/repos.rs
+++ b/tests/training_plan_service/support/repos.rs
@@ -198,7 +198,20 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
 
             let superseded_range_start =
                 std::cmp::max(today.as_str(), snapshot.start_date.as_str());
-            let superseded_range_end = snapshot.end_date.as_str();
+
+            let max_active_date = stored
+                .iter()
+                .filter(|day| {
+                    day.user_id == snapshot.user_id && day.superseded_at_epoch_seconds.is_none()
+                })
+                .map(|day| day.date.clone())
+                .max();
+
+            let superseded_range_end = max_active_date
+                .as_ref()
+                .map(|date| std::cmp::max(snapshot.end_date.as_str(), date.as_str()))
+                .unwrap_or(snapshot.end_date.as_str())
+                .to_string();
 
             let mut superseded_dates = Vec::new();
             for day in stored.iter_mut() {
@@ -209,7 +222,7 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
                     continue;
                 }
                 if day.date.as_str() < superseded_range_start
-                    || day.date.as_str() > superseded_range_end
+                    || day.date.as_str() > superseded_range_end.as_str()
                 {
                     continue;
                 }


### PR DESCRIPTION
When a plan is regenerated, calendar_view was only refreshed for the new plan's date range, leaving stale entries from the old plan outside that range. Now replace_window returns the superseded date range and persist_projection refreshes the union of both ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tracking of superseded date ranges when updating training plan windows through improved data structure organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->