### PR TITLE
fix: send Wahoo plan files as form-encoded data URIs

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-04-27 | user | Wahoo planned-workout sync invalid file
+
+- Problem: Wahoo planned-workout sync sent `POST/PUT /v1/plans` as JSON with a raw base64 string in `plan.file`, while the Wahoo Plans API expects form-encoded fields and a file value wrapped as `data:application/json;base64,...`. That made valid generated `plan.json` payloads fail upstream with `422 Unprocessable Entity (oauth_error=Invalid file)`.
+- Fix: changed the Wahoo client plan create/update paths to send form bodies with `plan[file]`, `plan[filename]`, and provider metadata exactly as documented, wrapped the base64 payload in a JSON data URI, removed the now-dead plan JSON request DTOs, and added focused client tests for both create and update plan form construction.
+- Prevention: when an upstream API describes file uploads as `resource[file]` parameters, verify both the transport encoding (`form` vs `json`) and the exact file wrapper format (`data:<mime>;base64,...` vs raw base64) before assuming a nested JSON request body is acceptable.
+
 ### 2026-04-27 | Copilot/CodeRabbit | PR #152 manual calendar refresh review follow-up
 
 - Problem: PR review found five confirmed issues in the self-service calendar refresh feature: the rebuild range still used a full-table scan with a "9999-12-31" sentinel instead of two indexed date lookups, the frontend 401-redirect test restored `window.location` without `try/finally`, the backend handler leaked raw repository error messages and user identifiers in logs, the backend error mapping did not cover the new `InvariantViolation` variant from race/credential errors, and no REST test verified user scoping on the refresh endpoint.

