### PR TITLE
Enable request body logging for all write endpoints with PII redaction

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -7,7 +7,7 @@ This document explains how to add logging for new REST endpoints and new externa
 - Keep logs structured and consistent.
 - Preserve trace propagation.
 - Default to low-risk logging for request and response bodies.
-- Redact secrets before they reach logs.
+- Redact secrets and PII before they reach logs.
 - Put transport logging in adapters, not domain code.
 
 ## REST Endpoint Logging
@@ -27,6 +27,27 @@ Main pieces:
 - `ENABLE_ENDPOINT_BODY_LOGGING=true` changes that default to `EndpointLogConfig::full()`.
 - Route-specific `with_log_config(...)` is authoritative and overrides the default config.
 
+### Write endpoint group
+
+All write endpoints (POST, PUT, PATCH) and read endpoints that benefit from observability are grouped into a sub-Router with `RequestLogLayer` and `EndpointLogConfig::request_only()`.
+
+Routes excluded from body logging:
+
+| Route | Reason |
+|---|---|
+| `/api/auth/google/start`, `/api/auth/google/callback` | Login redirects, no useful body |
+| `/api/auth/wahoo/start`, `/api/wahoo/callback` | Login redirects, no useful body |
+| `/api/auth/logout` | Logout, no request body |
+| `/api/auth/me` | Session cookie only, no body |
+| `/api/logs` | Circular risk — logging about incoming logs |
+| `/api/intervals/activities` POST | 16 MB file upload, impractical to buffer |
+| `/api/workout-summaries/{id}/ws` | WebSocket, not buffered by RequestLogLayer |
+| `/health`, `/ready` | Health checks, no body |
+
+The `/api/settings` GET route uses a separate group with `response_only()` logging because its response contains API keys and connection status that need redacted observability.
+
+When adding a new write endpoint, add it to the existing write group sub-Router in `router_with_frontend_dist()` so it gets request body logging automatically.
+
 ### When to enable endpoint body logging
 
 Use body logging only when the route needs extra observability and the payload shape is safe enough after redaction.
@@ -41,7 +62,9 @@ Always set a route-specific preview cap with `with_max_body_bytes(...)` when bod
 
 ### Body limits
 
-`with_max_body_bytes(...)` only limits what is written to logs. It does not limit how much of the request body the transport accepts.
+`with_max_body_bytes(...)` only limits what is written to logs. It does not limit how much of the request body the transport accepts. The default is 10 KB (10240 bytes).
+
+The `RequestLogLayer` has a hard cap of 10 MB (`MAX_COLLECT_BYTES`) on how much body it will buffer. This prevents unbounded memory allocation when a route with body logging enabled receives an unexpectedly large payload. Routes that accept genuinely large bodies (like file uploads) should be excluded from body logging entirely, as buffering multi-megabyte payloads is impractical.
 
 If `RequestLogLayer` can buffer the request body, also add a transport-level limit such as `DefaultBodyLimit::max(...)` before the logging layer.
 
@@ -79,6 +102,31 @@ let router = Router::new()
 - Sensitive headers are redacted by name.
 - Binary and non-JSON textual bodies are summarized instead of logged raw in the REST adapter.
 - If a route handles secrets or large uploads, prefer request-only or response-only logging, or leave body logging off.
+
+Sensitive key patterns (checked case-insensitively by `is_sensitive_key` in `src/telemetry.rs`):
+
+| Pattern | Catches | Examples |
+|---|---|---|
+| `password` | passwords | `password`, `db_password` |
+| `secret` | secrets | `client_secret`, `secret` |
+| `token` | tokens | `access_token`, `refreshToken` |
+| `username` | usernames | `username` |
+| `api_key`, `api-key`, `apikey` | API keys | `apiKey`, `x-api-key` |
+| `user` (exact) or `_user` suffix | user identifiers | `user`, `db_user` |
+| `email` | emails | `email`, `userEmail` |
+| `medication` | health data | `medications` |
+| `fullname` or `full_name` | real names | `fullName` |
+| `age` (exact) | age | `age` |
+| `weight` | body weight | `weightKg`, `weight_kg` |
+| `height` | height | `heightCm`, `height_cm` |
+| `hrmax` or `hr_max` | max heart rate | `hrMaxBpm`, `hr_max_bpm` |
+| `vo2max` or `vo2_max` | VO2 max | `vo2Max`, `vo2_max` |
+| `athlete_notes` or `athletenotes` | personal notes | `athleteNotes` |
+| `athlete_prompt` or `athleteprompt` | personal prompts | `athletePrompt` |
+| `athleteid` or `athlete_id` | third-party IDs | `athleteId` |
+| `content` (exact) | message content | `content` |
+| `message` (exact) | log/chat messages | `message` |
+| `filecontent` or `file_content` | binary payloads | `fileContents`, `fileContentsBase64` |
 
 ### Endpoint checklist
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -44,9 +44,15 @@ Routes excluded from body logging:
 | `/api/workout-summaries/{id}/ws` | WebSocket, not buffered by RequestLogLayer |
 | `/health`, `/ready` | Health checks, no body |
 
