### PR TITLE
fix: harden Wahoo workouts payload parsing

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-04-26 | user | Wahoo reconnect null boolean payload
+
+- Problem: after reconnecting Wahoo, the background `completed_workouts` poll could fail on `GET /v1/workouts` with `invalid type: null, expected a boolean` because Wahoo sometimes returns explicit `null` values inside the workouts payload. The DTO still relied on `#[serde(default)]` for `workout_summary.manual`, `workout_summary.edited`, `plan_ids`, and the top-level `workouts` list, but that only tolerates missing fields, not explicit `null`.
+- Fix: changed the Wahoo workouts DTO to deserialize nullable booleans and vectors through lenient helpers that map missing or `null` values to `false` / empty vectors, and added focused regressions covering the real workouts-list payload shape.
+- Prevention: when a provider field is documented or observed as nullable, do not rely on `#[serde(default)]` alone for scalars or collections because it does not accept explicit `null`; use `Option<T>` or a custom deserializer and add a regression with the real payload shape.
+
 ### 2026-04-26 | CodeRabbit | PR #143 Wahoo import duration fallback
 
 - Problem: `src/adapters/wahoo/import_mapping.rs` still fell back from `summary.duration_total_seconds` straight to `workout.minutes`, but `minutes` is the planned duration, not the actual elapsed duration. When Wahoo omitted total duration but still provided summary active duration, the canonical completed workout could record a wildly inflated elapsed time.

--- a/src/adapters/wahoo/dto.rs
+++ b/src/adapters/wahoo/dto.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Deserialize)]
 pub struct WahooTokenResponse {
@@ -42,9 +42,9 @@ pub struct WahooWorkoutSummaryResponse {
     pub speed_avg: Option<String>,
     pub work_accum: Option<String>,
     pub time_zone: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_or_default")]
     pub manual: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_or_default")]
     pub edited: bool,
     pub fitness_app_id: Option<i64>,
     pub file: Option<WahooFileReferenceResponse>,
@@ -59,7 +59,7 @@ pub struct WahooWorkoutResponse {
     pub minutes: Option<i32>,
     pub name: Option<String>,
     pub plan_id: Option<i64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_or_default")]
     pub plan_ids: Vec<i64>,
     pub route_id: Option<i64>,
     pub workout_token: Option<String>,
@@ -71,7 +71,7 @@ pub struct WahooWorkoutResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct WahooWorkoutListResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_or_default")]
     pub workouts: Vec<WahooWorkoutResponse>,
     pub total: Option<usize>,
     pub page: Option<usize>,
@@ -142,4 +142,82 @@ pub struct WahooUpdateWorkoutRequestBody {
     pub minutes: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<i64>,
+}
+
+fn deserialize_bool_or_default<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<bool>::deserialize(deserializer)?.unwrap_or(false))
+}
+
+fn deserialize_vec_or_default<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WahooWorkoutListResponse;
+
+    #[test]
+    fn workout_list_deserializes_null_summary_booleans_as_false() {
+        let payload = r#"{
+            "workouts": [
+                {
+                    "id": 56519,
+                    "starts": "2023-11-14T08:00:00.000Z",
+                    "minutes": 60,
+                    "workout_summary": {
+                        "id": 8297,
+                        "manual": null,
+                        "edited": null
+                    }
+                }
+            ],
+            "total": 1,
+            "page": 1,
+            "per_page": 30
+        }"#;
+
+        let response: WahooWorkoutListResponse = serde_json::from_str(payload).unwrap();
+        let summary = response.workouts[0].workout_summary.as_ref().unwrap();
+
+        assert!(!summary.manual);
+        assert!(!summary.edited);
+    }
+
+    #[test]
+    fn workout_list_deserializes_null_vectors_as_empty() {
+        let payload = r#"{
+            "workouts": [
+                {
+                    "id": 56519,
+                    "starts": "2023-11-14T08:00:00.000Z",
+                    "plan_ids": null
+                }
+            ]
+        }"#;
+
+        let response: WahooWorkoutListResponse = serde_json::from_str(payload).unwrap();
+
+        assert!(response.workouts[0].plan_ids.is_empty());
+    }
+
+    #[test]
+    fn workout_list_deserializes_null_workouts_as_empty() {
+        let payload = r#"{
+            "workouts": null,
+            "total": 0,
+            "page": 1,
+            "per_page": 30
+        }"#;
+
+        let response: WahooWorkoutListResponse = serde_json::from_str(payload).unwrap();
+
+        assert!(response.workouts.is_empty());
+    }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -51,6 +51,7 @@
 - If parsed JSON string data is only compared against a static literal, keep it borrowed as `&str` and compare in place instead of allocating an owned `String` first.
 - When a review-driven change upgrades a match-strength enum or ranking rule, grep the touched test module for old enum expectations before shipping. Production code and review replies can be correct while one stale assertion still expects the pre-change ranking.
 - For external client write logging, prefer adapter-local body preview logging only on the specific POST/PUT paths that need it, and redact secret-bearing form keys before they hit logs. Do not broaden body logging for unrelated requests just to debug one provider write flow.
+- For provider DTO scalars or collections, `#[serde(default)]` only handles missing fields, not explicit `null`. If upstream can send `null`, deserialize through `Option<T>` or a custom helper and add a regression with the real payload shape.
 
 ## Release Workflow Reliability
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Wahoo reconnection failures caused by improper handling of null values in workout data payloads. The app now correctly handles nullable fields, ensuring workouts sync reliably without deserialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->