### PR TITLE
fix: use JSON body instead of form-urlencoded for Wahoo API write ope…

### DIFF
--- a/src/adapters/wahoo/client.rs
+++ b/src/adapters/wahoo/client.rs
@@ -399,7 +399,7 @@ impl WahooApiPort for WahooOAuthClient {
                 .execute_api_write(
                     client
                         .bearer_post(client.api_url("/v1/plans"), &access_token)
-                        .form(&WahooCreatePlanRequest {
+                        .json(&WahooCreatePlanRequest {
                             plan: WahooCreatePlanRequestBody {
                                 file: request.file_base64,
                                 filename: request.filename,
@@ -432,7 +432,7 @@ impl WahooApiPort for WahooOAuthClient {
                             client.api_url(&format!("/v1/plans/{plan_id}")),
                             &access_token,
                         )
-                        .form(&WahooUpdatePlanRequest {
+                        .json(&WahooUpdatePlanRequest {
                             plan: WahooUpdatePlanRequestBody {
                                 file: request.file_base64,
                                 filename: request.filename,
@@ -529,7 +529,7 @@ impl WahooApiPort for WahooOAuthClient {
                 .execute_api_write(
                     client
                         .bearer_post(client.api_url("/v1/workouts"), &access_token)
-                        .form(&WahooCreateWorkoutRequest {
+                        .json(&WahooCreateWorkoutRequest {
                             workout: WahooCreateWorkoutRequestBody {
                                 name: request.name,
                                 workout_token: request.workout_token,
@@ -562,7 +562,7 @@ impl WahooApiPort for WahooOAuthClient {
                             client.api_url(&format!("/v1/workouts/{workout_id}")),
                             &access_token,
                         )
-                        .form(&WahooUpdateWorkoutRequest {
+                        .json(&WahooUpdateWorkoutRequest {
                             workout: WahooUpdateWorkoutRequestBody {
                                 name: request.name,
                                 workout_token: request.workout_token,


### PR DESCRIPTION
…rations

Form-encoded serialization of large base64 plan payloads was causing reqwest builder errors before the request could be sent. JSON body handles large payloads reliably and is widely supported by modern APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request payload format for Wahoo API write operations to ensure proper data transmission and compatibility with the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->