### PR TITLE
fix: use Wahoo workout ids for FIT enrichment

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-02 | user | Wahoo completed-workout id semantics vs summary id
+
+- Problem: Wahoo completed-workout import mixed three different identifiers from the same payload. The canonical completed workout and FIT enrichment path could end up persisting `workout_summary.id` or `workout_token` where the system actually needed the Wahoo workout resource id (`workout.id`). That left `completed_workouts.external_id` and task payloads pointing at the wrong id, so later `GET /v1/workouts/{id}/workout_summary` calls returned 404 or "does not expose a FIT file URL" even though the live workout resource did have a FIT file.
+- Fix: changed Wahoo import mapping to persist the workout resource id as `CompletedWorkout.external_id`, normalized Wahoo completed-workout imports so `source_activity_id` and `external_id` are reset from the imported Wahoo workout id before dedup/upsert, and taught FIT enrichment to prefer a numeric `CompletedWorkout.external_id` over a stale task payload workout id. Added focused regressions for the real split case where `workout.id != workout_summary.id` and `workout_token` carries an Intervals key.
+- Prevention: whenever an upstream payload contains both entity ids and nested summary ids, verify which id each downstream API endpoint expects before persisting or scheduling follow-up work. For Wahoo completed workouts specifically, treat `workout.id` as the provider resource id for sync/enrichment, `workout_summary.id` as a nested summary id only, and `workout_token` as a cross-system marker rather than the canonical external id.
+
 ### 2026-05-02 | user | Wahoo webhook real summary-only payload
 
 - Problem: the Wahoo webhook REST DTO still assumed the older payload shape with a top-level `workout` object and numeric metric fields already normalized to local names. Real `workout_summary` webhook deliveries from Wahoo can instead nest the planned workout under `workout_summary.workout`, send completed-workout metrics under string-valued keys like `distance_accum` and `power_avg`, and carry the real completed start time in `workout_summary.started_at`. That made valid webhook deliveries fail with `400`, and even a naive parser widening would have risked importing the planned workout id/start instead of the completed workout id/start.

--- a/src/domain/external_sync/import/mod.rs
+++ b/src/domain/external_sync/import/mod.rs
@@ -365,6 +365,7 @@ where
         &self,
         command: ExternalCompletedWorkoutImport,
     ) -> Result<ExternalImportOutcome, ExternalImportError> {
+        let command = normalize_completed_workout_import(command);
         let dedup_key = completed_workout_dedup_key(&command.workout);
         let resolved_link = self
             .resolve_planned_workout_id_for_completed_workout(
@@ -907,6 +908,17 @@ where
     ) -> BoxFuture<Result<ExternalImportOutcome, ExternalImportError>> {
         ExternalImportService::import(self, command)
     }
+}
+
+fn normalize_completed_workout_import(
+    mut command: ExternalCompletedWorkoutImport,
+) -> ExternalCompletedWorkoutImport {
+    if command.provider == ExternalProvider::Wahoo {
+        command.workout.external_id = Some(command.external_id.clone());
+        command.workout.source_activity_id = Some(command.external_id.clone());
+    }
+
+    command
 }
 
 fn map_planned_workout_error(error: PlannedWorkoutError) -> ExternalImportError {

--- a/src/domain/external_sync/import/tests/completed_workouts.rs
+++ b/src/domain/external_sync/import/tests/completed_workouts.rs
@@ -212,6 +212,54 @@ async fn import_completed_workout_reuses_existing_canonical_workout_for_matching
 }
 
 #[tokio::test]
