### PR TITLE
fix: accept Wahoo summary-only webhook payloads

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-02 | user | Wahoo webhook real summary-only payload
+
+- Problem: the Wahoo webhook REST DTO still assumed the older payload shape with a top-level `workout` object and numeric metric fields already normalized to local names. Real `workout_summary` webhook deliveries from Wahoo can instead nest the planned workout under `workout_summary.workout`, send completed-workout metrics under string-valued keys like `distance_accum` and `power_avg`, and carry the real completed start time in `workout_summary.started_at`. That made valid webhook deliveries fail with `400`, and even a naive parser widening would have risked importing the planned workout id/start instead of the completed workout id/start.
+- Fix: widened `src/adapters/rest/wahoo/dto.rs` to accept both webhook payload shapes, parse the string-or-number summary metric fields, and map summary-only webhook payloads into a completed-workout `WahooWorkout` using `workout_summary.id` plus `workout_summary.started_at` while still reusing the nested workout metadata for plan linkage fields. Added a REST regression in `tests/auth_rest/wahoo_webhook.rs` using a real summary-only payload shape and asserting the forwarded workout id/start values.
+- Prevention: when provider webhooks evolve independently from poll/list endpoints, do not reuse one rigid DTO shape across both paths without checking real captured payloads. For Wahoo `workout_summary` events specifically, verify which fields describe the completed workout versus the nested planned workout before choosing canonical id and start-time mapping.
+
 ### 2026-05-01 | CodeRabbit | PR #174 webhook nullish optional-field follow-up
 
 - Problem: after the broader PR #174 review-fix batch, the Wahoo webhook REST DTO still assumed several optional fields were either present or non-null. Real webhook payloads can send `plan_ids`, `manual`, or `edited` as explicit `null`, which made serde reject otherwise valid `workout_summary` events with `400` even though those fields should behave the same as missing values.

--- a/src/adapters/rest/wahoo/dto.rs
+++ b/src/adapters/rest/wahoo/dto.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Deserializer};
+use serde::{de::Error as _, Deserialize, Deserializer};
+use serde_json::Value;
 
 use crate::domain::wahoo::{WahooFileReference, WahooWorkout, WahooWorkoutSummary};
 
@@ -18,7 +19,7 @@ pub(crate) struct WahooWebhookRequest {
     #[serde(rename = "workout_summary")]
     pub(super) workout_summary: Option<WahooWebhookWorkoutSummary>,
     #[serde(rename = "workout")]
-    pub(super) workout: WahooWebhookWorkout,
+    pub(super) workout: Option<WahooWebhookWorkout>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,33 +62,100 @@ pub(super) struct WahooWebhookWorkout {
 pub(super) struct WahooWebhookWorkoutSummary {
     #[serde(rename = "id")]
     pub(super) id: i64,
+    #[serde(rename = "started_at")]
+    pub(super) started_at: Option<String>,
     #[serde(rename = "name")]
     pub(super) name: Option<String>,
-    #[serde(rename = "ascent_meters")]
+    #[serde(
+        rename = "ascent_meters",
+        alias = "ascent_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) ascent_meters: Option<f64>,
-    #[serde(rename = "cadence_avg_rpm")]
+    #[serde(
+        rename = "cadence_avg_rpm",
+        alias = "cadence_avg",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) cadence_avg_rpm: Option<f64>,
-    #[serde(rename = "calories")]
+    #[serde(
+        rename = "calories",
+        alias = "calories_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) calories: Option<f64>,
-    #[serde(rename = "distance_meters")]
+    #[serde(
+        rename = "distance_meters",
+        alias = "distance_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) distance_meters: Option<f64>,
-    #[serde(rename = "duration_active_seconds")]
+    #[serde(
+        rename = "duration_active_seconds",
+        alias = "duration_active_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) duration_active_seconds: Option<f64>,
-    #[serde(rename = "duration_paused_seconds")]
+    #[serde(
+        rename = "duration_paused_seconds",
+        alias = "duration_paused_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) duration_paused_seconds: Option<f64>,
-    #[serde(rename = "duration_total_seconds")]
+    #[serde(
+        rename = "duration_total_seconds",
+        alias = "duration_total_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) duration_total_seconds: Option<f64>,
-    #[serde(rename = "heart_rate_avg_bpm")]
+    #[serde(
+        rename = "heart_rate_avg_bpm",
+        alias = "heart_rate_avg",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) heart_rate_avg_bpm: Option<f64>,
-    #[serde(rename = "normalized_power_watts")]
+    #[serde(
+        rename = "normalized_power_watts",
+        alias = "power_bike_np_last",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) normalized_power_watts: Option<f64>,
-    #[serde(rename = "training_stress_score")]
+    #[serde(
+        rename = "training_stress_score",
+        alias = "power_bike_tss_last",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) training_stress_score: Option<f64>,
-    #[serde(rename = "average_power_watts")]
+    #[serde(
+        rename = "average_power_watts",
+        alias = "power_avg",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) average_power_watts: Option<f64>,
-    #[serde(rename = "speed_avg_mps")]
+    #[serde(
+        rename = "speed_avg_mps",
+        alias = "speed_avg",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) speed_avg_mps: Option<f64>,
-    #[serde(rename = "total_work_joules")]
+    #[serde(
+        rename = "total_work_joules",
+        alias = "work_accum",
+        default,
+        deserialize_with = "deserialize_optional_f64"
+    )]
     pub(super) total_work_joules: Option<f64>,
     #[serde(rename = "time_zone")]
     pub(super) time_zone: Option<String>,
