### PR TITLE
fix: harden workout summary alias handling

### DIFF
--- a/docs/plans/2026-04-28-wahoo-sync-state-migration.md
+++ b/docs/plans/2026-04-28-wahoo-sync-state-migration.md
@@ -6,6 +6,7 @@ This note describes the repository scripts used to migrate legacy Wahoo planned-
 
 - `scripts/mongo-migrate-wahoo-sync-states.js`
 - `scripts/mongo-verify-wahoo-sync-states.js`
+- `scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js`
 - `scripts/mongo-cleanup-legacy-wahoo-sync-states.js`
 
 ## Collections
@@ -25,8 +26,10 @@ This note describes the repository scripts used to migrate legacy Wahoo planned-
 1. Dry run the migration.
 2. Apply the migration.
 3. Verify the migrated rows.
-4. Dry run the cleanup.
-5. Apply the cleanup only after verification is clean.
+4. Optional: dry run the field-only cleanup.
+5. Optional: apply the field-only cleanup.
+6. Dry run the row cleanup.
+7. Apply the row cleanup only after verification is clean.
 
 ## Commands
 
@@ -50,11 +53,25 @@ MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-verify-
 
 ### 4. Cleanup Dry Run
 
+Field-only cleanup dry run:
+
+```bash
+MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+```
+
+### 5. Apply Field Cleanup
+
+```bash
+MIGRATION_APPLY=true MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+```
+
+### 6. Cleanup Dry Run
+
 ```bash
 MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-states.js
 ```
 
-### 5. Apply Cleanup
+### 7. Apply Cleanup
 
 ```bash
 MIGRATION_APPLY=true MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-states.js
@@ -71,6 +88,10 @@ MIGRATION_USER_ID=user-1 MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --f
 ```
 
 ```bash
+MIGRATION_APPLY=true MIGRATION_USER_ID=user-1 MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+```
+
+```bash
 MIGRATION_APPLY=true MIGRATION_USER_ID=user-1 MONGODB_DATABASE=aiwattcoach mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-states.js
 ```
 
@@ -78,4 +99,5 @@ MIGRATION_APPLY=true MIGRATION_USER_ID=user-1 MONGODB_DATABASE=aiwattcoach mongo
 
 - The migration aborts if the source collection contains duplicate non-null `wahoo_plan_id` or `wahoo_workout_token` values for the same user, because the target collection now enforces those lookups as unique.
 - By default the migration skips target rows that already exist for the same `(user_id, provider, canonical_entity_kind, canonical_entity_id)` key. Use `MIGRATION_OVERWRITE_EXISTING=true` only if you explicitly want to replace already-migrated rows.
+- Field-only cleanup unsets only the migrated Wahoo sync payload fields from legacy rows and leaves identifier/audit fields like `planned_workout_id`, `operation_key`, `date`, `source_workout_id`, `created_at*`, and `updated_at*` in place.
 - Cleanup deletes only source rows whose corresponding migrated target row exists and matches the expected migrated shape. Rows without a matching target row, or rows whose migrated document differs, are left in place and reported.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-04-30 | internal review loop | workout summary alias follow-up
+
+- Problem: the first completed-workout summary alias patch still had four confirmed review gaps: missing-`source_activity_id` fallback collapsed canonical ids to stripped activity ids, saved-workout side effects used the preferred alias instead of the persisted storage key and could drift operation ids on retry, `list_summaries(...)` could return the same summary twice when both aliases were requested, and batch `find_by_user_id_and_workout_ids(...)` no longer matched equivalent completed-workout aliases needed by `training_context`.
+- Fix: kept missing-`source_activity_id` targets on `completed_workout_id`, tracked the matched repository storage key inside `ResolvedWorkoutSummaryTarget`, drove saved-workout recap/plan side effects from that storage key, deduped `list_summaries(...)` by summary id after alias resolution, and taught batch summary lookup in both Mongo and in-memory test repositories to match equivalent completed-workout aliases.
+- Prevention: when adding alias resolution above a repository boundary, verify three separate surfaces before review: fallback identity selection when canonical metadata is missing, side effects that derive operation keys from ids, and batch lookup/list APIs used by downstream read models. Single-item get/create coverage is not enough.
+
 ### 2026-04-29 | user | workout detail modal black screen after summary refactor
 
 - Problem: after moving completed-workout summary loading into `WorkoutDetailModal`, the new `useCompletedWorkoutSummary(...)` call sat below `if (!selection) return null`. Opening workout details changes the modal from `selection = null` to a real selection, so React saw a different number of hooks between renders and crashed the page with a minified hook-order error.

--- a/scripts/mongo-backfill-readable-dates.js
+++ b/scripts/mongo-backfill-readable-dates.js
@@ -1,0 +1,28 @@
+/*
+Usage:
+
+  Run from the repository root:
+    MONGODB_DATABASE=aiwatt mongosh "$MONGODB_URI" --file scripts/mongo-backfill-readable-dates.js
+
+Optional environment variables:
+  MONGODB_DATABASE  Optional. Uses the current db when omitted.
+
+Notes:
+  - This is the main entrypoint for backfilling readable BSON DateTime mirror fields.
+  - The actual audited migration logic lives in:
+      docs/migrations/2026-04-29-readable-mongo-dates-backfill.mongodb.js
+  - The underlying script is idempotent: safe to run multiple times.
+  - It backfills only collections that currently have both legacy epoch fields and runtime
+    `*_at` DateTime mirror fields in the Mongo adapters.
+*/
+
+(function runReadableDatesBackfill() {
+  const databaseName = process.env.MONGODB_DATABASE;
+
+  if (databaseName) {
+    db = db.getSiblingDB(databaseName);
+  }
+
+  print("Running readable-date backfill entrypoint for database: " + db.getName());
+  load("docs/migrations/2026-04-29-readable-mongo-dates-backfill.mongodb.js");
+})();

