### PR TITLE
Fix/wahoo reconnect null payload

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-04-26 | user | Wahoo bootstrap poller loses all progress on rate limit
+
+- Problem: the Wahoo completed-workouts bootstrap scanned every `/v1/workouts` page before importing anything. For accounts with long history, the poller could get many successful `200` pages and then hit `429 Too Many Requests` before the scan finished, which left `cursor = null`, `last_successful_at = null`, and zero Wahoo observations/completed workouts even though dozens of pages had already been read successfully.
+- Fix: changed the Wahoo poller to persist a resumable page checkpoint in the poll cursor on partial scan failure and to import the workouts already gathered before returning the rate-limit error. Added regressions proving the poller now stores `next_page`/`newest_seen` after a later-page failure and resumes from that checkpoint on the next run instead of restarting from page 1.
+- Prevention: when a provider poll loop paginates large remote histories, do not postpone all durable progress until after the full scan succeeds. If later pages can fail or rate-limit independently, persist a resumable checkpoint and keep already-read pages importable so one late `429` does not reset the entire bootstrap to zero.
+
 ### 2026-04-26 | user | Wahoo reconnect null boolean payload
 
 - Problem: after reconnecting Wahoo, the background `completed_workouts` poll could fail on `GET /v1/workouts` with `invalid type: null, expected a boolean` because Wahoo sometimes returns explicit `null` values inside the workouts payload. The DTO still relied on `#[serde(default)]` for `workout_summary.manual`, `workout_summary.edited`, `plan_ids`, and the top-level `workouts` list, but that only tolerates missing fields, not explicit `null`.

--- a/src/adapters/intervals_icu/client/logging.rs
+++ b/src/adapters/intervals_icu/client/logging.rs
@@ -7,6 +7,8 @@ use sha2::Digest;
 use crate::telemetry::is_sensitive_key;
 
 const CLIENT_NAME: &str = "intervals_icu";
+const CLIENT_LABEL: &str = "intervals";
+const SAFE_QUERY_KEYS: &[&str] = &["oldest", "newest", "page", "per_page", "category"];
 
 /// Maximum characters to preview in logged request/response bodies.
 const MAX_LOGGED_BODY_CHARS: usize = 1024;