--- a/src/adapters/wahoo/client.rs
+++ b/src/adapters/wahoo/client.rs
@@ -9,11 +9,10 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     adapters::wahoo::dto::{
-        WahooCreatePlanRequest, WahooCreatePlanRequestBody, WahooCreateWorkoutRequest,
-        WahooCreateWorkoutRequestBody, WahooFileReferenceResponse, WahooPlanResponse,
-        WahooTokenResponse, WahooUpdatePlanRequest, WahooUpdatePlanRequestBody,
-        WahooUpdateWorkoutRequest, WahooUpdateWorkoutRequestBody, WahooWorkoutListResponse,
-        WahooWorkoutResponse, WahooWorkoutSummaryResponse,
+        WahooCreateWorkoutRequest, WahooCreateWorkoutRequestBody, WahooFileReferenceResponse,
+        WahooPlanResponse, WahooTokenResponse, WahooUpdateWorkoutRequest,
+        WahooUpdateWorkoutRequestBody, WahooWorkoutListResponse, WahooWorkoutResponse,
+        WahooWorkoutSummaryResponse,
     },
     domain::wahoo::{
         BoxFuture, WahooApiPort, WahooCreatePlan, WahooCreateWorkout, WahooError,
@@ -23,6 +22,7 @@ use crate::{
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.wahooligan.com";
+const PLAN_FILE_MEDIA_TYPE: &str = "application/json";
 
 #[derive(Clone)]
 pub struct WahooOAuthClient {
@@ -196,6 +196,45 @@ fn map_file_reference(file: Option<WahooFileReferenceResponse>) -> Option<WahooF
 
 fn parse_optional_decimal(value: Option<String>) -> Option<f64> {
     value?.trim().parse().ok()
+}
+
+fn encode_base64_data_uri(media_type: &str, base64: &str) -> String {
+    format!("data:{media_type};base64,{base64}")
+}
+
+fn build_create_plan_form(request: WahooCreatePlan) -> Vec<(String, String)> {
+    vec![
+        (
+            "plan[file]".to_string(),
+            encode_base64_data_uri(PLAN_FILE_MEDIA_TYPE, &request.file_base64),
+        ),
+        (
+            "plan[filename]".to_string(),
+            request.filename.unwrap_or_else(|| "plan.json".to_string()),
+        ),
+        ("plan[external_id]".to_string(), request.external_id),
+        (
+            "plan[provider_updated_at]".to_string(),
+            request.provider_updated_at,
+        ),
+    ]
+}
+
+fn build_update_plan_form(request: WahooUpdatePlan) -> Vec<(String, String)> {
+    vec![
+        (
+            "plan[file]".to_string(),
+            encode_base64_data_uri(PLAN_FILE_MEDIA_TYPE, &request.file_base64),
+        ),
+        (
+            "plan[filename]".to_string(),
+            request.filename.unwrap_or_else(|| "plan.json".to_string()),
+        ),
+        (
+            "plan[provider_updated_at]".to_string(),
+            request.provider_updated_at,
+        ),
+    ]
 }
 
 fn map_workout_summary(summary: WahooWorkoutSummaryResponse) -> WahooWorkoutSummary {
@@ -395,18 +434,12 @@ impl WahooApiPort for WahooOAuthClient {
         let client = self.clone();
         let access_token = access_token.to_string();
         Box::pin(async move {
+            let form = build_create_plan_form(request);
             let payload: WahooPlanResponse = client
                 .execute_api_write(
                     client
                         .bearer_post(client.api_url("/v1/plans"), &access_token)
-                        .json(&WahooCreatePlanRequest {
-                            plan: WahooCreatePlanRequestBody {
-                                file: request.file_base64,
-                                filename: request.filename,
-                                external_id: request.external_id,
-                                provider_updated_at: request.provider_updated_at,
-                            },
-                        }),
+                        .form(&form),
                     logging::BodyLoggingMode::Full,
                 )
                 .await?;
@@ -425,6 +458,7 @@ impl WahooApiPort for WahooOAuthClient {
         let client = self.clone();
         let access_token = access_token.to_string();
         Box::pin(async move {
+            let form = build_update_plan_form(request);
             let payload: WahooPlanResponse = client
                 .execute_api_write(
                     client
@@ -432,13 +466,7 @@ impl WahooApiPort for WahooOAuthClient {
                             client.api_url(&format!("/v1/plans/{plan_id}")),
                             &access_token,
                         )
-                        .json(&WahooUpdatePlanRequest {
-                            plan: WahooUpdatePlanRequestBody {
-                                file: request.file_base64,
-                                filename: request.filename,
-                                provider_updated_at: request.provider_updated_at,
-                            },
-                        }),
+                        .form(&form),
                     logging::BodyLoggingMode::Full,
                 )
                 .await?;
@@ -620,7 +648,72 @@ impl WahooApiPort for WahooOAuthClient {
 
 #[cfg(test)]
 mod tests {
-    use super::summarize_error_body;
+    use super::{
+        build_create_plan_form, build_update_plan_form, encode_base64_data_uri,
+        summarize_error_body, PLAN_FILE_MEDIA_TYPE,
+    };
+    use crate::domain::wahoo::{WahooCreatePlan, WahooUpdatePlan};
+
+    #[test]
+    fn encode_base64_data_uri_prefixes_plan_payloads() {
+        assert_eq!(
+            encode_base64_data_uri(PLAN_FILE_MEDIA_TYPE, "eyJ0ZXN0Ijp0cnVlfQ=="),
+            "data:application/json;base64,eyJ0ZXN0Ijp0cnVlfQ=="
+        );
+    }
+
+    #[test]
+    fn create_plan_form_uses_data_uri_and_required_fields() {
+        let form = build_create_plan_form(WahooCreatePlan {
+            file_base64: "eyJoZWFkZXIiOnt9fQ==".to_string(),
+            filename: None,
+            external_id: "planned-workout-1".to_string(),
+            provider_updated_at: "2026-04-27T17:03:21.000Z".to_string(),
+        });
+
+        assert_eq!(
+            form,
+            vec![
+                (
+                    "plan[file]".to_string(),
+                    "data:application/json;base64,eyJoZWFkZXIiOnt9fQ==".to_string()
+                ),
+                ("plan[filename]".to_string(), "plan.json".to_string()),
+                (
+                    "plan[external_id]".to_string(),
+                    "planned-workout-1".to_string()
+                ),
+                (
+                    "plan[provider_updated_at]".to_string(),
+                    "2026-04-27T17:03:21.000Z".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn update_plan_form_keeps_filename_and_uses_data_uri() {
+        let form = build_update_plan_form(WahooUpdatePlan {
+            file_base64: "eyJpbnRlcnZhbHMiOltdfQ==".to_string(),
+            filename: Some("custom-plan.json".to_string()),
+            provider_updated_at: "2026-04-27T17:03:21.000Z".to_string(),
+        });
+
+        assert_eq!(
+            form,
+            vec![
+                (
+                    "plan[file]".to_string(),
+                    "data:application/json;base64,eyJpbnRlcnZhbHMiOltdfQ==".to_string()
+                ),
+                ("plan[filename]".to_string(), "custom-plan.json".to_string()),
+                (
+                    "plan[provider_updated_at]".to_string(),
+                    "2026-04-27T17:03:21.000Z".to_string()
+                ),
+            ]
+        );
+    }
 
     #[test]
     fn summarize_error_body_uses_utf8_preview_when_available() {

--- a/src/adapters/wahoo/dto.rs
+++ b/src/adapters/wahoo/dto.rs
@@ -81,33 +81,6 @@ pub struct WahooWorkoutListResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub struct WahooCreatePlanRequest {
-    pub plan: WahooCreatePlanRequestBody,
-}
-
-#[derive(Debug, Serialize)]
-pub struct WahooCreatePlanRequestBody {
-    pub file: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub filename: Option<String>,
-    pub external_id: String,
-    pub provider_updated_at: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct WahooUpdatePlanRequest {
-    pub plan: WahooUpdatePlanRequestBody,
-}
-
-#[derive(Debug, Serialize)]
-pub struct WahooUpdatePlanRequestBody {
-    pub file: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub filename: Option<String>,
-    pub provider_updated_at: String,
-}
-
-#[derive(Debug, Serialize)]
 pub struct WahooCreateWorkoutRequest {
     pub workout: WahooCreateWorkoutRequestBody,
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -45,6 +45,7 @@
 
 ## Small Review Fixes
 
+- For upstream file-upload APIs, do not assume a nested JSON body is equivalent to documented `resource[file]` params. Check whether the provider expects `application/x-www-form-urlencoded` or multipart transport and whether the file field must be wrapped as `data:<mime>;base64,...` instead of raw base64.
 - When simplifying poll-cursor helpers, verify both branches explicitly: existing cursor plus new upstream results should usually advance, while existing cursor plus no new results may need to stay put. Do not drop the data-presence signal unless a regression test proves the simplified semantics are still correct.
 - If a polling loop filters fetched upstream records before import, do not tie cursor advancement only to the filtered subset unless repeated rereads of skipped records are intentional. Cursor/watermark movement usually belongs to the full consumed upstream page.
 - If a paginated provider bootstrap can span many pages, do not defer all durable progress until the entire scan succeeds. A later-page `429` or transient error can otherwise reset the bootstrap to zero forever. Persist a resumable checkpoint such as `next_page` plus the latest seen watermark before returning the failure.


### PR DESCRIPTION
fix: send Wahoo plan files as form-encoded data URIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with Wahoo planned-workout synchronization that were preventing successful syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->