--- a/scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+++ b/scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
@@ -1,0 +1,369 @@
+/*
+Usage:
+
+  Dry run (default):
+    MONGODB_DATABASE=aiwatt mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+
+  Apply field cleanup:
+    MIGRATION_APPLY=true MONGODB_DATABASE=aiwatt mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+
+  Cleanup one user only:
+    MIGRATION_APPLY=true MIGRATION_USER_ID=user-1 MONGODB_DATABASE=aiwatt mongosh "$MONGODB_URI" --file scripts/mongo-cleanup-legacy-wahoo-sync-state-fields.js
+
+Environment variables:
+  MONGODB_DATABASE            Optional. Uses the current db when omitted.
+  MIGRATION_SOURCE_COLLECTION Optional. Default: planned_workout_wahoo_syncs
+  MIGRATION_TARGET_COLLECTION Optional. Default: external_sync_states
+  MIGRATION_USER_ID           Optional. Limit cleanup to one user.
+  MIGRATION_APPLY             Optional. Set to true to write changes.
+
+Safety:
+  - Dry run is the default.
+  - Unsets only legacy fields that have already been migrated into external_sync_states.
+  - Touches only source rows whose migrated target row exists and matches the expected migrated shape.
+  - Leaves unmatched or mismatched legacy rows unchanged and reports them.
+*/
+
+const LEGACY_FIELDS_TO_UNSET = [
+  "payload_hash",
+  "status",
+  "wahoo_plan_external_id",
+  "wahoo_plan_id",
+  "wahoo_workout_id",
+  "wahoo_workout_token",
+  "last_error",
+  "last_synced_at_epoch_seconds",
+  "last_synced_at",
+];
+
+(function cleanupLegacyWahooSyncStateFields() {
+  const config = readConfig();
+  const database = resolveDatabase(config.databaseName);
+  const source = database.getCollection(config.sourceCollection);
+  const target = database.getCollection(config.targetCollection);
+  const sourceFilter = buildSourceFilter(config.userId);
+
+  printSection("Configuration");
+  printjson({
+    database: database.getName(),
+    sourceCollection: config.sourceCollection,
+    targetCollection: config.targetCollection,
+    userId: config.userId,
+    apply: config.apply,
+    fieldsToUnset: LEGACY_FIELDS_TO_UNSET,
+  });
+
+  const summary = {
+    scanned: 0,
+    eligibleForUnset: 0,
+    alreadyClean: 0,
+    missingTarget: 0,
+    mismatch: 0,
+    bulkWriteOps: 0,
+    matchedCount: 0,
+    modifiedCount: 0,
+    eligibleSamples: [],
+    alreadyCleanSamples: [],
+    missingTargetSamples: [],
+    mismatchSamples: [],
+  };
+  const operations = [];
+  const cursor = source.find(sourceFilter).sort({ user_id: 1, planned_workout_id: 1 });
+
+  while (cursor.hasNext()) {
+    const legacy = cursor.next();
+    const expected = mapLegacySyncDocument(legacy);
+    const actual = target.findOne(buildTargetFilter(expected));
+
+    summary.scanned += 1;
+
+    if (!actual) {
+      summary.missingTarget += 1;
+      pushSample(summary.missingTargetSamples, {
+        legacy_id: legacy._id,
+        user_id: legacy.user_id,
+        planned_workout_id: legacy.planned_workout_id,
+      });
+      continue;
+    }
+
+    const diffs = diffMigratedDocument(expected, actual);
+    if (diffs.length > 0) {
+      summary.mismatch += 1;
+      pushSample(summary.mismatchSamples, {
+        legacy_id: legacy._id,
+        user_id: legacy.user_id,
+        planned_workout_id: legacy.planned_workout_id,
+        diffs,
+      });
+      continue;
+    }
+
+    const unsetSpec = buildUnsetSpec(legacy);
+    if (!unsetSpec) {
+      summary.alreadyClean += 1;
+      pushSample(summary.alreadyCleanSamples, {
+        legacy_id: legacy._id,
+        user_id: legacy.user_id,
+        planned_workout_id: legacy.planned_workout_id,
+      });
+      continue;
+    }
+
+    summary.eligibleForUnset += 1;
+    pushSample(summary.eligibleSamples, {
+      legacy_id: legacy._id,
+      user_id: legacy.user_id,
+      planned_workout_id: legacy.planned_workout_id,
+      fields: Object.keys(unsetSpec),
+    });
+
+    if (!config.apply) {
+      continue;
+    }
+
+    operations.push({
+      updateOne: {
+        filter: { _id: legacy._id },
+        update: { $unset: unsetSpec },
+      },
+    });
+
+    if (operations.length >= 500) {
+      flushOperations(source, operations, summary);
+    }
+  }
+
+  if (config.apply) {
+    flushOperations(source, operations, summary);
+  }
+
+  printSection(config.apply ? "Field Cleanup Summary" : "Field Cleanup Dry Run Summary");
+  printjson(summary);
+
+  if (!config.apply) {
+    print("Dry run only. Re-run with MIGRATION_APPLY=true to unset eligible legacy fields.");
+  }
+})();
+
+function readConfig() {
+  return {
+    databaseName: readEnv("MONGODB_DATABASE", null),
+    sourceCollection: readEnv("MIGRATION_SOURCE_COLLECTION", "planned_workout_wahoo_syncs"),
+    targetCollection: readEnv("MIGRATION_TARGET_COLLECTION", "external_sync_states"),
+    userId: readEnv("MIGRATION_USER_ID", null),
+    apply: readEnv("MIGRATION_APPLY", "false") === "true",
+  };
+}
+
+function readEnv(name, fallbackValue) {
+  const value = process.env[name];
+  return value === undefined || value === "" ? fallbackValue : value;
+}
+
+function resolveDatabase(databaseName) {
+  return databaseName ? db.getSiblingDB(databaseName) : db;
+}
+
+function buildSourceFilter(userId) {
+  if (!userId) {
+    return {};
+  }
+
+  return { user_id: userId };
+}
+
+function buildTargetFilter(migrated) {
+  return {
+    user_id: migrated.user_id,
+    provider: migrated.provider,
+    canonical_entity_kind: migrated.canonical_entity_kind,
+    canonical_entity_id: migrated.canonical_entity_id,
+  };
+}
+
+function buildUnsetSpec(legacy) {
+  const unsetSpec = {};
+
+  LEGACY_FIELDS_TO_UNSET.forEach((fieldName) => {
+    if (Object.prototype.hasOwnProperty.call(legacy, fieldName)) {
+      unsetSpec[fieldName] = "";
+    }
+  });
+
+  return Object.keys(unsetSpec).length > 0 ? unsetSpec : null;
+}
+
+function mapLegacySyncDocument(legacy) {
+  const lastSyncedAtEpochSeconds = resolveLegacyLastSyncedEpochSeconds(legacy);
+  const includeRemoteSnapshot =
+    legacy.status === "synced" || legacy.status === "failed";
+
+  return {
+    user_id: legacy.user_id,
+    provider: "wahoo",
+    canonical_entity_kind: "planned_workout",
+    canonical_entity_id: legacy.planned_workout_id,
+    external_id:
+      legacy.wahoo_workout_id === undefined || legacy.wahoo_workout_id === null
+        ? null
+        : String(legacy.wahoo_workout_id),
+    wahoo_plan_external_id: legacy.wahoo_plan_external_id ?? null,
+    wahoo_plan_id: legacy.wahoo_plan_id ?? null,
+    wahoo_workout_id: legacy.wahoo_workout_id ?? null,
+    wahoo_workout_token: legacy.wahoo_workout_token ?? null,
+    sync_status: mapLegacyStatus(legacy.status),
+    last_synced_payload_hash: legacy.payload_hash ?? null,
+    last_seen_remote_payload_hash: includeRemoteSnapshot ? legacy.payload_hash ?? null : null,
+    last_error:
+      legacy.status === "failed"
+        ? legacy.last_error ?? "wahoo sync failed"
+        : legacy.last_error ?? null,
+    last_synced_at_epoch_seconds: lastSyncedAtEpochSeconds,
+    last_seen_remote_at_epoch_seconds: includeRemoteSnapshot ? lastSyncedAtEpochSeconds : null,
+    conflict_status: legacy.status === "synced" ? "in_sync" : "unknown",
+  };
+}
+
+function mapLegacyStatus(status) {
+  switch (status) {
+    case "synced":
+      return "synced";
+    case "failed":
+      return "failed";
+    case "pending":
+    case "unsynced":
+    case "modified":
+      return "pending";
+    default:
+      throw new Error(`Unsupported legacy Wahoo sync status: ${status}`);
+  }
+}
+
+function resolveLegacyLastSyncedEpochSeconds(legacy) {
+  const lastSynced = resolveEpochSeconds(
+    legacy.last_synced_at,
+    legacy.last_synced_at_epoch_seconds,
+  );
+
+  if (lastSynced !== null) {
+    return lastSynced;
+  }
+
+  if (legacy.status !== "synced") {
+    return null;
+  }
+
+  return resolveEpochSeconds(legacy.updated_at, legacy.updated_at_epoch_seconds);
+}
+
+function resolveEpochSeconds(dateValue, epochValue) {
+  if (epochValue !== undefined && epochValue !== null) {
+    return epochValue;
+  }
+
+  if (dateValue === undefined || dateValue === null) {
+    return null;
+  }
+
+  if (typeof dateValue.getTime === "function") {
+    return Math.floor(dateValue.getTime() / 1000);
+  }
+
+  throw new Error(`Unsupported date value: ${tojson(dateValue)}`);
+}
+
+function diffMigratedDocument(expected, actual) {
+  const diffs = [];
+  const actualLastSyncedAt = resolveEpochSeconds(
+    actual.last_synced_at,
+    actual.last_synced_at_epoch_seconds,
+  );
+  const actualLastSeenRemoteAt = resolveEpochSeconds(
+    actual.last_seen_remote_at,
+    actual.last_seen_remote_at_epoch_seconds,
+  );
+
+  compareField(diffs, "external_id", expected.external_id, actual.external_id ?? null);
+  compareField(
+    diffs,
+    "wahoo_plan_external_id",
+    expected.wahoo_plan_external_id,
+    actual.wahoo_plan_external_id ?? null,
+  );
+  compareField(diffs, "wahoo_plan_id", expected.wahoo_plan_id, actual.wahoo_plan_id ?? null);
+  compareField(
+    diffs,
+    "wahoo_workout_id",
+    expected.wahoo_workout_id,
+    actual.wahoo_workout_id ?? null,
+  );
+  compareField(
+    diffs,
+    "wahoo_workout_token",
+    expected.wahoo_workout_token,
+    actual.wahoo_workout_token ?? null,
+  );
+  compareField(diffs, "sync_status", expected.sync_status, actual.sync_status ?? null);
+  compareField(
+    diffs,
+    "last_synced_payload_hash",
+    expected.last_synced_payload_hash,
+    actual.last_synced_payload_hash ?? null,
+  );
+  compareField(
+    diffs,
+    "last_seen_remote_payload_hash",
+    expected.last_seen_remote_payload_hash,
+    actual.last_seen_remote_payload_hash ?? null,
+  );
+  compareField(diffs, "last_error", expected.last_error, actual.last_error ?? null);
+  compareField(
+    diffs,
+    "last_synced_at_epoch_seconds",
+    expected.last_synced_at_epoch_seconds,
+    actualLastSyncedAt,
+  );
+  compareField(
+    diffs,
+    "last_seen_remote_at_epoch_seconds",
+    expected.last_seen_remote_at_epoch_seconds,
+    actualLastSeenRemoteAt,
+  );
+  compareField(
+    diffs,
+    "conflict_status",
+    expected.conflict_status,
+    actual.conflict_status ?? null,
+  );
+
+  return diffs;
+}
+
+function compareField(diffs, fieldName, expected, actual) {
+  if (expected !== actual) {
+    diffs.push({ field: fieldName, expected, actual });
+  }
+}
+
+function flushOperations(source, operations, summary) {
+  if (operations.length === 0) {
+    return;
+  }
+
+  const result = source.bulkWrite(operations, { ordered: false });
+  summary.bulkWriteOps += operations.length;
+  summary.matchedCount += result.matchedCount ?? 0;
+  summary.modifiedCount += result.modifiedCount ?? 0;
+  operations.length = 0;
+}
+
+function pushSample(samples, sample) {
+  if (samples.length < 10) {
+    samples.push(sample);
+  }
+}
+
+function printSection(title) {
+  print(`\n=== ${title} ===`);
+}

--- a/src/adapters/mongo/training_plan_projections.rs
+++ b/src/adapters/mongo/training_plan_projections.rs
@@ -252,6 +252,12 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
 
             let superseded_range_start =
                 std::cmp::max(today.as_str(), snapshot.start_date.as_str());
+            let same_operation_active_date_range = load_active_operation_date_range(
+                &collection,
+                &snapshot.user_id,
+                &snapshot.operation_key,
+            )
+            .await?;
 
             let max_active_date: Option<String> = collection
                 .clone()
@@ -275,16 +281,33 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
                 .map(|date| std::cmp::max(snapshot.end_date.as_str(), date.as_str()))
                 .unwrap_or(snapshot.end_date.as_str())
                 .to_string();
+            let superseded_refresh_start = same_operation_active_date_range
+                .as_ref()
+                .map(|(start, _)| std::cmp::min(superseded_range_start, start.as_str()))
+                .unwrap_or(superseded_range_start)
+                .to_string();
+            let superseded_refresh_end = same_operation_active_date_range
+                .as_ref()
+                .map(|(_, end)| std::cmp::max(superseded_range_end.as_str(), end.as_str()))
+                .unwrap_or(superseded_range_end.as_str())
+                .to_string();
 
             let update_result = collection
                 .update_many(
                     doc! {
                         "user_id": &snapshot.user_id,
                         "superseded_at_epoch_seconds": mongodb::bson::Bson::Null,
-                        "date": {
-                            "$gte": superseded_range_start,
-                            "$lte": &superseded_range_end,
-                        },
+                        "$or": [
+                            {
+                                "date": {
+                                    "$gte": superseded_range_start,
+                                    "$lte": &superseded_range_end,
+                                },
+                            },
+                            {
+                                "operation_key": &snapshot.operation_key,
+                            },
+                        ],
                     },
                     doc! {
                         "$set": {
@@ -299,10 +322,7 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
             let superseded_date_range = if update_result.matched_count == 0 {
                 None
             } else {
-                Some((
-                    superseded_range_start.to_string(),
-                    superseded_range_end.clone(),
-                ))
+                Some((superseded_refresh_start, superseded_refresh_end))
             };
 
             snapshot_collection
@@ -336,6 +356,33 @@ impl TrainingPlanProjectionRepository for MongoTrainingPlanProjectionRepository 
             })
         })
     }
+}
+
+async fn load_active_operation_date_range(
+    collection: &Collection<TrainingPlanProjectedDayDocument>,
+    user_id: &str,
+    operation_key: &str,
+) -> Result<Option<(String, String)>, TrainingPlanError> {
+    let dates = collection
+        .clone()
+        .clone_with_type::<mongodb::bson::Document>()
+        .find(doc! {
+            "user_id": user_id,
+            "operation_key": operation_key,
+            "superseded_at_epoch_seconds": mongodb::bson::Bson::Null,
+        })
+        .sort(doc! { "date": 1 })
+        .projection(doc! { "date": 1, "_id": 0 })
+        .await
+        .map_err(|error| TrainingPlanError::Repository(error.to_string()))?
+        .try_collect::<Vec<_>>()
+        .await
+        .map_err(|error| TrainingPlanError::Repository(error.to_string()))?
+        .into_iter()
+        .filter_map(|doc| doc.get_str("date").ok().map(String::from))
+        .collect::<Vec<_>>();
+
+    Ok(dates.first().cloned().zip(dates.last().cloned()))
 }
 
 fn map_projected_day_to_document(

--- a/src/adapters/mongo/workout_summary.rs
+++ b/src/adapters/mongo/workout_summary.rs
@@ -12,9 +12,12 @@ use super::time::{
 };
 use crate::{
     adapters::mongo::error::is_duplicate_key_error,
-    domain::workout_summary::{
-        BoxFuture, ConversationMessage, MessageRole, WorkoutRecap, WorkoutSummary,
-        WorkoutSummaryError, WorkoutSummaryRepository,
+    domain::{
+        completed_workouts::{canonical_completed_workout_id, completed_workout_activity_id},
+        workout_summary::{
+            BoxFuture, ConversationMessage, MessageRole, WorkoutRecap, WorkoutSummary,
+            WorkoutSummaryError, WorkoutSummaryRepository,
+        },
     },
 };
 
@@ -422,10 +425,17 @@ async fn find_preferred_documents(
         return Ok(Vec::new());
     }
 
+    let current_lookup_ids = workout_ids
+        .iter()
+        .flat_map(|workout_id| current_lookup_ids_for_request(workout_id))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
     let current_documents = collection
         .find(doc! {
             "user_id": user_id,
-            "workout_id": { "$in": workout_ids },
+            "workout_id": { "$in": current_lookup_ids },
         })
         .await
         .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))?
@@ -433,7 +443,7 @@ async fn find_preferred_documents(
         .await
         .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))?;
 