@@ -235,6 +237,7 @@ fn log_request(
     if let Some(body) = body_preview {
         tracing::info!(
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.headers = ?header_fields,
@@ -244,6 +247,7 @@ fn log_request(
     } else {
         tracing::info!(
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.headers = ?header_fields,
@@ -285,6 +289,7 @@ fn log_response_with_body(
         tracing::Level::ERROR => tracing::event!(
             tracing::Level::ERROR,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -295,6 +300,7 @@ fn log_response_with_body(
         tracing::Level::WARN => tracing::event!(
             tracing::Level::WARN,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -305,6 +311,7 @@ fn log_response_with_body(
         tracing::Level::INFO => tracing::event!(
             tracing::Level::INFO,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -326,6 +333,7 @@ fn log_response_without_body(
         tracing::Level::ERROR => tracing::event!(
             tracing::Level::ERROR,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -335,6 +343,7 @@ fn log_response_without_body(
         tracing::Level::WARN => tracing::event!(
             tracing::Level::WARN,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -344,6 +353,7 @@ fn log_response_without_body(
         tracing::Level::INFO => tracing::event!(
             tracing::Level::INFO,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %url,
             http.status_code = status.as_u16(),
@@ -357,6 +367,7 @@ fn log_response_without_body(
 fn log_transport_failure(method: &Method, url: &reqwest::Url, error: &reqwest::Error, stage: &str) {
     tracing::error!(
         provider = CLIENT_NAME,
+        client = CLIENT_LABEL,
         http.method = %method,
         http.url = %sanitized_url(url),
         failure.stage = stage,
@@ -383,6 +394,27 @@ fn sanitized_url(url: &reqwest::Url) -> String {
     if let Some(port) = url.port() {
         let authority = format!("{}:{}", url.host_str().unwrap_or(""), port);
         sanitized = format!("{}://{}{}", url.scheme(), authority, url.path());
+    }
+
+    let safe_query = url
+        .query_pairs()
+        .filter(|(key, _)| {
+            SAFE_QUERY_KEYS
+                .iter()
+                .any(|allowed| key.eq_ignore_ascii_case(allowed))
+        })
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                urlencoding::encode(&key),
+                urlencoding::encode(&value)
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if !safe_query.is_empty() {
+        sanitized.push('?');
+        sanitized.push_str(&safe_query.join("&"));
     }
 
     sanitized
@@ -431,11 +463,11 @@ mod tests {
     }
 
     #[test]
-    fn sanitized_url_drops_query_string() {
-        let url = reqwest::Url::parse("https://intervals.icu/api/v1/athlete/athlete-7/activities?oldest=2026-03-01&newest=2026-03-31").unwrap();
+    fn sanitized_url_keeps_safe_intervals_query_params() {
+        let url = reqwest::Url::parse("https://intervals.icu/api/v1/athlete/athlete-7/activities?oldest=2026-03-01&newest=2026-03-31&page=2&per_page=20&api_key=secret").unwrap();
         assert_eq!(
             sanitized_url(&url),
-            "https://intervals.icu/api/v1/athlete/athlete-7/activities"
+            "https://intervals.icu/api/v1/athlete/athlete-7/activities?oldest=2026-03-01&newest=2026-03-31&page=2&per_page=20"
         );
     }
 }

--- a/src/adapters/wahoo/client/logging.rs
+++ b/src/adapters/wahoo/client/logging.rs
@@ -7,7 +7,9 @@ use sha2::Digest;
 use crate::telemetry::is_sensitive_key;
 
 const CLIENT_NAME: &str = "wahoo_oauth";
+const CLIENT_LABEL: &str = "wahoo";
 const MAX_LOGGED_BODY_CHARS: usize = 1024;
+const SAFE_QUERY_KEYS: &[&str] = &["page", "per_page", "sort", "order", "external_id"];
 
 pub struct LoggedResponse {
     pub status: StatusCode,
@@ -150,6 +152,7 @@ fn log_request(
     if let Some(body) = body_preview {
         tracing::info!(
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %sanitized_url(url),
             http.headers = ?header_fields,
@@ -159,6 +162,7 @@ fn log_request(
     } else {
         tracing::info!(
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %sanitized_url(url),
             http.headers = ?header_fields,
@@ -178,6 +182,7 @@ fn log_response(
         tracing::Level::ERROR => tracing::event!(
             tracing::Level::ERROR,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %sanitized_url(url),
             http.status_code = status.as_u16(),
@@ -187,6 +192,7 @@ fn log_response(
         tracing::Level::WARN => tracing::event!(
             tracing::Level::WARN,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %sanitized_url(url),
             http.status_code = status.as_u16(),
@@ -196,6 +202,7 @@ fn log_response(
         _ => tracing::event!(
             tracing::Level::INFO,
             provider = CLIENT_NAME,
+            client = CLIENT_LABEL,
             http.method = %method,
             http.url = %sanitized_url(url),
             http.status_code = status.as_u16(),
@@ -216,6 +223,7 @@ fn response_log_level(status: StatusCode) -> tracing::Level {
 fn log_transport_failure(method: &Method, url: &reqwest::Url, error: &reqwest::Error, stage: &str) {
     tracing::error!(
         provider = CLIENT_NAME,
+        client = CLIENT_LABEL,
         http.method = %method,
         http.url = %sanitized_url(url),
         failure.stage = stage,
@@ -249,12 +257,33 @@ fn sanitized_url(url: &reqwest::Url) -> String {
         );
     }
 
+    let safe_query = url
+        .query_pairs()
+        .filter(|(key, _)| {
+            SAFE_QUERY_KEYS
+                .iter()
+                .any(|allowed| key.eq_ignore_ascii_case(allowed))
+        })
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                urlencoding::encode(&key),
+                urlencoding::encode(&value)
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if !safe_query.is_empty() {
+        sanitized.push('?');
+        sanitized.push_str(&safe_query.join("&"));
+    }
+
     sanitized
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_request_body;
+    use super::{format_request_body, sanitized_url};
     use reqwest::Method;
 
     #[test]
@@ -268,5 +297,18 @@ mod tests {
         assert!(preview.contains("workout[workout_token]"));
         assert!(preview.contains("[REDACTED]"));
         assert!(!preview.contains("secret-token"));
+    }
+
+    #[test]
+    fn sanitized_url_keeps_safe_wahoo_query_params() {
+        let url = reqwest::Url::parse(
+            "https://api.wahooligan.com/v1/workouts?page=2&per_page=30&sort=updated_at&order=desc&access_token=secret",
+        )
+        .unwrap();
+
+        assert_eq!(
+            sanitized_url(&url),
+            "https://api.wahooligan.com/v1/workouts?page=2&per_page=30&sort=updated_at&order=desc"
+        );
     }
 }

--- a/src/config/provider_polling/mod.rs
+++ b/src/config/provider_polling/mod.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Duration as ChronoDuration, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
 use tokio::time::MissedTickBehavior;
 use tracing::warn;
 
@@ -215,23 +216,20 @@ where
 
     async fn process_due_state(&self, state: ProviderPollState) {
         let attempted_at_epoch_seconds = self.clock.now_epoch_seconds();
-        let attempted_state = state.clone().mark_attempted(attempted_at_epoch_seconds);
-        let attempted_state = match self.poll_states.upsert(attempted_state).await {
-            Ok(state) => state,
-            Err(error) => {
-                warn!(
-                    user_id = %state.user_id,
-                    provider = ?state.provider,
-                    stream = ?state.stream,
-                    error = %error,
-                    "failed to persist provider poll attempt"
-                );
-                return;
-            }
-        };
+        let mut attempted_state = state.clone().mark_attempted(attempted_at_epoch_seconds);
+        if let Err(error) = self.poll_states.upsert(attempted_state.clone()).await {
+            warn!(
+                user_id = %state.user_id,
+                provider = ?state.provider,
+                stream = ?state.stream,
+                error = %error,
+                "failed to persist provider poll attempt"
+            );
+            return;
+        }
 
         match self
-            .poll_state(&attempted_state, attempted_at_epoch_seconds)
+            .poll_state(&mut attempted_state, attempted_at_epoch_seconds)
             .await
         {
             Ok(cursor) => {
@@ -282,7 +280,7 @@ where
 
     async fn poll_state(
         &self,
-        state: &ProviderPollState,
+        state: &mut ProviderPollState,
         now_epoch_seconds: i64,
     ) -> Result<Option<String>, String> {
         match state.provider {
@@ -306,7 +304,7 @@ where
 
     async fn poll_intervals_state(
         &self,
-        state: &ProviderPollState,
+        state: &mut ProviderPollState,
         now_epoch_seconds: i64,
     ) -> Result<Option<String>, String> {
         let credentials = self
@@ -333,7 +331,7 @@ where
 
     async fn poll_wahoo_state(
         &self,
-        state: &ProviderPollState,
+        state: &mut ProviderPollState,
         now_epoch_seconds: i64,
     ) -> Result<Option<String>, String> {
         if state.stream != ProviderPollStream::CompletedWorkouts {
@@ -347,19 +345,39 @@ where
             .wahoo_service
             .as_ref()
             .ok_or_else(|| "Wahoo service is not configured".to_string())?;
+        let parsed_cursor = parse_wahoo_cursor(state.cursor.as_deref())?;
         let initial_watermark =
             wahoo_initial_watermark(now_epoch_seconds, self.completed_past_days);
-        let watermark = parse_wahoo_cursor(state.cursor.as_deref())?.or(initial_watermark);
-        let mut page = 1usize;
+        let watermark = parsed_cursor.watermark.or(initial_watermark);
+        let mut page = parsed_cursor.next_page;
         let per_page = 30usize;
         let mut workouts_to_import = Vec::new();
-        let mut newest_seen_cursor = watermark.clone();
+        let mut newest_seen_cursor = parsed_cursor.newest_seen.or(watermark.clone());
 
         loop {
-            let list = wahoo_service
+            let list = match wahoo_service
                 .list_workouts(&state.user_id, page, per_page)
                 .await
-                .map_err(|error| error.to_string())?;
+            {
+                Ok(list) => list,
+                Err(error) => {
+                    if page != parsed_cursor.next_page {
+                        let resume_cursor = format_wahoo_resume_cursor(&WahooPollCursor {
+                            watermark: watermark.clone(),
+                            next_page: page,
+                            newest_seen: newest_seen_cursor.clone(),
+                        })?;
+                        self.import_scanned_wahoo_workouts(
+                            state,
+                            &workouts_to_import,
+                            now_epoch_seconds,
+                        )
+                        .await?;
+                        state.cursor = Some(resume_cursor);
+                    }
+                    return Err(error.to_string());
+                }
+            };
 
             if list.workouts.is_empty() {
                 break;
@@ -390,7 +408,18 @@ where
             page += 1;
         }
 
-        let mut newest_cursor = newest_seen_cursor;
+        self.import_scanned_wahoo_workouts(state, &workouts_to_import, now_epoch_seconds)
+            .await?;
+
+        Ok(newest_seen_cursor)
+    }
+
+    async fn import_scanned_wahoo_workouts(
+        &self,
+        state: &ProviderPollState,
+        workouts_to_import: &[crate::domain::wahoo::WahooWorkout],
+        now_epoch_seconds: i64,
+    ) -> Result<(), String> {
         let mut earliest_imported_date = None::<String>;
         for workout in workouts_to_import.iter().rev() {
             let Some(command) = map_workout_to_import_command(&state.user_id, workout) else {
@@ -427,12 +456,6 @@ where
                 .await;
                 return Err(error);
             }
-
-            let updated_at = workout_sort_key(workout)?;
-            newest_cursor = match newest_cursor {
-                Some(current) => Some(std::cmp::max(current, updated_at)),
-                None => Some(updated_at),
-            };
         }
 
         if let (Some(service), Some(oldest_date)) = (
@@ -445,7 +468,7 @@ where
                 .map_err(|error| error.to_string())?;
         }
 
-        Ok(newest_cursor)
+        Ok(())
     }
 
     async fn recompute_partial_wahoo_imports_if_needed(
@@ -764,14 +787,71 @@ fn parse_date_cursor(cursor: Option<&str>) -> Result<NaiveDate, String> {
         .map_err(|error| format!("invalid poll cursor '{cursor}': {error}"))
 }
 
-fn parse_wahoo_cursor(cursor: Option<&str>) -> Result<Option<String>, String> {
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+struct WahooPollCursor {
+    watermark: Option<String>,
+    #[serde(default = "default_wahoo_cursor_page")]
+    next_page: usize,
+    newest_seen: Option<String>,
+}
+
+impl Default for WahooPollCursor {
+    fn default() -> Self {
+        Self {
+            watermark: None,
+            next_page: default_wahoo_cursor_page(),
+            newest_seen: None,
+        }
+    }
+}
+
+fn default_wahoo_cursor_page() -> usize {
+    1
+}
+
+fn parse_wahoo_cursor(cursor: Option<&str>) -> Result<WahooPollCursor, String> {
     match cursor {
-        None => Ok(None),
-        Some(cursor) if cursor.trim().is_empty() => Ok(None),
+        None => Ok(WahooPollCursor::default()),
+        Some(cursor) if cursor.trim().is_empty() => Ok(WahooPollCursor::default()),
+        Some(cursor) if cursor.trim_start().starts_with('{') => {
+            let mut checkpoint: WahooPollCursor = serde_json::from_str(cursor)
+                .map_err(|error| format!("invalid Wahoo poll checkpoint '{cursor}': {error}"))?;
+            if checkpoint.next_page == 0 {
+                return Err(format!(
+                    "invalid Wahoo poll checkpoint '{cursor}': next_page must be at least 1"
+                ));
+            }
+            checkpoint.watermark = checkpoint
+                .watermark
+                .as_deref()
+                .map(parse_wahoo_timestamp)
+                .transpose()
+                .map_err(|error| {
+                    format!("invalid Wahoo poll checkpoint '{cursor}' watermark: {error}")
+                })?;
+            checkpoint.newest_seen = checkpoint
+                .newest_seen
+                .as_deref()
+                .map(parse_wahoo_timestamp)
+                .transpose()
+                .map_err(|error| {
+                    format!("invalid Wahoo poll checkpoint '{cursor}' newest_seen: {error}")
+                })?;
+            Ok(checkpoint)
+        }
         Some(cursor) => parse_wahoo_timestamp(cursor)
-            .map(Some)
+            .map(|watermark| WahooPollCursor {
+                watermark: Some(watermark),
+                next_page: 1,
+                newest_seen: None,
+            })
             .map_err(|error| format!("invalid Wahoo poll cursor '{cursor}': {error}")),
     }
+}
+
+fn format_wahoo_resume_cursor(cursor: &WahooPollCursor) -> Result<String, String> {
+    serde_json::to_string(cursor)
+        .map_err(|error| format!("failed to encode Wahoo poll checkpoint: {error}"))
 }
 
 fn wahoo_initial_watermark(now_epoch_seconds: i64, completed_past_days: i64) -> Option<String> {

--- a/src/config/provider_polling/mod.rs
+++ b/src/config/provider_polling/mod.rs
@@ -29,6 +29,8 @@ use crate::{
 const DEFAULT_SUCCESS_INTERVAL_SECONDS: i64 = 5 * 60;
 const DEFAULT_WAHOO_SUCCESS_INTERVAL_SECONDS: i64 = 3 * 60 * 60;
 const DEFAULT_FAILURE_BACKOFF_SECONDS: i64 = 5 * 60;
+const DEFAULT_WAHOO_BOOTSTRAP_PER_PAGE: usize = 100;
+const DEFAULT_WAHOO_INCREMENTAL_PER_PAGE: usize = 30;
 const DEFAULT_CALENDAR_PAST_DAYS: i64 = 30;
 const DEFAULT_CALENDAR_FUTURE_DAYS: i64 = 30;
 const DEFAULT_COMPLETED_PAST_DAYS: i64 = 365 * 2;
@@ -350,7 +352,12 @@ where
             wahoo_initial_watermark(now_epoch_seconds, self.completed_past_days);
         let watermark = parsed_cursor.watermark.or(initial_watermark);
         let mut page = parsed_cursor.next_page;
-        let per_page = 30usize;
+        let per_page = match state.cursor.as_deref() {
+            None => DEFAULT_WAHOO_BOOTSTRAP_PER_PAGE,
+            Some(cursor) if cursor.trim().is_empty() => DEFAULT_WAHOO_BOOTSTRAP_PER_PAGE,
+            Some(cursor) if cursor.trim_start().starts_with('{') => parsed_cursor.per_page,
+            Some(_) => DEFAULT_WAHOO_INCREMENTAL_PER_PAGE,
+        };
         let mut workouts_to_import = Vec::new();
         let mut newest_seen_cursor = parsed_cursor.newest_seen.or(watermark.clone());
 
@@ -365,6 +372,7 @@ where
                         let resume_cursor = format_wahoo_resume_cursor(&WahooPollCursor {
                             watermark: watermark.clone(),
                             next_page: page,
+                            per_page,
                             newest_seen: newest_seen_cursor.clone(),
                         })?;
                         self.import_scanned_wahoo_workouts(
@@ -792,6 +800,8 @@ struct WahooPollCursor {
     watermark: Option<String>,
     #[serde(default = "default_wahoo_cursor_page")]
     next_page: usize,
+    #[serde(default = "default_wahoo_cursor_resume_per_page")]
+    per_page: usize,
     newest_seen: Option<String>,
 }
 
@@ -800,6 +810,7 @@ impl Default for WahooPollCursor {
         Self {
             watermark: None,
             next_page: default_wahoo_cursor_page(),
+            per_page: default_wahoo_cursor_resume_per_page(),
             newest_seen: None,
         }
     }
@@ -807,6 +818,10 @@ impl Default for WahooPollCursor {
 
 fn default_wahoo_cursor_page() -> usize {
     1
+}
+
+fn default_wahoo_cursor_resume_per_page() -> usize {
+    DEFAULT_WAHOO_INCREMENTAL_PER_PAGE
 }
 
 fn parse_wahoo_cursor(cursor: Option<&str>) -> Result<WahooPollCursor, String> {
@@ -819,6 +834,11 @@ fn parse_wahoo_cursor(cursor: Option<&str>) -> Result<WahooPollCursor, String> {
             if checkpoint.next_page == 0 {
                 return Err(format!(
                     "invalid Wahoo poll checkpoint '{cursor}': next_page must be at least 1"
+                ));
+            }
+            if checkpoint.per_page == 0 {
+                return Err(format!(
+                    "invalid Wahoo poll checkpoint '{cursor}': per_page must be at least 1"
                 ));
             }
             checkpoint.watermark = checkpoint
@@ -843,6 +863,7 @@ fn parse_wahoo_cursor(cursor: Option<&str>) -> Result<WahooPollCursor, String> {
             .map(|watermark| WahooPollCursor {
                 watermark: Some(watermark),
                 next_page: 1,
+                per_page: DEFAULT_WAHOO_INCREMENTAL_PER_PAGE,
                 newest_seen: None,
             })
             .map_err(|error| format!("invalid Wahoo poll cursor '{cursor}': {error}")),

--- a/src/config/provider_polling/tests/completed_workouts.rs
+++ b/src/config/provider_polling/tests/completed_workouts.rs
@@ -95,7 +95,7 @@ async fn first_wahoo_completed_sync_uses_two_year_bootstrap_watermark() {
     service.poll_due_once().await.unwrap();
 
     assert!(imports.commands().is_empty());
-    assert_eq!(wahoo.list_calls(), vec![("user-1".to_string(), 1, 30)]);
+    assert_eq!(wahoo.list_calls(), vec![("user-1".to_string(), 1, 100)]);
     let stored = poll_states
         .find_by_provider_and_stream(
             "user-1",
@@ -443,7 +443,7 @@ async fn wahoo_completed_stream_persists_partial_progress_when_later_page_fails(
             1_699_999_900,
         )]);
     let imports = RecordingImportService::default();
-    let workouts = (0..65)
+    let workouts = (0..205)
         .map(|index| {
             sample_wahoo_workout(
                 100 + index,
@@ -473,12 +473,12 @@ async fn wahoo_completed_stream_persists_partial_progress_when_later_page_fails(
     assert_eq!(
         wahoo.list_calls(),
         vec![
-            ("user-1".to_string(), 1, 30),
-            ("user-1".to_string(), 2, 30),
-            ("user-1".to_string(), 3, 30)
+            ("user-1".to_string(), 1, 100),
+            ("user-1".to_string(), 2, 100),
+            ("user-1".to_string(), 3, 100)
         ]
     );
-    assert_eq!(imports.commands().len(), 60);
+    assert_eq!(imports.commands().len(), 200);
 
     let stored = poll_states
         .find_by_provider_and_stream(
@@ -492,6 +492,7 @@ async fn wahoo_completed_stream_persists_partial_progress_when_later_page_fails(
     let cursor: serde_json::Value =
         serde_json::from_str(stored.cursor.as_deref().unwrap()).unwrap();
     assert_eq!(cursor["next_page"], json!(3));
+    assert_eq!(cursor["per_page"], json!(100));
     assert_eq!(cursor["watermark"], json!("2021-11-14T00:00:00+00:00"));
     assert_eq!(cursor["newest_seen"], json!("2023-11-30T09:00:00+00:00"));
     assert_eq!(stored.last_successful_at_epoch_seconds, None);
@@ -513,12 +514,13 @@ async fn wahoo_completed_stream_resumes_from_checkpoint_page_after_failure() {
         json!({
             "watermark": "2021-11-14T00:00:00+00:00",
             "next_page": 3,
+            "per_page": 100,
             "newest_seen": "2023-11-30T09:00:00+00:00"
         })
         .to_string(),
     );
 
-    let workouts = (0..95)
+    let workouts = (0..305)
         .map(|index| {
             sample_wahoo_workout(
                 100 + index,
@@ -544,9 +546,12 @@ async fn wahoo_completed_stream_resumes_from_checkpoint_page_after_failure() {
 
     assert_eq!(
         wahoo.list_calls(),
-        vec![("user-1".to_string(), 3, 30), ("user-1".to_string(), 4, 30)]
+        vec![
+            ("user-1".to_string(), 3, 100),
+            ("user-1".to_string(), 4, 100)
+        ]
     );
-    assert_eq!(imports.commands().len(), 35);
+    assert_eq!(imports.commands().len(), 105);
     let stored = poll_states
         .find_by_provider_and_stream(
             "user-1",

--- a/src/config/provider_polling/tests/completed_workouts.rs
+++ b/src/config/provider_polling/tests/completed_workouts.rs
@@ -3,6 +3,7 @@ use crate::domain::external_sync::{
     ProviderPollState, ProviderPollStateRepository, ProviderPollStream,
 };
 use crate::domain::intervals::IntervalsError;
+use serde_json::json;
 
 use super::{support::*, ProviderPollingService};
 
@@ -430,6 +431,134 @@ async fn wahoo_completed_stream_scans_later_pages_for_recently_edited_older_work
         .unwrap()
         .unwrap();
     assert_eq!(stored.cursor.as_deref(), Some("2023-11-21T09:00:00+00:00"));
+}
+
+#[tokio::test]
+async fn wahoo_completed_stream_persists_partial_progress_when_later_page_fails() {
+    let poll_states =
+        RecordingProviderPollStateRepository::with_states(vec![ProviderPollState::new(
+            "user-1".to_string(),
+            ExternalProvider::Wahoo,
+            ProviderPollStream::CompletedWorkouts,
+            1_699_999_900,
+        )]);
+    let imports = RecordingImportService::default();
+    let workouts = (0..65)
+        .map(|index| {
+            sample_wahoo_workout(
+                100 + index,
+                &format!("2023-11-{:02}T08:00:00Z", 30 - (index % 30)),
+                &format!("2023-11-{:02}T09:00:00+00:00", 30 - (index % 30)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let wahoo = RecordingWahooService::with_workouts_failing_on_page(
+        workouts,
+        3,
+        "Wahoo API request failed with status 429 Too Many Requests (oauth_error=Too Many Requests)",
+    );
+    let service = ProviderPollingService::new(
+        RecordingIntervalsApi::default(),
+        FakeIntervalsSettings,
+        poll_states.clone(),
+        imports.clone(),
+        FixedClock,
+        FixedIdGenerator,
+    )
+    .with_timing(300, 120)
+    .with_wahoo_service(std::sync::Arc::new(wahoo.clone()));
+
+    service.poll_due_once().await.unwrap();
+
+    assert_eq!(
+        wahoo.list_calls(),
+        vec![
+            ("user-1".to_string(), 1, 30),
+            ("user-1".to_string(), 2, 30),
+            ("user-1".to_string(), 3, 30)
+        ]
+    );
+    assert_eq!(imports.commands().len(), 60);
+
+    let stored = poll_states
+        .find_by_provider_and_stream(
+            "user-1",
+            ExternalProvider::Wahoo,
+            ProviderPollStream::CompletedWorkouts,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let cursor: serde_json::Value =
+        serde_json::from_str(stored.cursor.as_deref().unwrap()).unwrap();
+    assert_eq!(cursor["next_page"], json!(3));
+    assert_eq!(cursor["watermark"], json!("2021-11-14T00:00:00+00:00"));
+    assert_eq!(cursor["newest_seen"], json!("2023-11-30T09:00:00+00:00"));
+    assert_eq!(stored.last_successful_at_epoch_seconds, None);
+    assert_eq!(
+        stored.last_error.as_deref(),
+        Some("Wahoo API request failed with status 429 Too Many Requests (oauth_error=Too Many Requests)")
+    );
+}
+
+#[tokio::test]
+async fn wahoo_completed_stream_resumes_from_checkpoint_page_after_failure() {
+    let mut state = ProviderPollState::new(
+        "user-1".to_string(),
+        ExternalProvider::Wahoo,
+        ProviderPollStream::CompletedWorkouts,
+        1_699_999_900,
+    );
+    state.cursor = Some(
+        json!({
+            "watermark": "2021-11-14T00:00:00+00:00",
+            "next_page": 3,
+            "newest_seen": "2023-11-30T09:00:00+00:00"
+        })
+        .to_string(),
+    );
+
+    let workouts = (0..95)
+        .map(|index| {
+            sample_wahoo_workout(
+                100 + index,
+                &format!("2023-11-{:02}T08:00:00Z", 30 - (index % 30)),
+                &format!("2023-11-{:02}T09:00:00+00:00", 30 - (index % 30)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let poll_states = RecordingProviderPollStateRepository::with_states(vec![state]);
+    let imports = RecordingImportService::default();
+    let wahoo = RecordingWahooService::with_workouts(workouts);
+    let service = ProviderPollingService::new(
+        RecordingIntervalsApi::default(),
+        FakeIntervalsSettings,
+        poll_states.clone(),
+        imports.clone(),
+        FixedClock,
+        FixedIdGenerator,
+    )
+    .with_wahoo_service(std::sync::Arc::new(wahoo.clone()));
+
+    service.poll_due_once().await.unwrap();
+
+    assert_eq!(
+        wahoo.list_calls(),
+        vec![("user-1".to_string(), 3, 30), ("user-1".to_string(), 4, 30)]
+    );
+    assert_eq!(imports.commands().len(), 35);
+    let stored = poll_states
+        .find_by_provider_and_stream(
+            "user-1",
+            ExternalProvider::Wahoo,
+            ProviderPollStream::CompletedWorkouts,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.cursor.as_deref(), Some("2023-11-30T09:00:00+00:00"));
+    assert_eq!(stored.last_error, None);
+    assert_eq!(stored.last_successful_at_epoch_seconds, Some(1_700_000_000));
 }
 
 #[tokio::test]

--- a/src/config/provider_polling/tests/support.rs
+++ b/src/config/provider_polling/tests/support.rs
@@ -321,6 +321,7 @@ impl RecordingIntervalsApi {
 pub(super) struct RecordingWahooService {
     workouts: Arc<Mutex<Vec<WahooWorkout>>>,
     list_calls: Arc<Mutex<Vec<(String, usize, usize)>>>,
+    fail_on_page: Arc<Mutex<Option<(usize, String)>>>,
 }
 
 impl RecordingWahooService {
@@ -328,6 +329,19 @@ impl RecordingWahooService {
         Self {
             workouts: Arc::new(Mutex::new(workouts)),
             list_calls: Arc::new(Mutex::new(Vec::new())),
+            fail_on_page: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(super) fn with_workouts_failing_on_page(
+        workouts: Vec<WahooWorkout>,
+        page: usize,
+        message: &str,
+    ) -> Self {
+        Self {
+            workouts: Arc::new(Mutex::new(workouts)),
+            list_calls: Arc::new(Mutex::new(Vec::new())),
+            fail_on_page: Arc::new(Mutex::new(Some((page, message.to_string())))),
         }
     }
 
@@ -371,9 +385,15 @@ impl WahooUseCases for RecordingWahooService {
     ) -> crate::domain::wahoo::BoxFuture<Result<WahooWorkoutList, WahooError>> {
         let workouts = self.workouts.clone();
         let list_calls = self.list_calls.clone();
+        let fail_on_page = self.fail_on_page.clone();
         let user_id = user_id.to_string();
         Box::pin(async move {
             list_calls.lock().unwrap().push((user_id, page, per_page));
+            if let Some((failed_page, message)) = fail_on_page.lock().unwrap().clone() {
+                if failed_page == page {
+                    return Err(WahooError::External(message));
+                }
+            }
             let workouts = workouts.lock().unwrap().clone();
             let total = workouts.len();
             let start = (page.saturating_sub(1)) * per_page;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -47,6 +47,7 @@
 
 - When simplifying poll-cursor helpers, verify both branches explicitly: existing cursor plus new upstream results should usually advance, while existing cursor plus no new results may need to stay put. Do not drop the data-presence signal unless a regression test proves the simplified semantics are still correct.
 - If a polling loop filters fetched upstream records before import, do not tie cursor advancement only to the filtered subset unless repeated rereads of skipped records are intentional. Cursor/watermark movement usually belongs to the full consumed upstream page.
+- If a paginated provider bootstrap can span many pages, do not defer all durable progress until the entire scan succeeds. A later-page `429` or transient error can otherwise reset the bootstrap to zero forever. Persist a resumable checkpoint such as `next_page` plus the latest seen watermark before returning the failure.
 - In response/body mappers, decode a byte payload to UTF-8 once and reuse the borrowed text across classification and logging helpers instead of repeating `from_utf8(...)` work.
 - If parsed JSON string data is only compared against a static literal, keep it borrowed as `&str` and compare in place instead of allocating an owned `String` first.
 - When a review-driven change upgrades a match-strength enum or ranking rule, grep the touched test module for old enum expectations before shipping. Production code and review replies can be correct while one stale assertion still expects the pre-change ranking.

--- a/tests/intervals_adapters/activity_lists.rs
+++ b/tests/intervals_adapters/activity_lists.rs
@@ -169,8 +169,12 @@ async fn intervals_client_logs_list_activity_requests_without_query_string_leaka
         "normal list activity calls should not log response body previews, got: {logs}"
     );
     assert!(
-        !logs.contains("oldest=2026-03-01&newest=2026-03-31"),
-        "logs should not include raw query string, got: {logs}"
+        logs.contains("oldest=2026-03-01&newest=2026-03-31"),
+        "logs should include the whitelisted activity range query params, got: {logs}"
+    );
+    assert!(
+        !logs.contains("api_key="),
+        "logs should not include sensitive query params, got: {logs}"
     );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wahoo bootstrap polling now saves progress checkpoints when rate-limit errors occur, preventing loss of already-imported workouts and enabling seamless resumption from the last successful page.

* **Improvements**
  * Enhanced logging to sanitize sensitive query parameters across provider integrations while preserving pagination details needed for debugging.

* **Documentation**
  * Added guidance for handling partial failures during multi-page provider polling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->