### PR TITLE
fix: avoid parked poll state datetime panic

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-04-29 | user | provider_poll_states parked sentinel crash
+
+- Problem: parked provider poll states intentionally used `next_due_at_epoch_seconds = i64::MAX` as a disabled sentinel, but the Mongo write mapper still tried to mirror that value into BSON `next_due_at`, which exceeds the `DateTime` range and panicked the release on startup.
+- Fix: taught `map_poll_state_to_document(...)` in `src/adapters/mongo/provider_poll_states.rs` to skip the readable `next_due_at` mirror when the parked sentinel is present, preserved the epoch sentinel for runtime behavior, and added a focused regression proving the parked state no longer attempts BSON datetime serialization.
+- Prevention: when dual-writing readable BSON datetimes beside epoch sentinel fields, audit every sentinel value before mirroring it into `DateTime`. Values that encode "disabled" or "parked" state must stay in the epoch field only unless they are valid BSON timestamps.
+
 ### 2026-04-29 | Copilot | PR #150 readable Mongo dates follow-up
 
 - Problem: the readable-date follow-up branch still had unresolved review gaps in Mongo timestamp migration paths and then picked up merge drift in `src/main.rs`, where old planned-workout sync repository wiring no longer matched the merged calendar/external-sync service signatures.

--- a/src/adapters/mongo/provider_poll_states.rs
+++ b/src/adapters/mongo/provider_poll_states.rs
@@ -173,13 +173,19 @@ impl ProviderPollStateRepository for MongoProviderPollStateRepository {
 }
 
 fn map_poll_state_to_document(state: &ProviderPollState) -> ProviderPollStateDocument {
+    let next_due_at = if state.next_due_at_epoch_seconds == i64::MAX {
+        None
+    } else {
+        datetime_or_panic(Some(state.next_due_at_epoch_seconds), "next_due_at")
+    };
+
     ProviderPollStateDocument {
         user_id: state.user_id.clone(),
         provider: provider_as_str(&state.provider).to_string(),
         stream: stream_as_str(&state.stream).to_string(),
         cursor: state.cursor.clone(),
         next_due_at_epoch_seconds: Some(state.next_due_at_epoch_seconds),
-        next_due_at: datetime_or_panic(Some(state.next_due_at_epoch_seconds), "next_due_at"),
+        next_due_at,
         last_attempted_at_epoch_seconds: state.last_attempted_at_epoch_seconds,
         last_attempted_at: datetime_or_panic(
             state.last_attempted_at_epoch_seconds,
@@ -406,5 +412,23 @@ mod tests {
             crate::domain::external_sync::ExternalSyncRepositoryError::CorruptData(message)
                 if message == "missing next_due_at timestamp"
         ));
+    }
+
+    #[test]
+    fn poll_state_document_keeps_parked_sentinel_without_datetime_mirror() {
+        let document = map_poll_state_to_document(&ProviderPollState {
+            user_id: "user-1".to_string(),
+            provider: ExternalProvider::Intervals,
+            stream: ProviderPollStream::Calendar,
+            cursor: None,
+            next_due_at_epoch_seconds: i64::MAX,
+            last_attempted_at_epoch_seconds: None,
+            last_successful_at_epoch_seconds: None,
+            last_error: None,
+            backoff_until_epoch_seconds: None,
+        });
+
+        assert_eq!(document.next_due_at_epoch_seconds, Some(i64::MAX));
+        assert_eq!(document.next_due_at, None);
     }
 }


### PR DESCRIPTION
fix: avoid parked poll state datetime panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved a critical startup panic that occurred when the application encountered parked provider poll states, which were incorrectly serialized to MongoDB causing datetime range overflow.

## Tests
* Added regression test to verify parked provider poll states are handled correctly and do not cause serialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->