-    let mut preferred_by_workout_id = current_documents
+    let mut preferred_by_storage_workout_id = current_documents
         .into_iter()
         .map(|document| (document.workout_id.clone(), document))
         .collect::<std::collections::BTreeMap<_, _>>();
@@ -444,7 +454,7 @@ async fn find_preferred_documents(
 
     let missing_workout_ids = workout_ids
         .iter()
-        .filter(|workout_id| !preferred_by_workout_id.contains_key(workout_id.as_str()))
+        .filter(|workout_id| !preferred_by_storage_workout_id.contains_key(workout_id.as_str()))
         .cloned()
         .collect::<Vec<_>>();
 
@@ -461,16 +471,65 @@ async fn find_preferred_documents(
             .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))?;
 
         for document in legacy_documents {
-            preferred_by_workout_id
+            preferred_by_storage_workout_id
                 .entry(document.workout_id.clone())
                 .or_insert(document);
         }
     }
 
+    let mut preferred_by_requested_workout_id = std::collections::BTreeMap::new();
+
+    for workout_id in workout_ids {
+        if let Some(mut document) = preferred_by_storage_workout_id.remove(workout_id) {
+            document.workout_id = workout_id.clone();
+            preferred_by_requested_workout_id.insert(workout_id.clone(), document);
+            continue;
+        }
+
+        if let Some(mut document) = preferred_by_storage_workout_id
+            .values()
+            .find(|document| matches_requested_workout_id(document, workout_id))
+            .cloned()
+        {
+            document.workout_id = workout_id.clone();
+            preferred_by_requested_workout_id.insert(workout_id.clone(), document);
+        }
+    }
+
     Ok(workout_ids
         .iter()
-        .filter_map(|workout_id| preferred_by_workout_id.remove(workout_id))
+        .filter_map(|workout_id| preferred_by_requested_workout_id.remove(workout_id))
         .collect())
+}
+
+fn matches_requested_workout_id(
+    document: &WorkoutSummaryDocument,
+    requested_workout_id: &str,
+) -> bool {
+    document.workout_id == requested_workout_id
+        || document.workout_id == canonical_completed_workout_id(requested_workout_id)
+        || completed_workout_activity_id(&document.workout_id) == requested_workout_id
+}
+
+fn current_lookup_ids_for_request(requested_workout_id: &str) -> Vec<String> {
+    let mut lookup_ids = Vec::new();
+    let activity_id = completed_workout_activity_id(requested_workout_id);
+
+    push_unique_lookup_id(&mut lookup_ids, requested_workout_id.to_string());
+    push_unique_lookup_id(&mut lookup_ids, activity_id.to_string());
+    push_unique_lookup_id(
+        &mut lookup_ids,
+        canonical_completed_workout_id(requested_workout_id),
+    );
+    push_unique_lookup_id(&mut lookup_ids, format!("wahoo-workout:{activity_id}"));
+
+    lookup_ids
+}
+
+fn push_unique_lookup_id(lookup_ids: &mut Vec<String>, workout_id: String) {
+    if !lookup_ids.contains(&workout_id) {
+        lookup_ids.push(workout_id);
+    }
 }
 
 async fn find_preferred_message_lookup_document(

--- a/src/adapters/workout_summary_completed_target.rs
+++ b/src/adapters/workout_summary_completed_target.rs
@@ -1,6 +1,9 @@
 use crate::domain::{
     completed_workouts::{canonical_completed_workout_id, CompletedWorkoutRepository},
-    workout_summary::{BoxFuture, CompletedWorkoutTargetUseCases, WorkoutSummaryError},
+    workout_summary::{
+        BoxFuture, CompletedWorkoutTargetUseCases, ResolvedCompletedWorkoutTarget,
+        WorkoutSummaryError,
+    },
 };
 
 #[derive(Clone)]
@@ -27,21 +30,63 @@ where
         let user_id = user_id.to_string();
         let workout_id = workout_id.to_string();
         Box::pin(async move {
-            match repository
-                .find_by_user_id_and_source_activity_id(&user_id, &workout_id)
-                .await
-            {
-                Ok(Some(_)) => Ok(true),
-                Ok(None) => repository
-                    .find_by_user_id_and_completed_workout_id(
-                        &user_id,
-                        &canonical_completed_workout_id(&workout_id),
-                    )
-                    .await
-                    .map(|workout| workout.is_some())
-                    .map_err(|error| WorkoutSummaryError::Repository(error.to_string())),
-                Err(error) => Err(WorkoutSummaryError::Repository(error.to_string())),
-            }
+            let resolved = resolve_completed_workout(&repository, &user_id, &workout_id).await?;
+            Ok(resolved.is_some())
         })
+    }
+
+    fn resolve_completed_workout_target(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+    ) -> BoxFuture<Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>> {
+        let repository = self.repository.clone();
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        Box::pin(async move {
+            Ok(
+                resolve_completed_workout(&repository, &user_id, &workout_id)
+                    .await?
+                    .map(|workout| {
+                        let completed_workout_id = workout.completed_workout_id;
+                        let preferred_workout_id = workout
+                            .source_activity_id
+                            .unwrap_or_else(|| completed_workout_id.clone());
+                        let mut equivalent_workout_ids = vec![preferred_workout_id.clone()];
+                        if !equivalent_workout_ids.contains(&completed_workout_id) {
+                            equivalent_workout_ids.push(completed_workout_id);
+                        }
+
+                        ResolvedCompletedWorkoutTarget {
+                            preferred_workout_id,
+                            equivalent_workout_ids,
+                        }
+                    }),
+            )
+        })
+    }
+}
+
+async fn resolve_completed_workout<Repo>(
+    repository: &Repo,
+    user_id: &str,
+    workout_id: &str,
+) -> Result<Option<crate::domain::completed_workouts::CompletedWorkout>, WorkoutSummaryError>
+where
+    Repo: CompletedWorkoutRepository + Clone + Send + Sync + 'static,
+{
+    match repository
+        .find_by_user_id_and_source_activity_id(user_id, workout_id)
+        .await
+    {
+        Ok(Some(workout)) => Ok(Some(workout)),
+        Ok(None) => repository
+            .find_by_user_id_and_completed_workout_id(
+                user_id,
+                &canonical_completed_workout_id(workout_id),
+            )
+            .await
+            .map_err(|error| WorkoutSummaryError::Repository(error.to_string())),
+        Err(error) => Err(WorkoutSummaryError::Repository(error.to_string())),
     }
 }