@@ -111,6 +179,8 @@ pub(super) struct WahooWebhookWorkoutSummary {
     pub(super) created_at: Option<String>,
     #[serde(rename = "updated_at")]
     pub(super) updated_at: Option<String>,
+    #[serde(rename = "workout")]
+    pub(super) workout: Option<WahooWebhookWorkout>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -120,20 +190,30 @@ pub(super) struct WahooWebhookFileReference {
 }
 
 impl WahooWebhookRequest {
-    pub(super) fn into_domain_parts(self) -> (Option<String>, WahooWebhookDomainParts) {
-        let workout = self.workout.into_domain(self.workout_summary);
-        (
+    pub(super) fn into_domain_parts(
+        self,
+    ) -> Result<(Option<String>, WahooWebhookDomainParts), &'static str> {
+        let workout = match (self.workout, self.workout_summary) {
+            (Some(workout), Some(workout_summary)) => {
+                workout.into_domain(Some(workout_summary.into_domain()))
+            }
+            (Some(workout), None) => workout.into_domain(None),
+            (None, Some(workout_summary)) => workout_summary.into_summary_only_workout()?,
+            (None, None) => return Err("missing workout payload"),
+        };
+
+        Ok((
             self.event_type,
             WahooWebhookDomainParts {
                 wahoo_user_id: self.user.id,
                 workout,
             },
-        )
+        ))
     }
 }
 
 impl WahooWebhookWorkout {
-    fn into_domain(self, workout_summary: Option<WahooWebhookWorkoutSummary>) -> WahooWorkout {
+    fn into_domain(self, workout_summary: Option<WahooWorkoutSummary>) -> WahooWorkout {
         WahooWorkout {
             id: self.id,
             starts: self.starts,
@@ -144,7 +224,7 @@ impl WahooWebhookWorkout {
             route_id: self.route_id,
             workout_token: self.workout_token,
             workout_type_id: self.workout_type_id,
-            workout_summary: workout_summary.map(WahooWebhookWorkoutSummary::into_domain),
+            workout_summary,
             created_at: self.created_at,
             updated_at: self.updated_at,
         }
@@ -164,6 +244,30 @@ where
     T: Deserialize<'de>,
 {
     Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn deserialize_optional_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(number)) => number
+            .as_f64()
+            .map(Some)
+            .ok_or_else(|| D::Error::custom("invalid numeric value")),
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            if value.is_empty() {
+                return Ok(None);
+            }
+
+            value.parse::<f64>().map(Some).map_err(D::Error::custom)
+        }
+        Some(other) => Err(D::Error::custom(format!(
+            "expected number or string, got {other}"
+        ))),
+    }
 }
 
 impl WahooWebhookWorkoutSummary {
@@ -197,5 +301,157 @@ impl WahooWebhookWorkoutSummary {
             created_at: self.created_at,
             updated_at: self.updated_at,
         }
+    }
+
+    fn into_summary_only_workout(self) -> Result<WahooWorkout, &'static str> {
+        let WahooWebhookWorkoutSummary {
+            id,
+            started_at,
+            name,
+            ascent_meters,
+            cadence_avg_rpm,
+            calories,
+            distance_meters,
+            duration_active_seconds,
+            duration_paused_seconds,
+            duration_total_seconds,
+            heart_rate_avg_bpm,
+            normalized_power_watts,
+            training_stress_score,
+            average_power_watts,
+            speed_avg_mps,
+            total_work_joules,
+            time_zone,
+            manual,
+            edited,
+            fitness_app_id,
+            file,
+            created_at,
+            updated_at,
+            workout,
+        } = self;
+
+        let workout = workout.ok_or("missing workout payload")?;
+        let file = file
+            .and_then(|file| file.url)
+            .map(|url| url.trim().to_string())
+            .filter(|url| !url.is_empty())
+            .map(|url| WahooFileReference { url });
+        let summary = WahooWorkoutSummary {
+            id,
+            name,
+            ascent_meters,
+            cadence_avg_rpm,
+            calories,
+            distance_meters,
+            duration_active_seconds,
+            duration_paused_seconds,
+            duration_total_seconds,
+            heart_rate_avg_bpm,
+            normalized_power_watts,
+            training_stress_score,
+            average_power_watts,
+            speed_avg_mps,
+            total_work_joules,
+            time_zone,
+            manual,
+            edited,
+            fitness_app_id,
+            file,
+            created_at: created_at.clone(),
+            updated_at: updated_at.clone(),
+        };
+
+        Ok(WahooWorkout {
+            id,
+            starts: started_at.unwrap_or(workout.starts),
+            minutes: workout.minutes,
+            name: workout.name,
+            plan_id: workout.plan_id,
+            plan_ids: workout.plan_ids,
+            route_id: workout.route_id,
+            workout_token: workout.workout_token,
+            workout_type_id: workout.workout_type_id,
+            workout_summary: Some(summary),
+            created_at,
+            updated_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WahooWebhookRequest;
+
+    #[test]
+    fn real_summary_only_payload_maps_to_completed_workout_fields() {
+        let payload = r#"{
+            "event_type": "workout_summary",
+            "webhook_token": "secret-token",
+            "user": { "id": 616126 },
+            "workout_summary": {
+                "id": 402756448,
+                "started_at": "2026-05-02T08:14:29.000Z",
+                "ascent_accum": "36.0",
+                "cadence_avg": "76.0",
+                "calories_accum": "464.0",
+                "distance_accum": "20959.15",
+                "duration_active_accum": "2405.0",
+                "duration_paused_accum": "36.0",
+                "duration_total_accum": "2441.0",
+                "heart_rate_avg": null,
+                "power_bike_np_last": "221.0",
+                "power_bike_tss_last": "28.1",
+                "power_avg": "193.0",
+                "speed_avg": "8.72",
+                "work_accum": "464094.0",
+                "fitness_app_id": 14,
+                "time_zone": "Europe/Warsaw",
+                "created_at": "2026-05-02T10:11:08.000Z",
+                "updated_at": "2026-05-02T10:11:13.000Z",
+                "file": {
+                    "url": "https://cdn.wahooligan.com/wahoo-cloud/production/uploads/workout_file/file/test.fit"
+                },
+                "workout": {
+                    "id": 451769692,
+                    "starts": "2026-05-02T21:00:00.000Z",
+                    "minutes": 40,
+                    "name": "Race Openers",
+                    "created_at": "2026-05-01T11:50:19.000Z",
+                    "updated_at": "2026-05-01T11:50:19.000Z",
+                    "plan_id": 13449478,
+                    "workout_token": "icu_107574759",
+                    "workout_type_id": 0,
+                    "fitness_app_id": 1199
+                }
+            }
+        }"#;
+
+        let request: WahooWebhookRequest = serde_json::from_str(payload).unwrap();
+        let (event_type, parts) = request.into_domain_parts().unwrap();
+
+        assert_eq!(event_type.as_deref(), Some("workout_summary"));
+        assert_eq!(parts.wahoo_user_id, 616_126);
+        assert_eq!(parts.workout.id, 402_756_448);
+        assert_eq!(parts.workout.starts, "2026-05-02T08:14:29.000Z");
+        assert_eq!(parts.workout.minutes, Some(40));
+        assert_eq!(parts.workout.name.as_deref(), Some("Race Openers"));
+        assert_eq!(parts.workout.plan_id, Some(13_449_478));
+        assert_eq!(
+            parts.workout.workout_token.as_deref(),
+            Some("icu_107574759")
+        );
+        assert_eq!(parts.workout.workout_type_id, Some(0));
+
+        let summary = parts.workout.workout_summary.expect("summary should exist");
+        assert_eq!(summary.id, 402_756_448);
+        assert_eq!(summary.distance_meters, Some(20_959.15));
+        assert_eq!(summary.duration_total_seconds, Some(2_441.0));
+        assert_eq!(summary.normalized_power_watts, Some(221.0));
+        assert_eq!(summary.training_stress_score, Some(28.1));
+        assert_eq!(
+            summary.file.expect("file should exist").url,
+            "https://cdn.wahooligan.com/wahoo-cloud/production/uploads/workout_file/file/test.fit"
+        );
     }
 }

--- a/src/adapters/rest/wahoo/handlers.rs
+++ b/src/adapters/rest/wahoo/handlers.rs
@@ -40,7 +40,13 @@ pub async fn receive_webhook(
     };
 
     let webhook_token = payload.webhook_token.clone();
-    let (_, parts) = payload.into_domain_parts();
+    let (_, parts) = match payload.into_domain_parts() {
+        Ok(parts) => parts,
+        Err(error) => {
+            warn!(error, "Invalid Wahoo webhook payload");
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
     let WahooWebhookDomainParts {
         wahoo_user_id,
         workout,

--- a/tests/auth_rest/wahoo_webhook.rs
+++ b/tests/auth_rest/wahoo_webhook.rs
@@ -372,6 +372,83 @@ async fn wahoo_webhook_accepts_workout_summary_event_with_nullish_optional_field
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn wahoo_webhook_accepts_real_summary_only_payload_shape() {
+    let service = TestWahooWebhookService::accepting();
+    let app =
+        auth_test_app_with_wahoo_webhook(TestIdentityService::default(), service.clone()).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/wahoo/webhook")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "event_type": "workout_summary",
+                        "webhook_token": "secret-token",
+                        "user": { "id": 616126 },
+                        "workout_summary": {
+                            "id": 402756448,
+                            "started_at": "2026-05-02T08:14:29.000Z",
+                            "ascent_accum": "36.0",
+                            "cadence_avg": "76.0",
+                            "calories_accum": "464.0",
+                            "distance_accum": "20959.15",
+                            "duration_active_accum": "2405.0",
+                            "duration_paused_accum": "36.0",
+                            "duration_total_accum": "2441.0",
+                            "heart_rate_avg": null,
+                            "power_bike_np_last": "221.0",
+                            "power_bike_tss_last": "28.1",
+                            "power_avg": "193.0",
+                            "speed_avg": "8.72",
+                            "work_accum": "464094.0",
+                            "fitness_app_id": 14,
+                            "time_zone": "Europe/Warsaw",
+                            "created_at": "2026-05-02T10:11:08.000Z",
+                            "updated_at": "2026-05-02T10:11:13.000Z",
+                            "file": {
+                                "url": "https://cdn.wahooligan.com/wahoo-cloud/production/uploads/workout_file/file/test.fit"
+                            },
+                            "workout": {
+                                "id": 451769692,
+                                "starts": "2026-05-02T21:00:00.000Z",
+                                "minutes": 40,
+                                "name": "Race Openers",
+                                "created_at": "2026-05-01T11:50:19.000Z",
+                                "updated_at": "2026-05-01T11:50:19.000Z",
+                                "plan_id": 13449478,
+                                "workout_token": "icu_107574759",
+                                "workout_type_id": 0,
+                                "fitness_app_id": 1199
+                            }
+                        }
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT_BYTES)
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), br#"{"accepted":true}"#);
+    assert_eq!(
+        service.import_calls(),
+        vec![WahooWebhookImportCall {
+            webhook_token: "secret-token".to_string(),
+            wahoo_user_id: 616_126,
+            workout_id: 402_756_448,
+            starts: "2026-05-02T08:14:29.000Z".to_string(),
+            has_workout_summary: true,
+        }]
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn wahoo_webhook_returns_400_for_workout_summary_event_without_summary_payload() {
     let app = auth_test_app_with_wahoo_webhook(
         TestIdentityService::default(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Wahoo webhook handling to properly parse and accept "summary-only" payload variants that previously failed.
  * Improved webhook validation with explicit error handling; invalid payloads now return clear error responses instead of proceeding with incomplete data.

* **Tests**
  * Added test coverage for real-world Wahoo summary-only webhook payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->