+async fn import_completed_workout_persists_wahoo_workout_id_as_external_id() {
+    let completed_workouts = InMemoryCompletedWorkoutRepository::default();
+    let sync_states = InMemorySyncStateRepository::default();
+    let service = external_import_service_without_refresh(
+        InMemoryPlannedWorkoutRepository::default(),
+        completed_workouts.clone(),
+        InMemoryRaceRepository::default(),
+        InMemorySpecialDayRepository::default(),
+        InMemoryPlannedWorkoutTokenRepository::default(),
+        InMemoryPlannedCompletedWorkoutLinkRepository::default(),
+        InMemoryPlannedWorkoutWahooSyncRepository::default(),
+        InMemoryObservationRepository::default(),
+        sync_states.clone(),
+    );
+
+    service
+        .import(ExternalImportCommand::UpsertCompletedWorkout(Box::new(
+            ExternalCompletedWorkoutImport {
+                provider: ExternalProvider::Wahoo,
+                external_id: "451769692".to_string(),
+                normalized_payload_hash: "hash-wahoo-workout-id".to_string(),
+                intervals_paired_event_id: None,
+                marker_sources: Vec::new(),
+                wahoo_plan_id: None,
+                wahoo_workout_token: Some("icu_107574759".to_string()),
+                workout: sample_completed_workout_for_provider(
+                    ExternalProvider::Wahoo,
+                    "wahoo-workout:451769692",
+                    None,
+                ),
+            },
+        )))
+        .await
+        .unwrap();
+
+    let stored_workout = completed_workouts
+        .find_by_user_id_and_completed_workout_id("user-1", "wahoo-workout:451769692")
+        .await
+        .unwrap()
+        .expect("stored completed workout");
+    assert_eq!(stored_workout.external_id.as_deref(), Some("451769692"));
+
+    let stored_state = sync_states.stored();
+    assert_eq!(stored_state.len(), 1);
+    assert_eq!(stored_state[0].external_id.as_deref(), Some("451769692"));
+}
+
+#[tokio::test]
 async fn import_completed_workout_refreshes_old_and_new_dates_when_existing_canonical_date_moves() {
     let completed_workouts = InMemoryCompletedWorkoutRepository::default();
     let refresh = RecordingRefresh::default();

--- a/src/domain/wahoo/import_mapping.rs
+++ b/src/domain/wahoo/import_mapping.rs
@@ -93,7 +93,7 @@ fn map_workout_to_completed_workout(
         summary.name.clone().or_else(|| workout.name.clone()),
         None,
         map_activity_type(workout.workout_type_id),
-        workout.workout_token.clone(),
+        Some(workout.id.to_string()),
         is_trainer_workout(workout.workout_type_id),
         round_optional_i32(summary.duration_total_seconds)
             .or_else(|| round_optional_i32(summary.duration_active_seconds))

--- a/src/domain/wahoo/tests.rs
+++ b/src/domain/wahoo/tests.rs
@@ -321,6 +321,106 @@ impl WahooApiPort for TestOAuth {
     }
 }
 
+mod import_mapping_tests {
+    use super::*;
+    use crate::domain::wahoo::{map_workout_to_import_command, WahooFileReference};
+
+    fn sample_workout() -> WahooWorkout {
+        WahooWorkout {
+            id: 56_519,
+            starts: "2023-11-14T08:00:00.000Z".to_string(),
+            minutes: Some(60),
+            name: Some("Wahoo Ride".to_string()),
+            plan_id: None,
+            plan_ids: Vec::new(),
+            route_id: None,
+            workout_token: Some("token-1".to_string()),
+            workout_type_id: Some(0),
+            workout_summary: Some(WahooWorkoutSummary {
+                id: 8_297,
+                name: Some("Wahoo Ride".to_string()),
+                ascent_meters: Some(450.0),
+                cadence_avg_rpm: Some(50.0),
+                calories: Some(1500.0),
+                distance_meters: Some(24_909.71),
+                duration_active_seconds: Some(179.0),
+                duration_paused_seconds: Some(95.0),
+                duration_total_seconds: Some(275.0),
+                heart_rate_avg_bpm: Some(100.0),
+                normalized_power_watts: Some(150.0),
+                training_stress_score: Some(304.9),
+                average_power_watts: Some(94.59),
+                speed_avg_mps: Some(10.75),
+                total_work_joules: Some(1_041_480.0),
+                time_zone: Some("America/Denver".to_string()),
+                manual: false,
+                edited: false,
+                fitness_app_id: Some(1002),
+                file: Some(WahooFileReference {
+                    url: "https://example.test/file.fit".to_string(),
+                }),
+                created_at: Some("2023-11-14T08:00:00.000Z".to_string()),
+                updated_at: Some("2023-11-14T08:00:00.000Z".to_string()),
+            }),
+            created_at: Some("2023-11-14T08:00:00.000Z".to_string()),
+            updated_at: Some("2023-11-14T08:00:00.000Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn map_workout_to_import_command_uses_wahoo_canonical_identity() {
+        let mut workout = sample_workout();
+        workout.plan_id = Some(7001);
+        let command = map_workout_to_import_command("user-1", &workout)
+            .expect("workout with summary should map");
+
+        let crate::domain::external_sync::ExternalImportCommand::UpsertCompletedWorkout(import) =
+            command
+        else {
+            panic!("expected completed workout import");
+        };
+
+        assert_eq!(import.workout.completed_workout_id, "wahoo-workout:56519");
+        assert_eq!(import.workout.source_activity_id.as_deref(), Some("56519"));
+        assert_eq!(import.workout.external_id.as_deref(), Some("56519"));
+        assert_eq!(import.wahoo_workout_token.as_deref(), Some("token-1"));
+        assert_eq!(import.wahoo_plan_id, Some(7001));
+        assert_eq!(
+            import.workout.details_unavailable_reason.as_deref(),
+            Some("Detailed Wahoo workout data is still being processed. Please check back soon.")
+        );
+    }
+
+    #[test]
+    fn map_workout_to_import_command_uses_workout_id_not_summary_id_for_external_identity() {
+        let mut workout = sample_workout();
+        workout.id = 451_769_692;
+        workout.workout_token = Some("icu_107574759".to_string());
+        workout.workout_summary.as_mut().unwrap().id = 402_756_448;
+
+        let command = map_workout_to_import_command("user-1", &workout)
+            .expect("workout with summary should map");
+
+        let crate::domain::external_sync::ExternalImportCommand::UpsertCompletedWorkout(import) =
+            command
+        else {
+            panic!("expected completed workout import");
+        };
+
+        assert_eq!(import.external_id, "451769692");
+        assert_eq!(
+            import.workout.completed_workout_id,
+            "wahoo-workout:451769692"
+        );
+        assert_eq!(
+            import.workout.source_activity_id.as_deref(),
+            Some("451769692")
+        );
+        assert_eq!(import.workout.external_id.as_deref(), Some("451769692"));
+        assert_eq!(import.wahoo_workout_token.as_deref(), Some("icu_107574759"));
+    }
+}
+
 #[tokio::test]
 async fn finish_connect_rejects_state_owned_by_another_user() {
     let settings = InMemorySettingsRepository::default();

--- a/src/domain/wahoo_fit_enrichment/service.rs
+++ b/src/domain/wahoo_fit_enrichment/service.rs
@@ -142,6 +142,7 @@ where
             let workout = service
                 .load_completed_workout(&user_id, &completed_workout_id)
                 .await?;
+            let wahoo_workout_id = resolved_wahoo_workout_id(&workout, wahoo_workout_id);
             let fit_file = service
                 .load_or_create_fit_file(&user_id, &completed_workout_id, wahoo_workout_id)
                 .await?;
@@ -351,6 +352,14 @@ fn has_any_details(details: &CompletedWorkoutDetails) -> bool {
         || !details.heart_rate_zone_times.is_empty()
         || !details.pace_zone_times.is_empty()
         || !details.gap_zone_times.is_empty()
+}
+
+fn resolved_wahoo_workout_id(workout: &CompletedWorkout, fallback_wahoo_workout_id: i64) -> i64 {
+    workout
+        .external_id
+        .as_deref()
+        .and_then(|external_id| external_id.parse::<i64>().ok())
+        .unwrap_or(fallback_wahoo_workout_id)
 }
 
 fn merge_workout_enrichment(

--- a/src/domain/wahoo_fit_enrichment/service/tests.rs
+++ b/src/domain/wahoo_fit_enrichment/service/tests.rs
@@ -274,6 +274,8 @@ struct FakeWahooService {
     summary: Option<WahooWorkoutSummary>,
     file_bytes: Vec<u8>,
     download_calls: Arc<Mutex<usize>>,
+    expected_workout_id: Option<i64>,
+    requested_workout_ids: Arc<Mutex<Vec<i64>>>,
 }
 
 impl FakeWahooService {
@@ -307,11 +309,24 @@ impl FakeWahooService {
             }),
             file_bytes,
             download_calls: Arc::new(Mutex::new(0)),
+            expected_workout_id: None,
+            requested_workout_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn with_file_for_workout(file_url: &str, file_bytes: Vec<u8>, workout_id: i64) -> Self {
+        Self {
+            expected_workout_id: Some(workout_id),
+            ..Self::with_file(file_url, file_bytes)
         }
     }
 
     fn download_calls(&self) -> usize {
         *self.download_calls.lock().unwrap()
+    }
+
+    fn requested_workout_ids(&self) -> Vec<i64> {
+        self.requested_workout_ids.lock().unwrap().clone()
     }
 }
 
@@ -364,10 +379,18 @@ impl WahooUseCases for FakeWahooService {
     fn get_workout_summary(
         &self,
         _user_id: &str,
-        _workout_id: i64,
+        workout_id: i64,
     ) -> WahooBoxFuture<Result<Option<WahooWorkoutSummary>, WahooError>> {
         let summary = self.summary.clone();
-        Box::pin(async move { Ok(summary) })
+        let expected_workout_id = self.expected_workout_id;
+        let requested_workout_ids = self.requested_workout_ids.clone();
+        Box::pin(async move {
+            requested_workout_ids.lock().unwrap().push(workout_id);
+            if expected_workout_id.is_some_and(|expected| expected != workout_id) {
+                return Ok(None);
+            }
+            Ok(summary)
+        })
     }
 
     fn find_plan_by_external_id(
@@ -608,6 +631,34 @@ async fn enrich_completed_workout_updates_workout_and_fit_file() {
     );
     assert_eq!(fit_file.raw_fit_bytes, Some(vec![1, 2, 3, 4]));
     assert_eq!(recompute.calls().len(), 1);
+}
+
+#[tokio::test]
+async fn enrich_completed_workout_prefers_numeric_external_id_over_stale_task_workout_id() {
+    let mut workout = sample_workout();
+    workout.external_id = Some("451769692".to_string());
+    let workouts = InMemoryCompletedWorkoutRepository::with_workout(workout);
+    let fit_files = InMemoryWahooFitFileRepository::default();
+    let wahoo = Arc::new(FakeWahooService::with_file_for_workout(
+        "https://example.test/workout.fit",
+        vec![1, 2, 3, 4],
+        451_769_692,
+    ));
+    let service = WahooFitEnrichmentService::new(
+        wahoo.clone(),
+        workouts,
+        fit_files.clone(),
+        FakeParser::with_responses(vec![Ok(parsed_workout())]),
+        FixedClock,
+    );
+
+    service
+        .enrich_completed_workout("user-1", "wahoo-workout:42", 402_756_448)
+        .await
+        .expect("fit enrichment should use numeric external id when task payload id is stale");
+
+    assert_eq!(wahoo.requested_workout_ids(), vec![451_769_692]);
+    assert_eq!(fit_files.only_fit_file().wahoo_workout_id, 451_769_692);
 }
 
 #[tokio::test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Wahoo completed workout ID handling to correctly persist and reference the workout resource ID instead of the token
  * Improved ID normalization during import operations to prevent mixing different ID formats
  * Enhanced FIT enrichment to prioritize the canonical external ID over potentially stale task payload IDs

* **Tests**
  * Added regression coverage for Wahoo ID semantics with split workout scenarios
  * Added integration and unit tests validating corrected ID persistence and enrichment behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->