+Note: `/api/auth/whitelist` POST is included in the write group. Its `email` field is redacted by `is_sensitive_key`.
+
 The `/api/settings` GET route uses a separate group with `response_only()` logging because its response contains API keys and connection status that need redacted observability.
 
 When adding a new write endpoint, add it to the existing write group sub-Router in `router_with_frontend_dist()` so it gets request body logging automatically.
+
+GET routes inside the write group skip request body collection because `RequestLogService` only buffers the body for POST, PUT, and PATCH methods. Response body logging is controlled by the `EndpointLogConfig`; the write group uses `request_only()` so response bodies are not logged for those routes.
+
+The `DefaultBodyLimit` on a route inside a sub-Router with `RequestLogLayer` only bounds the handler's body limit, not the logger's buffer. The logger caps its own buffer at `MAX_COLLECT_BYTES` (10 MB). For routes that need a tighter transport limit (e.g. `/api/settings/intervals/test` with 8 KB), that limit protects the handler but the logger may still buffer up to 10 MB of the request before the handler sees it.
 
 ### When to enable endpoint body logging
 
@@ -115,17 +121,17 @@ Sensitive key patterns (checked case-insensitively by `is_sensitive_key` in `src
 | `user` (exact) or `_user` suffix | user identifiers | `user`, `db_user` |
 | `email` | emails | `email`, `userEmail` |
 | `medication` | health data | `medications` |
-| `fullname` or `full_name` | real names | `fullName` |
+| `fullname` (exact) or `full_name` (contains) | real names | `fullName` |
 | `age` (exact) | age | `age` |
-| `weight` | body weight | `weightKg`, `weight_kg` |
-| `height` | height | `heightCm`, `height_cm` |
+| `weightkg` (exact) or `weight_kg` (contains) | body weight | `weightKg`, `weight_kg` |
+| `heightcm` (exact) or `height_cm` (contains) | height | `heightCm`, `height_cm` |
 | `hrmax` or `hr_max` | max heart rate | `hrMaxBpm`, `hr_max_bpm` |
 | `vo2max` or `vo2_max` | VO2 max | `vo2Max`, `vo2_max` |
-| `athlete_notes` or `athletenotes` | personal notes | `athleteNotes` |
-| `athlete_prompt` or `athleteprompt` | personal prompts | `athletePrompt` |
+| `athletenotes` (exact) or `athlete_notes` (contains) | personal notes | `athleteNotes` |
+| `athleteprompt` (exact) or `athlete_prompt` (contains) | personal prompts | `athletePrompt` |
 | `athleteid` or `athlete_id` | third-party IDs | `athleteId` |
 | `content` (exact) | message content | `content` |
-| `message` (exact) | log/chat messages | `message` |
+| `message` (exact), `usermessage`, `coachmessage`, `messages` | log/chat messages | `message`, `userMessage`, `coachMessage`, `messages` |
 | `filecontent` or `file_content` | binary payloads | `fileContents`, `fileContentsBase64` |
 
 ### Endpoint checklist

--- a/src/adapters/intervals_icu/client/logging.rs
+++ b/src/adapters/intervals_icu/client/logging.rs
@@ -406,7 +406,7 @@ mod tests {
 
         assert_eq!(json["api_key"], "[REDACTED]");
         assert_eq!(json["events"][0]["token"], "[REDACTED]");
-        assert_eq!(json["athlete_id"], "12345");
+        assert_eq!(json["athlete_id"], "[REDACTED]");
     }
 
     #[test]

--- a/src/adapters/rest/logging/mod.rs
+++ b/src/adapters/rest/logging/mod.rs
@@ -27,7 +27,7 @@ impl Default for EndpointLogConfig {
         Self {
             log_request_body: false,
             log_response_body: false,
-            max_body_bytes: 4096,
+            max_body_bytes: 10240,
         }
     }
 }
@@ -145,7 +145,7 @@ mod tests {
         let config = EndpointLogConfig::default();
         assert!(!config.log_request_body);
         assert!(!config.log_response_body);
-        assert_eq!(config.max_body_bytes, 4096);
+        assert_eq!(config.max_body_bytes, 10240);
     }
 
     #[test]
@@ -205,6 +205,6 @@ mod tests {
 
         assert!(!config.log_request_body);
         assert!(!config.log_response_body);
-        assert_eq!(config.max_body_bytes, 4096);
+        assert_eq!(config.max_body_bytes, 10240);
     }
 }

--- a/src/adapters/rest/logging/redaction.rs
+++ b/src/adapters/rest/logging/redaction.rs
@@ -195,4 +195,82 @@ mod tests {
         let preview = format_binary_body_preview(bytes);
         assert!(preview.starts_with("binary(11 bytes,hash="));
     }
+
+    #[test]
+    fn redact_value_redacts_pii_fields() {
+        let mut value: serde_json::Value = serde_json::json!({
+            "email": "user@example.com",
+            "fullName": "Jan Kowalski",
+            "age": 35,
+            "weightKg": 75.0,
+            "heightCm": 180,
+            "hrMaxBpm": 190,
+            "vo2Max": 55.0
+        });
+
+        redact_value(&mut value);
+
+        assert_eq!(value["email"], "[REDACTED]");
+        assert_eq!(value["fullName"], "[REDACTED]");
+        assert_eq!(value["age"], "[REDACTED]");
+        assert_eq!(value["weightKg"], "[REDACTED]");
+        assert_eq!(value["heightCm"], "[REDACTED]");
+        assert_eq!(value["hrMaxBpm"], "[REDACTED]");
+        assert_eq!(value["vo2Max"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_value_redacts_health_and_personal_fields() {
+        let mut value: serde_json::Value = serde_json::json!({
+            "medications": "ibuprofen",
+            "athleteNotes": "feeling tired",
+            "athletePrompt": "train harder",
+            "athleteId": "12345"
+        });
+
+        redact_value(&mut value);
+
+        assert_eq!(value["medications"], "[REDACTED]");
+        assert_eq!(value["athleteNotes"], "[REDACTED]");
+        assert_eq!(value["athletePrompt"], "[REDACTED]");
+        assert_eq!(value["athleteId"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_value_redacts_content_and_binary_fields() {
+        let mut value: serde_json::Value = serde_json::json!({
+            "content": "private message",
+            "message": "log entry with PII",
+            "fileContents": "raw-file-data",
+            "fileContentsBase64": "base64data"
+        });
+
+        redact_value(&mut value);
+
+        assert_eq!(value["content"], "[REDACTED]");
+        assert_eq!(value["message"], "[REDACTED]");
+        assert_eq!(value["fileContents"], "[REDACTED]");
+        assert_eq!(value["fileContentsBase64"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_value_preserves_non_sensitive_fields() {
+        let mut value: serde_json::Value = serde_json::json!({
+            "name": "My Workout",
+            "category": "Cycling",
+            "date": "2025-01-01",
+            "rpe": 7,
+            "saved": true,
+            "indoor": false
+        });
+
+        redact_value(&mut value);
+
+        assert_eq!(value["name"], "My Workout");
+        assert_eq!(value["category"], "Cycling");
+        assert_eq!(value["date"], "2025-01-01");
+        assert_eq!(value["rpe"], 7);
+        assert_eq!(value["saved"], true);
+        assert_eq!(value["indoor"], false);
+    }
 }

--- a/src/adapters/rest/logging/redaction.rs
+++ b/src/adapters/rest/logging/redaction.rs
@@ -241,6 +241,9 @@ mod tests {
         let mut value: serde_json::Value = serde_json::json!({
             "content": "private message",
             "message": "log entry with PII",
+            "userMessage": "hello coach",
+            "coachMessage": "keep it up",
+            "messages": ["hi", "there"],
             "fileContents": "raw-file-data",
             "fileContentsBase64": "base64data"
         });
@@ -249,6 +252,9 @@ mod tests {
 
         assert_eq!(value["content"], "[REDACTED]");
         assert_eq!(value["message"], "[REDACTED]");
+        assert_eq!(value["userMessage"], "[REDACTED]");
+        assert_eq!(value["coachMessage"], "[REDACTED]");
+        assert_eq!(value["messages"][0], "[REDACTED]");
         assert_eq!(value["fileContents"], "[REDACTED]");
         assert_eq!(value["fileContentsBase64"], "[REDACTED]");
     }

--- a/src/adapters/rest/logging/request_logger.rs
+++ b/src/adapters/rest/logging/request_logger.rs
@@ -122,9 +122,14 @@ where
     }
 }
 
+/// Maximum bytes to buffer when collecting a request or response body for logging.
+/// Prevents unbounded memory allocation when RequestLogLayer is enabled on routes
+/// with large payloads.
+const MAX_COLLECT_BYTES: usize = 10 * 1024 * 1024;
+
 /// Collect the full body for logging and response reconstruction.
 async fn collect_body(body: Body) -> Result<Vec<u8>, ()> {
-    let bytes = match to_bytes(body, usize::MAX).await {
+    let bytes = match to_bytes(body, MAX_COLLECT_BYTES).await {
         Err(_) => return Err(()),
         Ok(bytes) => bytes,
     };

--- a/src/adapters/rest/logging/request_logger.rs
+++ b/src/adapters/rest/logging/request_logger.rs
@@ -68,28 +68,42 @@ where
             let uri = req.uri().clone();
             let headers = req.headers().clone();
 
-            let rebuilt_req = if config.log_request_body {
-                let (parts, body) = req.into_parts();
-                let Ok(body_bytes) = collect_body(body).await else {
-                    tracing::warn!(
-                        http.method = %method,
-                        http.target = %uri.path(),
-                        "skipping request body log because body collection failed"
-                    );
-                    return Ok(simple_error_response(StatusCode::BAD_REQUEST));
-                };
+            let has_request_body = matches!(method, Method::POST | Method::PUT | Method::PATCH);
 
-                let body_preview = format_body_for_logging(
-                    &method,
-                    &headers,
-                    body_bytes.as_slice(),
-                    config.max_body_bytes,
-                );
-                log_request(&method, &uri, &headers, Some(&body_preview));
-                Request::from_parts(parts, Body::from(body_bytes))
+            let (rebuilt_req, req_body_preview) = if config.log_request_body && has_request_body {
+                let (parts, body) = req.into_parts();
+                match collect_body(body).await {
+                    Ok(body_bytes) => {
+                        let body_preview = format_body_for_logging(
+                            &method,
+                            &headers,
+                            body_bytes.as_slice(),
+                            config.max_body_bytes,
+                        );
+                        log_request(&method, &uri, &headers, Some(&body_preview));
+                        (
+                            Request::from_parts(parts, Body::from(body_bytes)),
+                            Some(body_preview),
+                        )
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            http.method = %method,
+                            http.target = %uri.path(),
+                            "skipping request body log because body collection failed or was too large"
+                        );
+                        log_request(&method, &uri, &headers, None);
+                        return inner.call(Request::from_parts(parts, Body::empty())).await;
+                    }
+                }
             } else {
-                req
+                if config.log_request_body {
+                    log_request(&method, &uri, &headers, None);
+                }
+                (req, None)
             };
+
+            drop(req_body_preview);
 
             let response = inner.call(rebuilt_req).await?;
 
@@ -98,26 +112,28 @@ where
             }
 
             let (resp_parts, resp_body) = response.into_parts();
-            let Ok(resp_body_bytes) = collect_body(resp_body).await else {
-                tracing::warn!(
-                    http.status_code = resp_parts.status.as_u16(),
-                    "skipping response body log because body collection failed"
-                );
-                return Ok(simple_error_response(StatusCode::BAD_GATEWAY));
-            };
-
-            let resp_preview = format_response_body_for_logging(
-                &resp_parts.headers,
-                resp_body_bytes.as_slice(),
-                config.max_body_bytes,
-            );
-
-            log_response(resp_parts.status, Some(&resp_preview));
-
-            Ok(Response::from_parts(
-                resp_parts,
-                Body::from(resp_body_bytes),
-            ))
+            match collect_body(resp_body).await {
+                Ok(resp_body_bytes) => {
+                    let resp_preview = format_response_body_for_logging(
+                        &resp_parts.headers,
+                        resp_body_bytes.as_slice(),
+                        config.max_body_bytes,
+                    );
+                    log_response(resp_parts.status, Some(&resp_preview));
+                    Ok(Response::from_parts(
+                        resp_parts,
+                        Body::from(resp_body_bytes),
+                    ))
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        http.status_code = resp_parts.status.as_u16(),
+                        "skipping response body log because body collection failed or was too large"
+                    );
+                    log_response(resp_parts.status, None);
+                    Ok(Response::from_parts(resp_parts, Body::empty()))
+                }
+            }
         })
     }
 }
@@ -212,13 +228,6 @@ fn format_response_body_for_logging(
     }
 
     format_body_preview(body_str, max_body_bytes)
-}
-
-fn simple_error_response(status: StatusCode) -> Response<Body> {
-    Response::builder()
-        .status(status)
-        .body(Body::empty())
-        .expect("building static error response should not fail")
 }
 
 fn summarize_text_body(content_type: &str, bytes: &[u8], max_body_bytes: usize) -> String {

--- a/src/adapters/rest/mod.rs
+++ b/src/adapters/rest/mod.rs
@@ -64,10 +64,6 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
         .route("/api/auth/google/callback", get(auth::finish_google_login))
         .route("/api/auth/wahoo/start", get(auth::start_wahoo_connect))
         .route("/api/wahoo/callback", get(auth::finish_wahoo_connect))
-        .route(
-            "/api/auth/whitelist",
-            post(auth::join_whitelist).layer(DefaultBodyLimit::max(4 * 1024)),
-        )
         .route("/api/auth/me", get(auth::current_user))
         .route("/api/auth/logout", post(auth::logout))
         .merge(Router::new().route(
@@ -76,6 +72,10 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
         ))
         .merge(
             Router::new()
+                .route(
+                    "/api/auth/whitelist",
+                    post(auth::join_whitelist).layer(DefaultBodyLimit::max(4 * 1024)),
+                )
                 .route("/api/admin/system-info", get(admin::system_info))
                 .route(
                     "/api/admin/completed-workouts/{user_id}/backfill-details",
@@ -98,6 +98,9 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
                 .route(
                     "/api/settings/intervals/test",
                     post(settings::test_intervals_connection)
+                        // NOTE: This MethodRouter-level DefaultBodyLimit is enforced by the
+                        // handler, but the outer RequestLogLayer still buffers up to
+                        // MAX_COLLECT_BYTES (10 MB) before this limit is checked.
                         .layer(DefaultBodyLimit::max(8 * 1024)),
                 )
                 .route("/api/settings/options", patch(settings::update_options))

--- a/src/adapters/rest/mod.rs
+++ b/src/adapters/rest/mod.rs
@@ -54,6 +54,9 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
     let static_files = ServeDir::new(&frontend_dist);
     let spa_index = ServeFile::new(frontend_dist.join("index.html"));
 
+    let write_log_config = EndpointLogConfig::request_only().with_max_body_bytes(10240);
+    let settings_read_log_config = EndpointLogConfig::response_only().with_max_body_bytes(10240);
+
     Router::new()
         .route("/health", get(health::health_check))
         .route("/ready", get(health::readiness_check))
@@ -71,124 +74,126 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
             "/api/logs",
             post(logs::ingest_logs).layer(DefaultBodyLimit::max(logs::MAX_REQUEST_BODY_BYTES)),
         ))
-        .route("/api/admin/system-info", get(admin::system_info))
-        .route(
-            "/api/admin/completed-workouts/{user_id}/backfill-details",
-            post(admin::backfill_completed_workout_details),
-        )
-        .route(
-            "/api/admin/completed-workouts/{user_id}/backfill-metrics",
-            post(admin::backfill_completed_workout_metrics),
-        )
-        .route(
-            "/api/admin/settings/{user_id}",
-            get(settings::admin_get_user_settings),
-        )
         .merge(
             Router::new()
-                .route("/api/settings", get(settings::get_settings))
-                .layer(RequestLogLayer::new())
-                .route_layer(with_log_config(
-                    EndpointLogConfig::response_only().with_max_body_bytes(2048),
-                )),
-        )
-        .route("/api/settings/ai-agents", patch(settings::update_ai_agents))
-        .route(
-            "/api/settings/ai-agents/test",
-            post(settings::test_ai_agents_connection),
-        )
-        .route("/api/settings/intervals", patch(settings::update_intervals))
-        .merge(
-            Router::new()
+                .route("/api/admin/system-info", get(admin::system_info))
+                .route(
+                    "/api/admin/completed-workouts/{user_id}/backfill-details",
+                    post(admin::backfill_completed_workout_details),
+                )
+                .route(
+                    "/api/admin/completed-workouts/{user_id}/backfill-metrics",
+                    post(admin::backfill_completed_workout_metrics),
+                )
+                .route(
+                    "/api/admin/settings/{user_id}",
+                    get(settings::admin_get_user_settings),
+                )
+                .route("/api/settings/ai-agents", patch(settings::update_ai_agents))
+                .route(
+                    "/api/settings/ai-agents/test",
+                    post(settings::test_ai_agents_connection),
+                )
+                .route("/api/settings/intervals", patch(settings::update_intervals))
                 .route(
                     "/api/settings/intervals/test",
                     post(settings::test_intervals_connection)
                         .layer(DefaultBodyLimit::max(8 * 1024)),
                 )
+                .route("/api/settings/options", patch(settings::update_options))
+                .route(
+                    "/api/settings/availability",
+                    patch(settings::update_availability),
+                )
+                .route("/api/settings/cycling", patch(settings::update_cycling))
+                .route(
+                    "/api/athlete-summary",
+                    get(athlete_summary::get_athlete_summary),
+                )
+                .route(
+                    "/api/athlete-summary/generate",
+                    post(athlete_summary::generate_athlete_summary),
+                )
+                .route("/api/calendar/events", get(calendar::list_events))
+                .route("/api/calendar/labels", get(calendar::list_labels))
+                .route(
+                    "/api/completed-workouts",
+                    get(completed_workouts::list_completed_workouts),
+                )
+                .route(
+                    "/api/completed-workouts/{activity_id}",
+                    get(completed_workouts::get_completed_workout),
+                )
+                .route(
+                    "/api/dashboard/training-load",
+                    get(dashboard::get_training_load_dashboard),
+                )
+                .route(
+                    "/api/calendar/planned-workouts/{operation_key}/{date}/sync",
+                    post(calendar::sync_planned_workout),
+                )
+                .route(
+                    "/api/races",
+                    get(races::list_races).post(races::create_race),
+                )
+                .route(
+                    "/api/races/{race_id}",
+                    get(races::get_race)
+                        .put(races::update_race)
+                        .delete(races::delete_race),
+                )
+                .route(
+                    "/api/workout-summaries",
+                    get(workout_summary::list_summaries),
+                )
+                .route(
+                    "/api/workout-summaries/{workout_id}",
+                    get(workout_summary::get_summary).post(workout_summary::create_summary),
+                )
+                .route(
+                    "/api/workout-summaries/{workout_id}/rpe",
+                    patch(workout_summary::update_rpe),
+                )
+                .route(
+                    "/api/workout-summaries/{workout_id}/state",
+                    post(workout_summary::set_saved_state).patch(workout_summary::set_saved_state),
+                )
+                .route(
+                    "/api/workout-summaries/{workout_id}/messages",
+                    post(workout_summary::send_message),
+                )
+                .route(
+                    "/api/intervals/events",
+                    get(intervals::list_events).post(intervals::create_event),
+                )
+                .route(
+                    "/api/intervals/events/{event_id}",
+                    get(intervals::get_event)
+                        .put(intervals::update_event)
+                        .delete(intervals::delete_event),
+                )
+                .route(
+                    "/api/intervals/events/{event_id}/download.fit",
+                    get(intervals::download_fit),
+                )
+                .route(
+                    "/api/intervals/activities/{activity_id}",
+                    get(intervals::get_activity)
+                        .put(intervals::update_activity)
+                        .delete(intervals::delete_activity),
+                )
                 .layer(RequestLogLayer::new())
-                .route_layer(with_log_config(
-                    EndpointLogConfig::request_only().with_max_body_bytes(1024),
-                )),
+                .route_layer(with_log_config(write_log_config)),
         )
-        .route("/api/settings/options", patch(settings::update_options))
-        .route(
-            "/api/settings/availability",
-            patch(settings::update_availability),
-        )
-        .route("/api/settings/cycling", patch(settings::update_cycling))
-        .route(
-            "/api/athlete-summary",
-            get(athlete_summary::get_athlete_summary),
-        )
-        .route(
-            "/api/athlete-summary/generate",
-            post(athlete_summary::generate_athlete_summary),
-        )
-        .route("/api/calendar/events", get(calendar::list_events))
-        .route("/api/calendar/labels", get(calendar::list_labels))
-        .route(
-            "/api/completed-workouts",
-            get(completed_workouts::list_completed_workouts),
-        )
-        .route(
-            "/api/completed-workouts/{activity_id}",
-            get(completed_workouts::get_completed_workout),
-        )
-        .route(
-            "/api/dashboard/training-load",
-            get(dashboard::get_training_load_dashboard),
-        )
-        .route(
-            "/api/calendar/planned-workouts/{operation_key}/{date}/sync",
-            post(calendar::sync_planned_workout),
-        )
-        .route(
-            "/api/races",
-            get(races::list_races).post(races::create_race),
-        )
-        .route(
-            "/api/races/{race_id}",
-            get(races::get_race)
-                .put(races::update_race)
-                .delete(races::delete_race),
-        )
-        .route(
-            "/api/workout-summaries",
-            get(workout_summary::list_summaries),
-        )
-        .route(
-            "/api/workout-summaries/{workout_id}",
-            get(workout_summary::get_summary).post(workout_summary::create_summary),
-        )
-        .route(
-            "/api/workout-summaries/{workout_id}/rpe",
-            patch(workout_summary::update_rpe),
-        )
-        .route(
-            "/api/workout-summaries/{workout_id}/state",
-            post(workout_summary::set_saved_state).patch(workout_summary::set_saved_state),
-        )
-        .route(
-            "/api/workout-summaries/{workout_id}/messages",
-            post(workout_summary::send_message),
+        .merge(
+            Router::new()
+                .route("/api/settings", get(settings::get_settings))
+                .layer(RequestLogLayer::new())
+                .route_layer(with_log_config(settings_read_log_config)),
         )
         .route(
             "/api/workout-summaries/{workout_id}/ws",
             get(workout_summary::workout_summary_ws),
-        )
-        .route(
-            "/api/intervals/events",
-            get(intervals::list_events).post(intervals::create_event),
-        )
-        .route(
-            "/api/intervals/events/{event_id}",
-            get(intervals::get_event)
-                .put(intervals::update_event)
-                .delete(intervals::delete_event),
-        )
-        .route(
-            "/api/intervals/events/{event_id}/download.fit",
-            get(intervals::download_fit),
         )
         .route(
             "/api/intervals/activities",
@@ -197,12 +202,6 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
                 .layer(DefaultBodyLimit::max(
                     intervals::MAX_ACTIVITY_UPLOAD_REQUEST_BYTES,
                 )),
-        )
-        .route(
-            "/api/intervals/activities/{activity_id}",
-            get(intervals::get_activity)
-                .put(intervals::update_activity)
-                .delete(intervals::delete_activity),
         )
         .fallback(move |request| serve_frontend(request, static_files.clone(), spa_index.clone()))
         .layer(

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -204,6 +204,29 @@ pub fn is_sensitive_key(key: &str) -> bool {
         || lowercase.contains("apikey")
         || lowercase == "user"
         || lowercase.ends_with("_user")
+        || lowercase.contains("email")
+        || lowercase.contains("medication")
+        || lowercase == "fullname"
+        || lowercase.contains("full_name")
+        || lowercase == "age"
+        || lowercase == "weightkg"
+        || lowercase == "weight_kg"
+        || lowercase == "heightcm"
+        || lowercase == "height_cm"
+        || lowercase.contains("hrmax")
+        || lowercase.contains("hr_max")
+        || lowercase.contains("vo2max")
+        || lowercase.contains("vo2_max")
+        || lowercase == "athletenotes"
+        || lowercase.contains("athlete_notes")
+        || lowercase == "athleteprompt"
+        || lowercase.contains("athlete_prompt")
+        || lowercase.contains("athleteid")
+        || lowercase.contains("athlete_id")
+        || lowercase == "content"
+        || lowercase == "message"
+        || lowercase.contains("filecontent")
+        || lowercase.contains("file_content")
 }
 
 #[cfg(test)]
@@ -225,8 +248,8 @@ mod tests {
     use tracing_subscriber::{layer::SubscriberExt, Registry};
 
     use super::{
-        build_log_bridge_layer, build_resource, combine_shutdown_errors, redact_if_sensitive,
-        resolve_service_name,
+        build_log_bridge_layer, build_resource, combine_shutdown_errors, is_sensitive_key,
+        redact_if_sensitive, resolve_service_name,
     };
 
     fn telemetry_env_lock() -> &'static Mutex<()> {
@@ -268,6 +291,52 @@ mod tests {
     fn leaves_non_sensitive_fields_unchanged() {
         assert_eq!(redact_if_sensitive("request_id", "abc-123"), "abc-123");
         assert_eq!(redact_if_sensitive("environment", "dev"), "dev");
+    }
+
+    #[test]
+    fn is_sensitive_key_redacts_pii_fields() {
+        assert!(is_sensitive_key("email"));
+        assert!(is_sensitive_key("fullName"));
+        assert!(is_sensitive_key("full_name"));
+        assert!(is_sensitive_key("age"));
+        assert!(is_sensitive_key("weightKg"));
+        assert!(is_sensitive_key("weight_kg"));
+        assert!(is_sensitive_key("heightCm"));
+        assert!(is_sensitive_key("height_cm"));
+        assert!(is_sensitive_key("hrMaxBpm"));
+        assert!(is_sensitive_key("hr_max_bpm"));
+        assert!(is_sensitive_key("vo2Max"));
+        assert!(is_sensitive_key("vo2_max"));
+    }
+
+    #[test]
+    fn is_sensitive_key_redacts_health_and_personal_fields() {
+        assert!(is_sensitive_key("medications"));
+        assert!(is_sensitive_key("athleteNotes"));
+        assert!(is_sensitive_key("athlete_notes"));
+        assert!(is_sensitive_key("athletePrompt"));
+        assert!(is_sensitive_key("athlete_prompt"));
+        assert!(is_sensitive_key("athleteId"));
+        assert!(is_sensitive_key("athlete_id"));
+    }
+
+    #[test]
+    fn is_sensitive_key_redacts_content_and_binary_fields() {
+        assert!(is_sensitive_key("content"));
+        assert!(is_sensitive_key("message"));
+        assert!(is_sensitive_key("fileContents"));
+        assert!(is_sensitive_key("file_contents"));
+        assert!(is_sensitive_key("fileContentsBase64"));
+    }
+
+    #[test]
+    fn is_sensitive_key_does_not_over_match() {
+        assert!(!is_sensitive_key("contentType"));
+        assert!(!is_sensitive_key("content-Type"));
+        assert!(!is_sensitive_key("ageGroup"));
+        assert!(!is_sensitive_key("deviceId"));
+        assert!(!is_sensitive_key("weightedScore"));
+        assert!(!is_sensitive_key("messageId"));
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -225,6 +225,9 @@ pub fn is_sensitive_key(key: &str) -> bool {
         || lowercase.contains("athlete_id")
         || lowercase == "content"
         || lowercase == "message"
+        || lowercase == "usermessage"
+        || lowercase == "coachmessage"
+        || lowercase == "messages"
         || lowercase.contains("filecontent")
         || lowercase.contains("file_content")
 }


### PR DESCRIPTION
- Group all POST/PUT/PATCH endpoints into a write sub-Router with RequestLogLayer using request_only() at 10KB preview limit
- Expand is_sensitive_key with PII, health data, and binary payload patterns (email, fullName, age, weightKg, heightCm, hrMaxBpm, vo2Max, medications, athleteNotes, athletePrompt, athleteId, content, message, fileContents/fileContentsBase64)
- Raise default max_body_bytes from 4096 to 10240 (10KB)
- Add MAX_COLLECT_BYTES (10MB) cap in RequestLogService to prevent unbounded memory buffering
- Exclude login/callback/logout/logs/activity-upload/websocket routes
- Update logging docs with route group table and redaction pattern reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded logging guide with redaction requirements for secrets and personally identifiable information (PII)
  * Added reference table of sensitive field patterns

* **Bug Fixes**
  * Implemented memory protection limit for request/response body logging to prevent unbounded memory usage
  * Broadened sensitive data detection to redact more PII fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->