--- a/src/domain/races/tests.rs
+++ b/src/domain/races/tests.rs
@@ -430,9 +430,12 @@ impl RaceRepository for InMemoryRaceRepository {
 #[derive(Clone, Default)]
 struct RecordingIntervalsService {
     created_events: Arc<Mutex<Vec<CreateEvent>>>,
+    create_event_user_ids: Arc<Mutex<Vec<String>>>,
     updated_events: Arc<Mutex<Vec<(i64, UpdateEvent)>>>,
+    update_event_user_ids: Arc<Mutex<Vec<String>>>,
     deleted_event_ids: Arc<Mutex<Vec<i64>>>,
     listed_events: Arc<Mutex<Vec<Event>>>,
+    list_event_user_ids: Arc<Mutex<Vec<String>>>,
     fail_updates: bool,
 }
 
@@ -486,11 +489,16 @@ impl RecordingIntervalsService {
 impl IntervalsUseCases for RecordingIntervalsService {
     fn list_events(
         &self,
-        _user_id: &str,
+        user_id: &str,
         _range: &DateRange,
     ) -> IntervalsBoxFuture<Result<Vec<Event>, IntervalsError>> {
         let listed_events = self.listed_events.clone();
-        Box::pin(async move { Ok(listed_events.lock().unwrap().clone()) })
+        let list_event_user_ids = self.list_event_user_ids.clone();
+        let user_id = user_id.to_string();
+        Box::pin(async move {
+            list_event_user_ids.lock().unwrap().push(user_id);
+            Ok(listed_events.lock().unwrap().clone())
+        })
     }
 
     fn get_event(
@@ -503,11 +511,14 @@ impl IntervalsUseCases for RecordingIntervalsService {
 
     fn create_event(
         &self,
-        _user_id: &str,
+        user_id: &str,
         event: CreateEvent,
     ) -> IntervalsBoxFuture<Result<Event, IntervalsError>> {
         let created_events = self.created_events.clone();
+        let create_event_user_ids = self.create_event_user_ids.clone();
+        let user_id = user_id.to_string();
         Box::pin(async move {
+            create_event_user_ids.lock().unwrap().push(user_id);
             created_events.lock().unwrap().push(event.clone());
             Ok(Event {
                 id: 77,
@@ -525,16 +536,19 @@ impl IntervalsUseCases for RecordingIntervalsService {
 
     fn update_event(
         &self,
-        _user_id: &str,
+        user_id: &str,
         event_id: i64,
         event: UpdateEvent,
     ) -> IntervalsBoxFuture<Result<Event, IntervalsError>> {
         let updated_events = self.updated_events.clone();
+        let update_event_user_ids = self.update_event_user_ids.clone();
         let fail_updates = self.fail_updates;
+        let user_id = user_id.to_string();
         Box::pin(async move {
             if fail_updates {
                 return Err(IntervalsError::ConnectionError("boom".to_string()));
             }
+            update_event_user_ids.lock().unwrap().push(user_id);
             updated_events
                 .lock()
                 .unwrap()
@@ -907,6 +921,77 @@ async fn create_race_retry_without_external_id_reuses_existing_remote_event() {
     let stored_sync = sync_states.stored();
     assert_eq!(stored_sync.len(), 1);
     assert_eq!(stored_sync[0].external_id.as_deref(), Some("77"));
+}
+
+#[tokio::test]
+async fn update_race_ignores_other_users_sync_state_and_calls_intervals_with_current_user() {
+    let repository = InMemoryRaceRepository::with_races(vec![Race {
+        race_id: "race-123".to_string(),
+        user_id: "user-1".to_string(),
+        date: "2026-09-12".to_string(),
+        name: "Gravel Attack".to_string(),
+        distance_meters: 120_000,
+        discipline: RaceDiscipline::Gravel,
+        priority: RacePriority::B,
+        result: None,
+        created_at_epoch_seconds: 1,
+        updated_at_epoch_seconds: 1,
+    }]);
+    let sync_states = InMemoryExternalSyncStateRepository::default();
+    let race_ref = CanonicalEntityRef::new(CanonicalEntityKind::Race, "race-123".to_string());
+    sync_states
+        .upsert(
+            ExternalSyncState::new("user-2".to_string(), ExternalProvider::Intervals, race_ref)
+                .mark_synced("88".to_string(), "hash".to_string(), 2),
+        )
+        .await
+        .expect("infallible sync state upsert");
+    let intervals = RecordingIntervalsService::default();
+    let service = RaceService::new(
+        repository,
+        intervals.clone(),
+        sync_states.clone(),
+        TestClock,
+        TestIdGenerator::default(),
+    );
+
+    service
+        .update_race(
+            "user-1",
+            "race-123",
+            UpdateRace {
+                date: "2026-09-12".to_string(),
+                name: "Updated Gravel Attack".to_string(),
+                distance_meters: 125_000,
+                discipline: RaceDiscipline::Road,
+                priority: RacePriority::A,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(intervals.created_events.lock().unwrap().len(), 1);
+    assert_eq!(intervals.updated_events.lock().unwrap().len(), 0);
+    assert_eq!(
+        *intervals.list_event_user_ids.lock().unwrap(),
+        vec!["user-1".to_string()]
+    );
+    assert_eq!(
+        *intervals.create_event_user_ids.lock().unwrap(),
+        vec!["user-1".to_string()]
+    );
+    assert!(intervals.update_event_user_ids.lock().unwrap().is_empty());
+
+    let stored_sync = sync_states.stored();
+    assert_eq!(stored_sync.len(), 2);
+    assert!(stored_sync
+        .iter()
+        .any(|state| { state.user_id == "user-2" && state.external_id.as_deref() == Some("88") }));
+    assert!(stored_sync.iter().any(|state| {
+        state.user_id == "user-1"
+            && state.external_id.as_deref() == Some("77")
+            && state.sync_status == ExternalSyncStatus::Synced
+    }));
 }
 
 #[tokio::test]

--- a/src/domain/training_context/service/tests/builder.rs
+++ b/src/domain/training_context/service/tests/builder.rs
@@ -937,6 +937,160 @@ async fn builder_falls_back_to_event_id_summary_when_activity_id_summary_is_miss
 }
 
 #[tokio::test]
+async fn builder_uses_alias_backed_summary_for_recent_activity_context() {
+    #[derive(Clone)]
+    struct AliasSummaryRepository;
+
+    impl crate::domain::workout_summary::WorkoutSummaryRepository for AliasSummaryRepository {
+        fn find_by_user_id_and_workout_id(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<
+                Option<crate::domain::workout_summary::WorkoutSummary>,
+                crate::domain::workout_summary::WorkoutSummaryError,
+            >,
+        > {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn find_by_user_id_and_workout_ids(
+            &self,
+            _user_id: &str,
+            workout_ids: Vec<String>,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<
+                Vec<crate::domain::workout_summary::WorkoutSummary>,
+                crate::domain::workout_summary::WorkoutSummaryError,
+            >,
+        > {
+            Box::pin(async move {
+                Ok(workout_ids
+                    .into_iter()
+                    .filter(|id| id == "ride-1")
+                    .map(|id| {
+                        let mut summary = crate::domain::workout_summary::WorkoutSummary {
+                            id: "summary-wahoo-alias".to_string(),
+                            user_id: "user-1".to_string(),
+                            workout_id: "wahoo-workout:ride-1".to_string(),
+                            rpe: Some(9),
+                            messages: Vec::new(),
+                            saved_at_epoch_seconds: None,
+                            workout_recap_text: Some("Recovered alias-backed recap".to_string()),
+                            workout_recap_provider: Some("openrouter".to_string()),
+                            workout_recap_model: Some("test-model".to_string()),
+                            workout_recap_generated_at_epoch_seconds: Some(1),
+                            created_at_epoch_seconds: 1,
+                            updated_at_epoch_seconds: 1,
+                        };
+                        summary.workout_id = id;
+                        summary
+                    })
+                    .collect())
+            })
+        }
+
+        fn create(
+            &self,
+            _summary: crate::domain::workout_summary::WorkoutSummary,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<
+                crate::domain::workout_summary::WorkoutSummary,
+                crate::domain::workout_summary::WorkoutSummaryError,
+            >,
+        > {
+            unreachable!()
+        }
+
+        fn update_rpe(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+            _rpe: u8,
+            _updated_at_epoch_seconds: i64,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<(), crate::domain::workout_summary::WorkoutSummaryError>,
+        > {
+            unreachable!()
+        }
+
+        fn append_message(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+            _message: crate::domain::workout_summary::ConversationMessage,
+            _updated_at_epoch_seconds: i64,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<(), crate::domain::workout_summary::WorkoutSummaryError>,
+        > {
+            unreachable!()
+        }
+
+        fn find_message_by_id(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+            _message_id: &str,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<
+                Option<crate::domain::workout_summary::ConversationMessage>,
+                crate::domain::workout_summary::WorkoutSummaryError,
+            >,
+        > {
+            unreachable!()
+        }
+
+        fn set_saved_state(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+            _saved_at_epoch_seconds: Option<i64>,
+            _updated_at_epoch_seconds: i64,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<(), crate::domain::workout_summary::WorkoutSummaryError>,
+        > {
+            unreachable!()
+        }
+
+        fn persist_workout_recap(
+            &self,
+            _user_id: &str,
+            _workout_id: &str,
+            _recap: crate::domain::workout_summary::WorkoutRecap,
+            _updated_at_epoch_seconds: i64,
+        ) -> crate::domain::workout_summary::BoxFuture<
+            Result<(), crate::domain::workout_summary::WorkoutSummaryError>,
+        > {
+            unreachable!()
+        }
+    }
+
+    let builder = DefaultTrainingContextBuilder::new(
+        Arc::new(TestSettingsService),
+        Arc::new(AliasSummaryRepository),
+        FixedClock,
+    )
+    .with_completed_workout_repository(TestCompletedWorkoutRepository::default())
+    .with_planned_workout_repository(TestPlannedWorkoutRepository::default())
+    .with_special_day_repository(TestSpecialDayRepository::default());
+
+    let result = builder.build("user-1", "ride-1").await.unwrap();
+    let recent_day = result
+        .context
+        .recent_days
+        .iter()
+        .find(|day| day.date == "2026-04-03")
+        .expect("recent day should exist");
+
+    assert_eq!(recent_day.workouts[0].rpe, Some(9));
+    assert_eq!(
+        recent_day.workouts[0].workout_recap.as_deref(),
+        Some("Recovered alias-backed recap")
+    );
+}
+
+#[tokio::test]
 async fn builder_uses_configured_ftp_when_activity_ftp_is_missing() {
     let builder = DefaultTrainingContextBuilder::new(
         Arc::new(TestSettingsService),

--- a/src/domain/workout_summary/mod.rs
+++ b/src/domain/workout_summary/mod.rs
@@ -13,7 +13,7 @@ pub use model::{
 pub use ports::{BoxFuture, CoachReplyOperationRepository, WorkoutSummaryRepository};
 pub use service::{
     spawn_workout_summary_coach_reply_task_runner, workout_summary_coach_reply_task_handler,
-    CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases, SaveSummaryResult,
-    SaveWorkflowResult, SaveWorkflowStatus, SchedulerBackedWorkoutSummaryService,
-    WorkoutSummaryService, WorkoutSummaryUseCases,
+    CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases,
+    ResolvedCompletedWorkoutTarget, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus,
+    SchedulerBackedWorkoutSummaryService, WorkoutSummaryService, WorkoutSummaryUseCases,
 };

--- a/src/domain/workout_summary/service/internals.rs
+++ b/src/domain/workout_summary/service/internals.rs
@@ -20,35 +20,77 @@ where
             .ok_or(WorkoutSummaryError::NotFound)
     }
 
+    pub(super) async fn resolve_workout_summary_target(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+    ) -> Result<ResolvedWorkoutSummaryTarget, WorkoutSummaryError> {
+        let Some(service) = &self.completed_workout_target_service else {
+            let existing_summary = self
+                .repository
+                .find_by_user_id_and_workout_id(user_id, workout_id)
+                .await?;
+            return Ok(ResolvedWorkoutSummaryTarget {
+                requested_workout_id: workout_id.to_string(),
+                preferred_workout_id: workout_id.to_string(),
+                summary_workout_id: workout_id.to_string(),
+                storage_workout_id: workout_id.to_string(),
+                existing_summary,
+            });
+        };
+
+        let Some(resolved_target) = service
+            .resolve_completed_workout_target(user_id, workout_id)
+            .await?
+        else {
+            return Err(WorkoutSummaryError::Validation(
+                "workout summary is only available for completed workouts".to_string(),
+            ));
+        };
+
+        let mut candidate_workout_ids = Vec::new();
+        push_unique_workout_id(
+            &mut candidate_workout_ids,
+            resolved_target.preferred_workout_id.clone(),
+        );
+        push_unique_workout_id(&mut candidate_workout_ids, workout_id.to_string());
+        for equivalent_workout_id in &resolved_target.equivalent_workout_ids {
+            push_unique_workout_id(&mut candidate_workout_ids, equivalent_workout_id.clone());
+        }
+
+        let mut existing_summary = None;
+        let mut summary_workout_id = resolved_target.preferred_workout_id.clone();
+        let mut storage_workout_id = resolved_target.preferred_workout_id.clone();
+        for candidate_workout_id in candidate_workout_ids {
+            if let Some(summary) = self
+                .repository
+                .find_by_user_id_and_workout_id(user_id, &candidate_workout_id)
+                .await?
+            {
+                storage_workout_id = candidate_workout_id;
+                summary_workout_id = summary.workout_id.clone();
+                existing_summary = Some(summary);
+                break;
+            }
+        }
+
+        Ok(ResolvedWorkoutSummaryTarget {
+            requested_workout_id: workout_id.to_string(),
+            preferred_workout_id: resolved_target.preferred_workout_id,
+            summary_workout_id,
+            storage_workout_id,
+            existing_summary,
+        })
+    }
+
     pub(super) async fn validate_completed_workout_target(
         &self,
         user_id: &str,
         workout_id: &str,
     ) -> Result<(), WorkoutSummaryError> {
-        let is_completed_target = self
-            .is_completed_workout_target(user_id, workout_id)
-            .await?;
-        if is_completed_target {
-            Ok(())
-        } else {
-            Err(WorkoutSummaryError::Validation(
-                "workout summary is only available for completed workouts".to_string(),
-            ))
-        }
-    }
-
-    pub(super) async fn is_completed_workout_target(
-        &self,
-        user_id: &str,
-        workout_id: &str,
-    ) -> Result<bool, WorkoutSummaryError> {
-        let Some(service) = &self.completed_workout_target_service else {
-            return Ok(true);
-        };
-
-        service
-            .is_completed_workout_target(user_id, workout_id)
+        self.resolve_workout_summary_target(user_id, workout_id)
             .await
+            .map(|_| ())
     }
 
     pub(super) async fn append_message_with_role(
@@ -171,6 +213,42 @@ where
             coach_message,
             athlete_summary_was_regenerated: false,
         })
+    }
+
+    pub(super) fn present_summary(
+        &self,
+        mut summary: WorkoutSummary,
+        requested_workout_id: &str,
+    ) -> WorkoutSummary {
+        summary.workout_id = requested_workout_id.to_string();
+        summary
+    }
+
+    pub(super) fn present_persisted_user_message(
+        &self,
+        mut persisted: PersistedUserMessage,
+        requested_workout_id: &str,
+    ) -> PersistedUserMessage {
+        persisted.summary = self.present_summary(persisted.summary, requested_workout_id);
+        persisted
+    }
+
+    pub(super) fn present_coach_reply(
+        &self,
+        mut reply: CoachReply,
+        requested_workout_id: &str,
+    ) -> CoachReply {
+        reply.summary = self.present_summary(reply.summary, requested_workout_id);
+        reply
+    }
+
+    pub(super) fn present_save_summary_result(
+        &self,
+        mut result: SaveSummaryResult,
+        requested_workout_id: &str,
+    ) -> SaveSummaryResult {
+        result.summary = self.present_summary(result.summary, requested_workout_id);
+        result
     }
 
     pub(super) fn map_existing_llm_failure(
@@ -336,5 +414,11 @@ where
         };
 
         Ok((Some(ensured.summary.summary_text), ensured.was_regenerated))
+    }
+}
+
+fn push_unique_workout_id(workout_ids: &mut Vec<String>, workout_id: String) {
+    if !workout_ids.contains(&workout_id) {
+        workout_ids.push(workout_id);
     }
 }

--- a/src/domain/workout_summary/service/mod.rs
+++ b/src/domain/workout_summary/service/mod.rs
@@ -104,12 +104,45 @@ pub trait LatestCompletedActivityUseCases: Send + Sync {
     ) -> BoxFuture<Result<Option<String>, WorkoutSummaryError>>;
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedCompletedWorkoutTarget {
+    pub preferred_workout_id: String,
+    pub equivalent_workout_ids: Vec<String>,
+}
+
 pub trait CompletedWorkoutTargetUseCases: Send + Sync {
     fn is_completed_workout_target(
         &self,
         user_id: &str,
         workout_id: &str,
     ) -> BoxFuture<Result<bool, WorkoutSummaryError>>;
+
+    fn resolve_completed_workout_target(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+    ) -> BoxFuture<Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>> {
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        let is_completed = self.is_completed_workout_target(&user_id, &workout_id);
+        Box::pin(async move {
+            Ok(is_completed
+                .await?
+                .then_some(ResolvedCompletedWorkoutTarget {
+                    preferred_workout_id: workout_id.clone(),
+                    equivalent_workout_ids: vec![workout_id],
+                }))
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ResolvedWorkoutSummaryTarget {
+    requested_workout_id: String,
+    preferred_workout_id: String,
+    summary_workout_id: String,
+    storage_workout_id: String,
+    existing_summary: Option<WorkoutSummary>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/domain/workout_summary/service/use_cases/chat.rs
+++ b/src/domain/workout_summary/service/use_cases/chat.rs
@@ -44,14 +44,22 @@ where
         workout_id: &str,
         content: String,
     ) -> Result<PersistedUserMessage, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
 
         let user_message = self
-            .append_message_with_role(user_id, workout_id, MessageRole::User, content)
+            .append_message_with_role(
+                user_id,
+                &target.summary_workout_id,
+                MessageRole::User,
+                content,
+            )
             .await?;
 
-        let summary = self.get_existing_summary(user_id, workout_id).await?;
+        let summary = self
+            .get_existing_summary(user_id, &target.summary_workout_id)
+            .await?;
         let athlete_summary_may_regenerate_before_reply =
             if let Some(athlete_summary_service) = &self.athlete_summary_service {
                 match athlete_summary_service.get_summary_state(user_id).await {
@@ -70,11 +78,14 @@ where
                 false
             };
 
-        Ok(PersistedUserMessage {
-            summary,
-            user_message,
-            athlete_summary_may_regenerate_before_reply,
-        })
+        Ok(self.present_persisted_user_message(
+            PersistedUserMessage {
+                summary,
+                user_message,
+                athlete_summary_may_regenerate_before_reply,
+            },
+            &target.requested_workout_id,
+        ))
     }
 
     pub(super) async fn generate_coach_reply_impl(
@@ -83,44 +94,58 @@ where
         workout_id: &str,
         user_message_id: String,
     ) -> Result<CoachReply, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
 
         let user_message = self
-            .load_persisted_user_message(user_id, workout_id, &user_message_id)
+            .load_persisted_user_message(user_id, &target.summary_workout_id, &user_message_id)
             .await?;
         let operation = match self
-            .claim_coach_reply_operation(user_id, workout_id, &user_message)
+            .claim_coach_reply_operation(user_id, &target.summary_workout_id, &user_message)
             .await?
         {
             CoachReplyOperationResolution::Continue(operation) => operation,
-            CoachReplyOperationResolution::Reply(reply) => return Ok(reply),
+            CoachReplyOperationResolution::Reply(reply) => {
+                return Ok(self.present_coach_reply(reply, &target.requested_workout_id));
+            }
             CoachReplyOperationResolution::Error(error) => return Err(error),
         };
 
         info!(
-            workout_id = %workout_id,
+            workout_id = %target.summary_workout_id,
             user_message_id = %user_message.id,
             attempt_count = operation.attempt_count,
             "requesting workout summary coach reply"
         );
 
         let (operation, llm_response, athlete_summary_was_regenerated) = self
-            .request_and_checkpoint_coach_reply(user_id, workout_id, &user_message, operation)
+            .request_and_checkpoint_coach_reply(
+                user_id,
+                &target.summary_workout_id,
+                &user_message,
+                operation,
+            )
             .await?;
         let coach_message = self
-            .append_coach_reply_message(user_id, workout_id, &operation, &llm_response)
+            .append_coach_reply_message(
+                user_id,
+                &target.summary_workout_id,
+                &operation,
+                &llm_response,
+            )
             .await?;
         self.finalize_coach_reply_operation(operation, &llm_response, &coach_message)
             .await?;
 
         self.build_coach_reply_result(
             user_id,
-            workout_id,
+            &target.summary_workout_id,
             coach_message,
             athlete_summary_was_regenerated,
         )
         .await
+        .map(|reply| self.present_coach_reply(reply, &target.requested_workout_id))
     }
 
     async fn load_persisted_user_message(

--- a/src/domain/workout_summary/service/use_cases/read.rs
+++ b/src/domain/workout_summary/service/use_cases/read.rs
@@ -1,5 +1,7 @@
 use futures::{stream, StreamExt, TryStreamExt};
 
+use std::collections::HashSet;
+
 use super::*;
 
 const LIST_SUMMARIES_TARGET_CHECK_CONCURRENCY: usize = 8;
@@ -16,9 +18,13 @@ where
         user_id: &str,
         workout_id: &str,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
-        self.get_existing_summary(user_id, workout_id).await
+        let summary = target
+            .existing_summary
+            .ok_or(WorkoutSummaryError::NotFound)?;
+        Ok(self.present_summary(summary, &target.requested_workout_id))
     }
 
     pub(super) async fn create_summary_impl(
@@ -26,34 +32,30 @@ where
         user_id: &str,
         workout_id: &str,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
 
-        if let Some(existing) = self
-            .repository
-            .find_by_user_id_and_workout_id(user_id, workout_id)
-            .await?
-        {
-            return Ok(existing);
+        if let Some(existing) = target.existing_summary {
+            return Ok(self.present_summary(existing, &target.requested_workout_id));
         }
 
         let now = self.clock.now_epoch_seconds();
         let summary = WorkoutSummary::new(
             self.ids.new_id("workout-summary"),
             user_id.to_string(),
-            workout_id.to_string(),
+            target.summary_workout_id.clone(),
             now,
         );
         let summary_user_id = summary.user_id.clone();
         let summary_workout_id = summary.workout_id.clone();
 
         match self.repository.create(summary).await {
-            Ok(summary) => Ok(summary),
+            Ok(summary) => Ok(self.present_summary(summary, &target.requested_workout_id)),
             Err(WorkoutSummaryError::AlreadyExists) => self
-                .repository
-                .find_by_user_id_and_workout_id(&summary_user_id, &summary_workout_id)
-                .await?
-                .ok_or(WorkoutSummaryError::NotFound),
+                .get_existing_summary(&summary_user_id, &summary_workout_id)
+                .await
+                .map(|summary| self.present_summary(summary, &target.requested_workout_id)),
             Err(error) => Err(error),
         }
     }
@@ -63,31 +65,37 @@ where
         user_id: &str,
         workout_ids: Vec<String>,
     ) -> Result<Vec<WorkoutSummary>, WorkoutSummaryError> {
-        let completed_workout_ids = stream::iter(workout_ids.into_iter().map(|workout_id| {
-            let service = self.clone();
-            let user_id = user_id.to_string();
-            async move {
-                let is_completed = service
-                    .is_completed_workout_target(&user_id, &workout_id)
-                    .await?;
-                Ok::<_, WorkoutSummaryError>(is_completed.then_some(workout_id))
-            }
-        }))
-        .buffered(LIST_SUMMARIES_TARGET_CHECK_CONCURRENCY)
-        .try_collect::<Vec<_>>()
-        .await?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+        let mut summaries =
+            stream::iter(workout_ids.into_iter().map(|workout_id| {
+                let service = self.clone();
+                let user_id = user_id.to_string();
+                async move {
+                    let target = match service
+                        .resolve_workout_summary_target(&user_id, &workout_id)
+                        .await
+                    {
+                        Ok(target) => target,
+                        Err(WorkoutSummaryError::Validation(_)) => {
+                            return Ok::<_, WorkoutSummaryError>(None);
+                        }
+                        Err(error) => return Err(error),
+                    };
 
-        if completed_workout_ids.is_empty() {
-            return Ok(Vec::new());
-        }
+                    Ok::<_, WorkoutSummaryError>(target.existing_summary.map(|summary| {
+                        service.present_summary(summary, &target.requested_workout_id)
+                    }))
+                }
+            }))
+            .buffered(LIST_SUMMARIES_TARGET_CHECK_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
-        let mut summaries = self
-            .repository
-            .find_by_user_id_and_workout_ids(user_id, completed_workout_ids)
-            .await?;
+        let mut seen_summary_ids = HashSet::new();
+        summaries.retain(|summary| seen_summary_ids.insert(summary.id.clone()));
+
         summaries.sort_by(|left, right| {
             right
                 .updated_at_epoch_seconds
@@ -107,21 +115,25 @@ where
         workout_id: &str,
         rpe: u8,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
-
         let rpe = validate_rpe(rpe)?;
-        let existing = self.get_existing_summary(user_id, workout_id).await?;
+        let existing = target
+            .existing_summary
+            .ok_or(WorkoutSummaryError::NotFound)?;
         if existing.saved_at_epoch_seconds.is_some() {
             return Err(WorkoutSummaryError::Locked);
         }
         let now = self.clock.now_epoch_seconds();
 
         self.repository
-            .update_rpe(user_id, workout_id, rpe, now)
+            .update_rpe(user_id, &target.summary_workout_id, rpe, now)
             .await?;
 
-        self.get_existing_summary(user_id, workout_id).await
+        self.get_existing_summary(user_id, &target.summary_workout_id)
+            .await
+            .map(|summary| self.present_summary(summary, &target.requested_workout_id))
     }
 
     pub(super) async fn reopen_summary_impl(
@@ -129,19 +141,23 @@ where
         user_id: &str,
         workout_id: &str,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
-
-        let existing = self.get_existing_summary(user_id, workout_id).await?;
+        let existing = target
+            .existing_summary
+            .ok_or(WorkoutSummaryError::NotFound)?;
         if existing.saved_at_epoch_seconds.is_none() {
-            return Ok(existing);
+            return Ok(self.present_summary(existing, &target.requested_workout_id));
         }
         let now = self.clock.now_epoch_seconds();
         self.repository
-            .set_saved_state(user_id, workout_id, None, now)
+            .set_saved_state(user_id, &target.summary_workout_id, None, now)
             .await?;
 
-        self.get_existing_summary(user_id, workout_id).await
+        self.get_existing_summary(user_id, &target.summary_workout_id)
+            .await
+            .map(|summary| self.present_summary(summary, &target.requested_workout_id))
     }
 
     pub(super) async fn persist_workout_recap_impl(
@@ -150,23 +166,27 @@ where
         workout_id: &str,
         recap: WorkoutRecap,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
-
-        let existing = self.get_existing_summary(user_id, workout_id).await?;
+        let existing = target
+            .existing_summary
+            .ok_or(WorkoutSummaryError::NotFound)?;
         if existing.workout_recap_text.as_deref() == Some(recap.text.as_str())
             && existing.workout_recap_provider.as_deref() == Some(recap.provider.as_str())
             && existing.workout_recap_model.as_deref() == Some(recap.model.as_str())
             && existing.workout_recap_generated_at_epoch_seconds
                 == Some(recap.generated_at_epoch_seconds)
         {
-            return Ok(existing);
+            return Ok(self.present_summary(existing, &target.requested_workout_id));
         }
         let now = self.clock.now_epoch_seconds();
         self.repository
-            .persist_workout_recap(user_id, workout_id, recap, now)
+            .persist_workout_recap(user_id, &target.summary_workout_id, recap, now)
             .await?;
 
-        self.get_existing_summary(user_id, workout_id).await
+        self.get_existing_summary(user_id, &target.summary_workout_id)
+            .await
+            .map(|summary| self.present_summary(summary, &target.requested_workout_id))
     }
 }

--- a/src/domain/workout_summary/service/use_cases/save.rs
+++ b/src/domain/workout_summary/service/use_cases/save.rs
@@ -68,14 +68,15 @@ where
         user_id: &str,
         workout_id: &str,
     ) -> Result<SaveSummaryResult, WorkoutSummaryError> {
-        self.validate_completed_workout_target(user_id, workout_id)
+        let target = self
+            .resolve_workout_summary_target(user_id, workout_id)
             .await?;
-
-        let existing = self.get_existing_summary(user_id, workout_id).await?;
+        let existing = target
+            .existing_summary
+            .clone()
+            .ok_or(WorkoutSummaryError::NotFound)?;
         if existing.saved_at_epoch_seconds.is_some() {
-            return self
-                .retry_saved_workflow(user_id, workout_id, existing)
-                .await;
+            return self.retry_saved_workflow(user_id, &target, existing).await;
         }
         if existing.rpe.is_none() {
             return Err(WorkoutSummaryError::Validation(
@@ -85,28 +86,33 @@ where
 
         let now = self.clock.now_epoch_seconds();
         self.repository
-            .set_saved_state(user_id, workout_id, Some(now), now)
+            .set_saved_state(user_id, &target.summary_workout_id, Some(now), now)
             .await?;
 
         if !has_finished_conversation(&existing) {
-            let summary = self.get_existing_summary(user_id, workout_id).await?;
-            return Ok(SaveSummaryResult {
-                summary,
-                workflow: SaveWorkflowResult {
-                    recap_status: SaveWorkflowStatus::Skipped,
-                    plan_status: SaveWorkflowStatus::Skipped,
-                    messages: vec!["No finished coach conversation to process.".to_string()],
+            let summary = self
+                .get_existing_summary(user_id, &target.summary_workout_id)
+                .await?;
+            return Ok(self.present_save_summary_result(
+                SaveSummaryResult {
+                    summary,
+                    workflow: SaveWorkflowResult {
+                        recap_status: SaveWorkflowStatus::Skipped,
+                        plan_status: SaveWorkflowStatus::Skipped,
+                        messages: vec!["No finished coach conversation to process.".to_string()],
+                    },
                 },
-            });
+                &target.requested_workout_id,
+            ));
         }
 
         let is_latest_completed_activity = self
-            .is_latest_completed_activity(user_id, workout_id)
+            .is_latest_completed_activity(user_id, &target.preferred_workout_id)
             .await?;
 
         let recap_status = if let Some(training_plan_service) = &self.training_plan_service {
             match training_plan_service
-                .generate_recap_for_saved_workout(user_id, workout_id, now)
+                .generate_recap_for_saved_workout(user_id, &target.storage_workout_id, now)
                 .await
             {
                 Ok(_) => SaveWorkflowStatus::Generated,
@@ -128,7 +134,7 @@ where
         let plan_status = if is_latest_completed_activity {
             if let Some(training_plan_service) = &self.training_plan_service {
                 match training_plan_service
-                    .generate_for_saved_workout(user_id, workout_id, now)
+                    .generate_for_saved_workout(user_id, &target.storage_workout_id, now)
                     .await
                 {
                     Ok(_) => SaveWorkflowStatus::Generated,
@@ -150,29 +156,32 @@ where
             SaveWorkflowStatus::Skipped
         };
 
-        let summary = self.get_existing_summary(user_id, workout_id).await?;
-        Ok(SaveSummaryResult {
-            summary,
-            workflow: SaveWorkflowResult {
-                recap_status: recap_status.clone(),
-                plan_status: plan_status.clone(),
-                messages: if is_latest_completed_activity {
-                    vec![
-                        status_message(
-                            &recap_status,
-                            "Workout recap generated.",
-                            "Workout recap failed.",
-                            "Workout recap skipped.",
-                        ),
-                        status_message(
-                            &plan_status,
-                            "14-day schedule generated.",
-                            "14-day schedule failed.",
-                            "14-day schedule skipped.",
-                        ),
-                    ]
-                } else {
-                    vec![
+        let summary = self
+            .get_existing_summary(user_id, &target.summary_workout_id)
+            .await?;
+        Ok(self.present_save_summary_result(
+            SaveSummaryResult {
+                summary,
+                workflow: SaveWorkflowResult {
+                    recap_status: recap_status.clone(),
+                    plan_status: plan_status.clone(),
+                    messages: if is_latest_completed_activity {
+                        vec![
+                            status_message(
+                                &recap_status,
+                                "Workout recap generated.",
+                                "Workout recap failed.",
+                                "Workout recap skipped.",
+                            ),
+                            status_message(
+                                &plan_status,
+                                "14-day schedule generated.",
+                                "14-day schedule failed.",
+                                "14-day schedule skipped.",
+                            ),
+                        ]
+                    } else {
+                        vec![
                         status_message(
                             &recap_status,
                             "Workout recap generated.",
@@ -182,40 +191,48 @@ where
                         "14-day schedule skipped because this is not the latest completed activity."
                             .to_string(),
                     ]
+                    },
                 },
             },
-        })
+            &target.requested_workout_id,
+        ))
     }
 
     async fn retry_saved_workflow(
         &self,
         user_id: &str,
-        workout_id: &str,
+        target: &ResolvedWorkoutSummaryTarget,
         existing: WorkoutSummary,
     ) -> Result<SaveSummaryResult, WorkoutSummaryError> {
         if !has_finished_conversation(&existing) {
-            return Ok(SaveSummaryResult {
-                summary: existing,
-                workflow: SaveWorkflowResult {
-                    recap_status: SaveWorkflowStatus::Unchanged,
-                    plan_status: SaveWorkflowStatus::Skipped,
-                    messages: Vec::new(),
+            return Ok(self.present_save_summary_result(
+                SaveSummaryResult {
+                    summary: existing,
+                    workflow: SaveWorkflowResult {
+                        recap_status: SaveWorkflowStatus::Unchanged,
+                        plan_status: SaveWorkflowStatus::Skipped,
+                        messages: Vec::new(),
+                    },
                 },
-            });
+                &target.requested_workout_id,
+            ));
         }
 
         let is_latest_completed_activity = self
-            .is_latest_completed_activity(user_id, workout_id)
+            .is_latest_completed_activity(user_id, &target.preferred_workout_id)
             .await?;
         if !is_latest_completed_activity {
-            return Ok(SaveSummaryResult {
-                summary: existing,
-                workflow: SaveWorkflowResult {
-                    recap_status: SaveWorkflowStatus::Unchanged,
-                    plan_status: SaveWorkflowStatus::Skipped,
-                    messages: Vec::new(),
+            return Ok(self.present_save_summary_result(
+                SaveSummaryResult {
+                    summary: existing,
+                    workflow: SaveWorkflowResult {
+                        recap_status: SaveWorkflowStatus::Unchanged,
+                        plan_status: SaveWorkflowStatus::Skipped,
+                        messages: Vec::new(),
+                    },
                 },
-            });
+                &target.requested_workout_id,
+            ));
         }
 
         let recap_before_retry = RecapSnapshot::from_summary(&existing);
@@ -224,83 +241,100 @@ where
             (&self.training_plan_service, existing.saved_at_epoch_seconds)
         {
             match training_plan_service
-                .generate_for_saved_workout(user_id, workout_id, saved_at_epoch_seconds)
+                .generate_for_saved_workout(
+                    user_id,
+                    &target.storage_workout_id,
+                    saved_at_epoch_seconds,
+                )
                 .await
             {
                 Ok(generated_plan) => {
-                    let summary = self.get_existing_summary(user_id, workout_id).await?;
+                    let summary = self
+                        .get_existing_summary(user_id, &target.summary_workout_id)
+                        .await?;
                     let recap_status =
                         if RecapSnapshot::from_summary(&summary) != recap_before_retry {
                             SaveWorkflowStatus::Generated
                         } else {
                             SaveWorkflowStatus::Unchanged
                         };
-                    return Ok(SaveSummaryResult {
-                        summary,
-                        workflow: SaveWorkflowResult {
-                            recap_status: recap_status.clone(),
-                            plan_status: if generated_plan.was_generated {
-                                SaveWorkflowStatus::Generated
-                            } else {
-                                SaveWorkflowStatus::Unchanged
-                            },
-                            messages: match (recap_status, generated_plan.was_generated) {
-                                (SaveWorkflowStatus::Generated, true) => vec![
-                                    "Workout recap generated on retry.".to_string(),
-                                    "14-day schedule generated on retry.".to_string(),
-                                ],
-                                (SaveWorkflowStatus::Generated, false) => {
-                                    vec!["Workout recap generated on retry.".to_string()]
-                                }
-                                (_, true) => {
-                                    vec!["14-day schedule generated on retry.".to_string()]
-                                }
-                                _ => Vec::new(),
+                    return Ok(self.present_save_summary_result(
+                        SaveSummaryResult {
+                            summary,
+                            workflow: SaveWorkflowResult {
+                                recap_status: recap_status.clone(),
+                                plan_status: if generated_plan.was_generated {
+                                    SaveWorkflowStatus::Generated
+                                } else {
+                                    SaveWorkflowStatus::Unchanged
+                                },
+                                messages: match (recap_status, generated_plan.was_generated) {
+                                    (SaveWorkflowStatus::Generated, true) => vec![
+                                        "Workout recap generated on retry.".to_string(),
+                                        "14-day schedule generated on retry.".to_string(),
+                                    ],
+                                    (SaveWorkflowStatus::Generated, false) => {
+                                        vec!["Workout recap generated on retry.".to_string()]
+                                    }
+                                    (_, true) => {
+                                        vec!["14-day schedule generated on retry.".to_string()]
+                                    }
+                                    _ => Vec::new(),
+                                },
                             },
                         },
-                    });
+                        &target.requested_workout_id,
+                    ));
                 }
                 Err(error) => {
                     warn!(
                         user_id,
-                        workout_id,
+                        workout_id = %target.storage_workout_id,
                         saved_at_epoch_seconds,
                         error = %error,
                         "Saved workout summary remains persisted after training plan generation retry failure"
                     );
 
-                    let summary = self.get_existing_summary(user_id, workout_id).await?;
+                    let summary = self
+                        .get_existing_summary(user_id, &target.summary_workout_id)
+                        .await?;
                     let recap_status =
                         if RecapSnapshot::from_summary(&summary) != recap_before_retry {
                             SaveWorkflowStatus::Generated
                         } else {
                             SaveWorkflowStatus::Unchanged
                         };
-                    return Ok(SaveSummaryResult {
-                        summary,
-                        workflow: SaveWorkflowResult {
-                            recap_status: recap_status.clone(),
-                            plan_status: SaveWorkflowStatus::Failed,
-                            messages: if recap_status == SaveWorkflowStatus::Generated {
-                                vec![
-                                    "Workout recap generated on retry.".to_string(),
-                                    "14-day schedule failed on retry.".to_string(),
-                                ]
-                            } else {
-                                vec!["14-day schedule failed on retry.".to_string()]
+                    return Ok(self.present_save_summary_result(
+                        SaveSummaryResult {
+                            summary,
+                            workflow: SaveWorkflowResult {
+                                recap_status: recap_status.clone(),
+                                plan_status: SaveWorkflowStatus::Failed,
+                                messages: if recap_status == SaveWorkflowStatus::Generated {
+                                    vec![
+                                        "Workout recap generated on retry.".to_string(),
+                                        "14-day schedule failed on retry.".to_string(),
+                                    ]
+                                } else {
+                                    vec!["14-day schedule failed on retry.".to_string()]
+                                },
                             },
                         },
-                    });
+                        &target.requested_workout_id,
+                    ));
                 }
             }
         }
-        Ok(SaveSummaryResult {
-            summary: existing,
-            workflow: SaveWorkflowResult {
-                recap_status: SaveWorkflowStatus::Unchanged,
-                plan_status: SaveWorkflowStatus::Skipped,
-                messages: Vec::new(),
+        Ok(self.present_save_summary_result(
+            SaveSummaryResult {
+                summary: existing,
+                workflow: SaveWorkflowResult {
+                    recap_status: SaveWorkflowStatus::Unchanged,
+                    plan_status: SaveWorkflowStatus::Skipped,
+                    messages: Vec::new(),
+                },
             },
-        })
+            &target.requested_workout_id,
+        ))
     }
 }

--- a/tests/training_plan_mongo.rs
+++ b/tests/training_plan_mongo.rs
@@ -456,6 +456,76 @@ async fn training_plan_projection_repository_replay_heals_partial_same_operation
 }
 
 #[tokio::test]
+async fn training_plan_projection_repository_supersedes_stale_leading_days_for_same_operation_key()
+{
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository =
+        MongoTrainingPlanProjectionRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    let original_snapshot =
+        sample_snapshot("training-plan:user-1:workout-1:1700000000", "2026-05-01");
+    repository
+        .replace_window(
+            original_snapshot.clone(),
+            sample_projected_days(&original_snapshot, "2026-05-01"),
+            "2026-05-01",
+            1_700_000_000,
+        )
+        .await
+        .unwrap();
+
+    let replacement_snapshot =
+        sample_snapshot("training-plan:user-1:workout-1:1700000000", "2026-05-02");
+    repository
+        .replace_window(
+            replacement_snapshot.clone(),
+            sample_projected_days(&replacement_snapshot, "2026-05-02"),
+            "2026-05-02",
+            1_700_086_400,
+        )
+        .await
+        .unwrap();
+
+    let stored_days = fixture
+        .client
+        .database(&fixture.database)
+        .collection::<mongodb::bson::Document>("training_plan_projected_days")
+        .find(doc! { "operation_key": &replacement_snapshot.operation_key })
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    let stale_leading_day = stored_days
+        .iter()
+        .find(|day| day.get_str("date").ok() == Some("2026-05-01"))
+        .expect("expected old leading day to remain stored for audit trail");
+    assert_eq!(
+        stale_leading_day
+            .get_i64("superseded_at_epoch_seconds")
+            .ok(),
+        Some(1_700_086_400)
+    );
+
+    let active_for_operation = repository
+        .find_active_by_operation_key(&replacement_snapshot.operation_key)
+        .await
+        .unwrap();
+    assert!(!active_for_operation
+        .iter()
+        .any(|day| day.date == "2026-05-01"));
+    assert!(active_for_operation
+        .iter()
+        .any(|day| day.date == "2026-05-02"));
+
+    fixture.cleanup().await;
+}
+
+#[tokio::test]
 async fn training_plan_projection_repository_creates_operation_unsuperseded_date_index() {
     let Some(fixture) = mongo_fixture_or_skip().await else {
         return;

--- a/tests/training_plan_service/support/repos.rs
+++ b/tests/training_plan_service/support/repos.rs
@@ -196,6 +196,15 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
 
             let superseded_range_start =
                 std::cmp::max(today.as_str(), snapshot.start_date.as_str());
+            let same_operation_active_date_range = stored
+                .iter()
+                .filter(|day| {
+                    day.user_id == snapshot.user_id
+                        && day.operation_key == snapshot.operation_key
+                        && day.superseded_at_epoch_seconds.is_none()
+                })
+                .map(|day| day.date.clone())
+                .collect::<Vec<_>>();
 
             let max_active_date = stored
                 .iter()
@@ -210,6 +219,16 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
                 .map(|date| std::cmp::max(snapshot.end_date.as_str(), date.as_str()))
                 .unwrap_or(snapshot.end_date.as_str())
                 .to_string();
+            let superseded_refresh_start = same_operation_active_date_range
+                .first()
+                .map(|start| std::cmp::min(superseded_range_start, start.as_str()))
+                .unwrap_or(superseded_range_start)
+                .to_string();
+            let superseded_refresh_end = same_operation_active_date_range
+                .last()
+                .map(|end| std::cmp::max(superseded_range_end.as_str(), end.as_str()))
+                .unwrap_or(superseded_range_end.as_str())
+                .to_string();
 
             let mut superseded_dates = Vec::new();
             for day in stored.iter_mut() {
@@ -219,9 +238,10 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
                 if day.user_id != snapshot.user_id {
                     continue;
                 }
-                if day.date.as_str() < superseded_range_start
-                    || day.date.as_str() > superseded_range_end.as_str()
-                {
+                let overlaps_replaced_range = day.date.as_str() >= superseded_range_start
+                    && day.date.as_str() <= superseded_range_end.as_str();
+                let is_same_operation_replay = day.operation_key == snapshot.operation_key;
+                if !overlaps_replaced_range && !is_same_operation_replay {
                     continue;
                 }
                 superseded_dates.push(day.date.clone());
@@ -254,11 +274,7 @@ impl TrainingPlanProjectionRepository for InMemoryTrainingPlanProjectedDayReposi
             let superseded_date_range = if superseded_dates.is_empty() {
                 None
             } else {
-                superseded_dates.sort();
-                superseded_dates
-                    .first()
-                    .cloned()
-                    .zip(superseded_dates.last().cloned())
+                Some((superseded_refresh_start, superseded_refresh_end))
             };
 
             Ok(TrainingPlanReplacementResult {

--- a/tests/workout_summary_mongo.rs
+++ b/tests/workout_summary_mongo.rs
@@ -180,6 +180,37 @@ async fn workout_summary_repository_creates_legacy_event_id_index() {
     fixture.cleanup().await;
 }
 
+#[tokio::test]
+async fn workout_summary_repository_batch_lookup_matches_aliases_for_requested_activity_ids() {
+    let Some(fixture) = mongo_fixture_or_skip().await else {
+        return;
+    };
+    let repository = MongoWorkoutSummaryRepository::new(fixture.client.clone(), &fixture.database);
+    repository.ensure_indexes().await.unwrap();
+
+    repository
+        .create(sample_summary(
+            "summary-alias",
+            "user-1",
+            "wahoo-workout:450868242",
+            Some(6),
+            10,
+        ))
+        .await
+        .unwrap();
+
+    let summaries = repository
+        .find_by_user_id_and_workout_ids("user-1", vec!["450868242".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, "summary-alias");
+    assert_eq!(summaries[0].workout_id, "450868242");
+
+    fixture.cleanup().await;
+}
+
 struct MongoFixture {
     client: Client,
     database: String,

--- a/tests/workout_summary_service/create_and_get.rs
+++ b/tests/workout_summary_service/create_and_get.rs
@@ -396,7 +396,7 @@ async fn mark_saved_rejects_planned_workout_targets() {
     assert!(latest_activity.calls().is_empty());
     assert_eq!(
         completed_target.calls(),
-        vec!["is_completed_workout_target:user-1:workout-1".to_string()]
+        vec!["resolve_completed_workout_target:user-1:workout-1".to_string()]
     );
 }
 
@@ -429,9 +429,240 @@ async fn list_summaries_ignores_non_completed_workout_targets() {
     assert_eq!(
         completed_target.calls(),
         vec![
-            "is_completed_workout_target:user-1:workout-1".to_string(),
-            "is_completed_workout_target:user-1:activity-1".to_string(),
+            "resolve_completed_workout_target:user-1:workout-1".to_string(),
+            "resolve_completed_workout_target:user-1:activity-1".to_string(),
         ]
+    );
+}
+
+#[tokio::test]
+async fn get_summary_reuses_equivalent_completed_workout_alias_without_duplicate_create() {
+    let mut summary = existing_summary_with_finished_conversation();
+    summary.workout_id = "i144331018".to_string();
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+    let completed_target = RecordingCompletedWorkoutTargetService::resolving(&[(
+        "wahoo-workout:450868242",
+        "i144331018",
+        &["i144331018", "wahoo-workout:450868242"],
+    )]);
+    let service = WorkoutSummaryService::new(
+        repository.clone(),
+        crate::shared::InMemoryCoachReplyOperationRepository::default(),
+        crate::shared::TestClock,
+        crate::shared::TestIdGenerator::default(),
+    )
+    .with_completed_workout_target_service(std::sync::Arc::new(completed_target.clone()));
+
+    let fetched = service
+        .get_summary("user-1", "wahoo-workout:450868242")
+        .await
+        .unwrap();
+    let created = service
+        .create_summary("user-1", "wahoo-workout:450868242")
+        .await
+        .unwrap();
+
+    assert_eq!(fetched.id, "summary-1");
+    assert_eq!(fetched.workout_id, "wahoo-workout:450868242");
+    assert_eq!(created.id, "summary-1");
+    assert_eq!(created.workout_id, "wahoo-workout:450868242");
+    assert!(repository.calls().is_empty());
+    assert_eq!(
+        completed_target.calls(),
+        vec![
+            "resolve_completed_workout_target:user-1:wahoo-workout:450868242".to_string(),
+            "resolve_completed_workout_target:user-1:wahoo-workout:450868242".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn mark_saved_uses_preferred_completed_workout_id_for_side_effects() {
+    let mut summary = existing_summary_with_finished_conversation();
+    summary.workout_id = "i144331018".to_string();
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+    let training_plan = RecordingTrainingPlanService::default();
+    training_plan.succeed_next(aiwattcoach::domain::training_plan::GeneratedTrainingPlan {
+        snapshot: aiwattcoach::domain::training_plan::TrainingPlanSnapshot {
+            user_id: "user-1".to_string(),
+            workout_id: "i144331018".to_string(),
+            operation_key: "training-plan:user-1:i144331018:1700000000".to_string(),
+            saved_at_epoch_seconds: 1_700_000_000,
+            start_date: "2026-04-06".to_string(),
+            end_date: "2026-04-19".to_string(),
+            days: Vec::new(),
+            created_at_epoch_seconds: 1_700_000_000,
+        },
+        active_projected_days: Vec::new(),
+        was_generated: true,
+    });
+    let latest_activity = RecordingLatestCompletedActivityService::new(Some("i144331018"));
+    let completed_target = RecordingCompletedWorkoutTargetService::resolving(&[(
+        "wahoo-workout:450868242",
+        "i144331018",
+        &["i144331018", "wahoo-workout:450868242"],
+    )]);
+    let service = test_service_with_training_plan_latest_activity_and_completed_target(
+        repository.clone(),
+        std::sync::Arc::new(training_plan.clone()),
+        std::sync::Arc::new(latest_activity.clone()),
+        std::sync::Arc::new(completed_target.clone()),
+    );
+
+    let result = service
+        .mark_saved("user-1", "wahoo-workout:450868242")
+        .await
+        .unwrap();
+
+    assert_eq!(result.summary.workout_id, "wahoo-workout:450868242");
+    assert_eq!(
+        repository.calls(),
+        vec!["set_saved_state:i144331018:Some(1700000000)".to_string()]
+    );
+    assert_eq!(
+        training_plan.calls(),
+        vec![
+            "generate_recap_for_saved_workout:user-1:i144331018:1700000000".to_string(),
+            "generate_for_saved_workout:user-1:i144331018:1700000000".to_string(),
+        ]
+    );
+    assert_eq!(
+        latest_activity.calls(),
+        vec!["latest_completed_activity_id:user-1".to_string()]
+    );
+    assert_eq!(
+        completed_target.calls(),
+        vec!["resolve_completed_workout_target:user-1:wahoo-workout:450868242".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn mark_saved_retries_side_effects_with_existing_alias_storage_workout_id() {
+    let mut summary = existing_summary_with_finished_conversation();
+    summary.workout_id = "wahoo-workout:450868242".to_string();
+    summary.saved_at_epoch_seconds = Some(1_700_000_000);
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+    let training_plan = RecordingTrainingPlanService::default();
+    let latest_activity = RecordingLatestCompletedActivityService::new(Some("i144331018"));
+    let completed_target = RecordingCompletedWorkoutTargetService::resolving(&[(
+        "i144331018",
+        "i144331018",
+        &["i144331018", "wahoo-workout:450868242"],
+    )]);
+    let service = test_service_with_training_plan_latest_activity_and_completed_target(
+        repository,
+        std::sync::Arc::new(training_plan.clone()),
+        std::sync::Arc::new(latest_activity),
+        std::sync::Arc::new(completed_target),
+    );
+
+    let result = service.mark_saved("user-1", "i144331018").await.unwrap();
+
+    assert_eq!(result.summary.workout_id, "i144331018");
+    assert_eq!(result.workflow.plan_status.as_str(), "failed");
+    assert_eq!(
+        training_plan.calls(),
+        vec!["generate_for_saved_workout:user-1:wahoo-workout:450868242:1700000000".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn list_summaries_dedupes_equivalent_completed_workout_aliases() {
+    let mut summary = existing_summary();
+    summary.id = "summary-alias".to_string();
+    summary.workout_id = "i144331018".to_string();
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+    let completed_target = RecordingCompletedWorkoutTargetService::resolving(&[
+        (
+            "i144331018",
+            "i144331018",
+            &["i144331018", "wahoo-workout:450868242"],
+        ),
+        (
+            "wahoo-workout:450868242",
+            "i144331018",
+            &["i144331018", "wahoo-workout:450868242"],
+        ),
+    ]);
+    let service = WorkoutSummaryService::new(
+        repository,
+        crate::shared::InMemoryCoachReplyOperationRepository::default(),
+        crate::shared::TestClock,
+        crate::shared::TestIdGenerator::default(),
+    )
+    .with_completed_workout_target_service(std::sync::Arc::new(completed_target));
+
+    let summaries = service
+        .list_summaries(
+            "user-1",
+            vec![
+                "i144331018".to_string(),
+                "wahoo-workout:450868242".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, "summary-alias");
+    assert_eq!(summaries[0].workout_id, "i144331018");
+}
+
+#[tokio::test]
+async fn batch_lookup_reuses_equivalent_completed_workout_alias_for_requested_activity_id() {
+    let mut summary = existing_summary();
+    summary.id = "summary-alias".to_string();
+    summary.workout_id = "wahoo-workout:450868242".to_string();
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+
+    let summaries = repository
+        .find_by_user_id_and_workout_ids("user-1", vec!["450868242".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].workout_id, "450868242");
+}
+
+#[tokio::test]
+async fn persist_workout_recap_updates_existing_equivalent_alias_summary() {
+    let mut summary = existing_summary();
+    summary.workout_id = "wahoo-workout:450868242".to_string();
+    let repository = InMemoryWorkoutSummaryRepository::with_summary(summary);
+    let completed_target = RecordingCompletedWorkoutTargetService::resolving(&[(
+        "i144331018",
+        "i144331018",
+        &["i144331018", "wahoo-workout:450868242"],
+    )]);
+    let service = WorkoutSummaryService::new(
+        repository.clone(),
+        crate::shared::InMemoryCoachReplyOperationRepository::default(),
+        crate::shared::TestClock,
+        crate::shared::TestIdGenerator::default(),
+    )
+    .with_completed_workout_target_service(std::sync::Arc::new(completed_target.clone()));
+
+    let updated = service
+        .persist_workout_recap(
+            "user-1",
+            "i144331018",
+            WorkoutRecap::generated("Recovered recap", "openrouter", "gemini", 1_700_000_010),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.workout_id, "i144331018");
+    assert_eq!(
+        updated.workout_recap_text.as_deref(),
+        Some("Recovered recap")
+    );
+    assert_eq!(
+        repository.calls(),
+        vec!["persist_workout_recap:wahoo-workout:450868242".to_string()]
+    );
+    assert_eq!(
+        completed_target.calls(),
+        vec!["resolve_completed_workout_target:user-1:i144331018".to_string()]
     );
 }
 

--- a/tests/workout_summary_service/shared/mod.rs
+++ b/tests/workout_summary_service/shared/mod.rs
@@ -15,8 +15,8 @@ use aiwattcoach::domain::{
     workout_summary::{
         BoxFuture, CoachReplyClaimResult, CoachReplyOperation, CoachReplyOperationRepository,
         CoachReplyOperationStatus, CompletedWorkoutTargetUseCases, ConversationMessage,
-        MessageRole, WorkoutCoach, WorkoutRecap, WorkoutSummary, WorkoutSummaryError,
-        WorkoutSummaryRepository, WorkoutSummaryService,
+        MessageRole, ResolvedCompletedWorkoutTarget, WorkoutCoach, WorkoutRecap, WorkoutSummary,
+        WorkoutSummaryError, WorkoutSummaryRepository, WorkoutSummaryService,
     },
 };
 

--- a/tests/workout_summary_service/shared/services.rs
+++ b/tests/workout_summary_service/shared/services.rs
@@ -390,7 +390,7 @@ pub(crate) struct RecordingLatestCompletedActivityService {
 
 #[derive(Clone, Default)]
 pub(crate) struct RecordingCompletedWorkoutTargetService {
-    allowed_workout_ids: Arc<Mutex<Vec<String>>>,
+    resolved_targets: Arc<Mutex<BTreeMap<String, ResolvedCompletedWorkoutTarget>>>,
     calls: Arc<Mutex<Vec<String>>>,
 }
 
@@ -410,10 +410,44 @@ impl RecordingLatestCompletedActivityService {
 impl RecordingCompletedWorkoutTargetService {
     pub(crate) fn allowing(workout_ids: &[&str]) -> Self {
         Self {
-            allowed_workout_ids: Arc::new(Mutex::new(
+            resolved_targets: Arc::new(Mutex::new(
                 workout_ids
                     .iter()
-                    .map(|value| (*value).to_string())
+                    .map(|value| {
+                        let workout_id = (*value).to_string();
+                        (
+                            workout_id.clone(),
+                            ResolvedCompletedWorkoutTarget {
+                                preferred_workout_id: workout_id.clone(),
+                                equivalent_workout_ids: vec![workout_id],
+                            },
+                        )
+                    })
+                    .collect(),
+            )),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(crate) fn resolving(entries: &[(&str, &str, &[&str])]) -> Self {
+        Self {
+            resolved_targets: Arc::new(Mutex::new(
+                entries
+                    .iter()
+                    .map(
+                        |(requested_workout_id, preferred_workout_id, equivalent_workout_ids)| {
+                            (
+                                (*requested_workout_id).to_string(),
+                                ResolvedCompletedWorkoutTarget {
+                                    preferred_workout_id: (*preferred_workout_id).to_string(),
+                                    equivalent_workout_ids: equivalent_workout_ids
+                                        .iter()
+                                        .map(|value| (*value).to_string())
+                                        .collect(),
+                                },
+                            )
+                        },
+                    )
                     .collect(),
             )),
             calls: Arc::new(Mutex::new(Vec::new())),
@@ -452,7 +486,7 @@ impl CompletedWorkoutTargetUseCases for RecordingCompletedWorkoutTargetService {
         user_id: &str,
         workout_id: &str,
     ) -> aiwattcoach::domain::workout_summary::BoxFuture<Result<bool, WorkoutSummaryError>> {
-        let allowed_workout_ids = self.allowed_workout_ids.lock().unwrap().clone();
+        let resolved_targets = self.resolved_targets.lock().unwrap().clone();
         let calls = self.calls.clone();
         let user_id = user_id.to_string();
         let workout_id = workout_id.to_string();
@@ -460,7 +494,26 @@ impl CompletedWorkoutTargetUseCases for RecordingCompletedWorkoutTargetService {
             calls.lock().unwrap().push(format!(
                 "is_completed_workout_target:{user_id}:{workout_id}"
             ));
-            Ok(allowed_workout_ids.contains(&workout_id))
+            Ok(resolved_targets.contains_key(&workout_id))
+        })
+    }
+
+    fn resolve_completed_workout_target(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+    ) -> aiwattcoach::domain::workout_summary::BoxFuture<
+        Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>,
+    > {
+        let resolved_targets = self.resolved_targets.lock().unwrap().clone();
+        let calls = self.calls.clone();
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        Box::pin(async move {
+            calls.lock().unwrap().push(format!(
+                "resolve_completed_workout_target:{user_id}:{workout_id}"
+            ));
+            Ok(resolved_targets.get(&workout_id).cloned())
         })
     }
 }

--- a/tests/workout_summary_service/shared/summary_repository.rs
+++ b/tests/workout_summary_service/shared/summary_repository.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+use aiwattcoach::domain::completed_workouts::{
+    canonical_completed_workout_id, completed_workout_activity_id,
+};
+
 #[derive(Clone, Default)]
 pub(crate) struct InMemoryWorkoutSummaryRepository {
     summaries: Arc<Mutex<BTreeMap<(String, String), WorkoutSummary>>>,
@@ -61,7 +65,19 @@ impl WorkoutSummaryRepository for InMemoryWorkoutSummaryRepository {
             let summaries = summaries.lock().unwrap();
             Ok(workout_ids
                 .into_iter()
-                .filter_map(|workout_id| summaries.get(&(user_id.clone(), workout_id)).cloned())
+                .filter_map(|workout_id| {
+                    let mut summary = summaries
+                        .get(&(user_id.clone(), workout_id.clone()))
+                        .cloned()
+                        .or_else(|| {
+                            summaries
+                                .values()
+                                .find(|summary| matches_requested_workout_id(summary, &workout_id))
+                                .cloned()
+                        })?;
+                    summary.workout_id = workout_id;
+                    Some(summary)
+                })
                 .collect())
         })
     }
@@ -230,4 +246,10 @@ impl WorkoutSummaryRepository for InMemoryWorkoutSummaryRepository {
                 }))
         })
     }
+}
+
+fn matches_requested_workout_id(summary: &WorkoutSummary, requested_workout_id: &str) -> bool {
+    summary.workout_id == requested_workout_id
+        || summary.workout_id == canonical_completed_workout_id(requested_workout_id)
+        || completed_workout_activity_id(&summary.workout_id) == requested_workout_id
 }


### PR DESCRIPTION
Keep completed-workout summary reads and side effects aligned with persisted alias identities, and add the supporting regressions and Mongo maintenance scripts needed to validate and operate the rollout safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance for Wahoo sync state cleanup workflow with field-only migration option.
  * Documented completed-workout summary alias resolution updates.

* **Bug Fixes**
  * Improved workout summary retrieval to correctly match equivalent workout IDs and prevent duplicate processing.
  * Enhanced training plan projections to handle repeated operations with same key properly.
  * Fixed batch lookups to deduplicate results when multiple IDs map to the same completed workout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->