### PR TITLE
Add get_w_prime_balance LLM tool (Skiba W' balance model)

### DIFF
--- a/src/domain/llm_tools/mod.rs
+++ b/src/domain/llm_tools/mod.rs
@@ -23,6 +23,9 @@ pub use get_selected_workout::{GetSelectedWorkout, GetSelectedWorkoutDataPort};
 mod selected_workout_power_curve;
 pub use selected_workout_power_curve::SelectedWorkoutPowerCurve;
 
+mod w_prime_balance;
+pub use w_prime_balance::WPrimeBalance;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ToolScope {
     WorkoutSummaryChat,
@@ -345,6 +348,7 @@ fn all_tools() -> Vec<Box<dyn LlmTool>> {
         Box::new(SimulateForwardLoad),
         Box::new(GetSelectedWorkout),
         Box::new(SelectedWorkoutPowerCurve),
+        Box::new(WPrimeBalance),
     ]
 }
 
@@ -566,6 +570,7 @@ mod tests {
         assert!(prompt.contains("`simulate_forward_load`"));
         assert!(prompt.contains("`get_selected_workout`"));
         assert!(prompt.contains("`selected_workout_power_curve`"));
+        assert!(prompt.contains("`get_w_prime_balance`"));
         assert!(prompt.contains("call it instead of guessing"));
     }
 
@@ -581,6 +586,7 @@ mod tests {
         assert!(prompt.contains("`simulate_forward_load`"));
         assert!(!prompt.contains("`get_selected_workout`"));
         assert!(!prompt.contains("`selected_workout_power_curve`"));
+        assert!(!prompt.contains("`get_w_prime_balance`"));
     }
 
     #[test]

--- a/src/domain/llm_tools/w_prime_balance/mod.rs
+++ b/src/domain/llm_tools/w_prime_balance/mod.rs
@@ -221,6 +221,16 @@ fn parse_args(arguments_json: &str) -> Result<WPrimeBalanceArgs, String> {
             args.date
         ));
     }
+    if let Some(cp) = args.cp_watts {
+        if cp <= 0 {
+            return Err(format!("invalid cp_watts: expected > 0, got {cp}"));
+        }
+    }
+    if let Some(wp) = args.w_prime_joules {
+        if wp <= 0 {
+            return Err(format!("invalid w_prime_joules: expected > 0, got {wp}"));
+        }
+    }
     Ok(args)
 }
 
@@ -279,7 +289,7 @@ fn extract_power_samples(workout: &CompletedWorkout) -> Result<Vec<Option<i32>>,
     match series {
         Some(CompletedWorkoutSeries::Integers(values)) => Ok(values
             .iter()
-            .map(|&v| (v >= 0).then_some(v as i32))
+            .map(|&v| (v >= 0 && v <= i32::MAX as i64).then_some(v as i32))
             .collect()),
         Some(CompletedWorkoutSeries::Floats(values)) => Ok(values
             .iter()
@@ -328,7 +338,7 @@ fn compute_w_prime_balance(
     w_prime_joules: i32,
 ) -> (Vec<f64>, f64, f64, f64, f64, u32, u32, u32, u32, bool) {
     let cp = cp_watts as f64;
-    let w_prime = w_prime_joules as f64;
+    let w_prime = (w_prime_joules.max(1)) as f64;
     let mut balance = w_prime;
     let mut series = Vec::with_capacity(power_samples.len());
     let mut min_balance = w_prime;

--- a/src/domain/llm_tools/w_prime_balance/mod.rs
+++ b/src/domain/llm_tools/w_prime_balance/mod.rs
@@ -1,0 +1,394 @@
+use std::{future::Future, pin::Pin};
+
+use chrono::NaiveDate;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::domain::{
+    completed_workouts::{CompletedWorkout, CompletedWorkoutSeries},
+    llm::LlmToolDefinition,
+    llm_tools::{LlmTool, ToolExecutionContext},
+};
+
+mod response;
+use response::{build_w_prime_balance_response, WPrimeBalanceOutput};
+
+#[cfg(test)]
+mod tests;
+
+const W_PRIME_BALANCE_TOOL_NAME: &str = "get_w_prime_balance";
+const DEFAULT_CP_WATTS: i32 = 250;
+const DEFAULT_W_PRIME_JOULES: i32 = 20_000;
+const CP_FTP_RATIO: f64 = 0.90;
+const W_PRIME_PER_KG: f64 = 280.0;
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct WPrimeBalanceArgs {
+    date: String,
+    #[serde(default)]
+    workout_id: Option<String>,
+    #[serde(default)]
+    cp_watts: Option<i32>,
+    #[serde(default)]
+    w_prime_joules: Option<i32>,
+}
+
+pub struct WPrimeBalance;
+
+impl LlmTool for WPrimeBalance {
+    fn name(&self) -> &'static str {
+        W_PRIME_BALANCE_TOOL_NAME
+    }
+
+    fn definition(&self) -> LlmToolDefinition {
+        LlmToolDefinition {
+            name: self.name().to_string(),
+            description: "Compute W' (W-prime) balance for a completed workout. Tracks anaerobic work capacity depletion and recovery for each second using the Skiba differential model. When power exceeds Critical Power, W' depletes linearly; when power drops below CP, W' recovers exponentially. Returns time-series balance data and summary statistics including time spent at various depletion levels. Only available for completed workouts with power data.".to_string(),
+            input_schema_json: json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "description": "Date in YYYY-MM-DD format, e.g. 2026-05-05"
+                    },
+                    "workout_id": {
+                        "type": "string",
+                        "description": "Completed workout ID for the date. Required when multiple completed workouts exist on the same day."
+                    },
+                    "cp_watts": {
+                        "type": "integer",
+                        "description": "Critical Power in watts. If omitted, estimated as 90% of athlete FTP from context."
+                    },
+                    "w_prime_joules": {
+                        "type": "integer",
+                        "description": "W' capacity in joules. If omitted, estimated from athlete body weight (280 J/kg) from context."
+                    }
+                },
+                "required": ["date"]
+            })
+            .to_string(),
+        }
+    }
+
+    fn prompt_guidance(&self) -> Option<&'static str> {
+        Some(
+            "very useful for post-race analysis — use after selecting a completed workout to evaluate anaerobic capacity depletion, pacing strategy, or interval execution quality; prefer this over guessing from normalized power or intensity factor alone",
+        )
+    }
+
+    fn execute(
+        &self,
+        arguments_json: &str,
+        context: &ToolExecutionContext,
+    ) -> Pin<Box<dyn Future<Output = String> + Send>> {
+        let args = arguments_json.to_string();
+        let ctx = context.clone();
+        Box::pin(async move { execute_w_prime_balance(&args, &ctx).await })
+    }
+
+    fn preview_arguments(&self, arguments_json: &str) -> Option<String> {
+        let args: WPrimeBalanceArgs = serde_json::from_str(arguments_json).ok()?;
+        parse_date(&args.date)?;
+        let mut out = format!("date {}", args.date);
+        if let Some(ref id) = args.workout_id {
+            out.push_str(&format!(" workout {id}"));
+        }
+        if let Some(cp) = args.cp_watts {
+            out.push_str(&format!(" CP={cp}W"));
+        }
+        if let Some(wp) = args.w_prime_joules {
+            out.push_str(&format!(" W'={wp}J"));
+        }
+        Some(out)
+    }
+
+    fn is_available(&self, context: &ToolExecutionContext) -> bool {
+        context.data_port.is_some()
+    }
+}
+
+async fn execute_w_prime_balance(arguments_json: &str, context: &ToolExecutionContext) -> String {
+    let args = match parse_args(arguments_json) {
+        Ok(args) => args,
+        Err(err) => return json!({ "error": err }).to_string(),
+    };
+
+    let Some(port) = context.data_port.as_ref() else {
+        return json!({ "error": "data port not available" }).to_string();
+    };
+
+    let completed = match port
+        .list_completed_by_date_range(&context.user_id, &args.date, &args.date)
+        .await
+    {
+        Ok(workouts) => workouts,
+        Err(err) => {
+            return json!({ "error": format!("failed to load completed workouts: {err}") })
+                .to_string()
+        }
+    };
+
+    let workout = match select_workout(&args, completed) {
+        Ok(w) => w,
+        Err(err) => return json!({ "error": err }).to_string(),
+    };
+
+    if workout.details_unavailable_reason.is_some() {
+        return json!({
+            "error": "W' balance computation skipped",
+            "reason": "completed workout details are unavailable",
+            "date": args.date,
+            "workout_id": workout.completed_workout_id,
+        })
+        .to_string();
+    }
+
+    let power_samples = match extract_power_samples(&workout) {
+        Ok(samples) => samples,
+        Err(reason) => {
+            return json!({
+                "error": "W' balance computation skipped",
+                "reason": reason,
+                "date": args.date,
+                "workout_id": workout.completed_workout_id,
+            })
+            .to_string();
+        }
+    };
+
+    let valid_power_samples = power_samples.iter().filter(|v| v.is_some()).count();
+    if valid_power_samples == 0 {
+        return json!({
+            "error": "W' balance computation skipped",
+            "reason": "no valid power samples available",
+            "date": args.date,
+            "workout_id": workout.completed_workout_id,
+        })
+        .to_string();
+    }
+
+    let (cp_watts, cp_source) = estimate_cp(&args, context);
+    let (w_prime_joules, w_prime_source) = estimate_w_prime(&args, context);
+
+    let (
+        balance_series,
+        start_balance,
+        end_balance,
+        min_balance,
+        max_deficit,
+        time_above_90,
+        time_50_to_90,
+        time_10_to_50,
+        time_below_10,
+        depleted,
+    ) = compute_w_prime_balance(&power_samples, cp_watts, w_prime_joules);
+
+    let sample_count = power_samples.len();
+
+    let output = WPrimeBalanceOutput {
+        date: args.date,
+        workout_id: workout.completed_workout_id,
+        workout_name: workout.name,
+        cp_watts,
+        w_prime_joules,
+        cp_source,
+        w_prime_source,
+        sample_count,
+        valid_power_samples,
+        balance_series,
+        start_balance,
+        end_balance,
+        min_balance,
+        max_deficit,
+        time_above_90,
+        time_50_to_90,
+        time_10_to_50,
+        time_below_10,
+        depleted,
+    };
+
+    build_w_prime_balance_response(&output)
+}
+
+fn parse_args(arguments_json: &str) -> Result<WPrimeBalanceArgs, String> {
+    let args: WPrimeBalanceArgs =
+        serde_json::from_str(arguments_json).map_err(|err| format!("invalid arguments: {err}"))?;
+    if parse_date(&args.date).is_none() {
+        return Err(format!(
+            "invalid date: expected YYYY-MM-DD, got {}",
+            args.date
+        ));
+    }
+    Ok(args)
+}
+
+fn parse_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").ok()
+}
+
+fn select_workout(
+    args: &WPrimeBalanceArgs,
+    completed: Vec<CompletedWorkout>,
+) -> Result<CompletedWorkout, String> {
+    if completed.is_empty() {
+        return Err(format!(
+            "no completed workouts found for date {}",
+            args.date
+        ));
+    }
+
+    if let Some(ref workout_id) = args.workout_id {
+        completed
+            .into_iter()
+            .find(|w| w.completed_workout_id == *workout_id)
+            .ok_or_else(|| {
+                format!(
+                    "completed workout {workout_id} not found for date {}",
+                    args.date
+                )
+            })
+    } else if completed.len() == 1 {
+        Ok(completed.into_iter().next().unwrap())
+    } else {
+        let ids: Vec<String> = completed
+            .iter()
+            .map(|w| w.completed_workout_id.clone())
+            .collect();
+        Err(format!(
+            "multiple completed workouts found for date {}. Provide workout_id. Candidates: {ids:?}",
+            args.date
+        ))
+    }
+}
+
+fn extract_power_samples(workout: &CompletedWorkout) -> Result<Vec<Option<i32>>, String> {
+    let watts_stream = workout
+        .details
+        .streams
+        .iter()
+        .find(|s| s.stream_type.to_lowercase() == "watts")
+        .ok_or("no watts power stream in workout details")?;
+
+    let series = watts_stream
+        .primary_series
+        .as_ref()
+        .or(watts_stream.secondary_series.as_ref());
+
+    match series {
+        Some(CompletedWorkoutSeries::Integers(values)) => Ok(values
+            .iter()
+            .map(|&v| (v >= 0).then_some(v as i32))
+            .collect()),
+        Some(CompletedWorkoutSeries::Floats(values)) => Ok(values
+            .iter()
+            .map(|&v| {
+                if v.is_finite() && v >= 0.0 && v <= i32::MAX as f64 {
+                    Some(v.round() as i32)
+                } else {
+                    None
+                }
+            })
+            .collect()),
+        _ => Err("watts stream uses an unsupported series type".to_string()),
+    }
+}
+
+fn estimate_cp(args: &WPrimeBalanceArgs, context: &ToolExecutionContext) -> (i32, String) {
+    if let Some(cp) = args.cp_watts {
+        return (cp, "user_provided".to_string());
+    }
+    if let Some(ftp) = context.training_context.history.ftp_current {
+        if ftp > 0 {
+            let cp = (ftp as f64 * CP_FTP_RATIO).floor() as i32;
+            return (cp, "estimated_from_ftp".to_string());
+        }
+    }
+    (DEFAULT_CP_WATTS, "default".to_string())
+}
+
+fn estimate_w_prime(args: &WPrimeBalanceArgs, context: &ToolExecutionContext) -> (i32, String) {
+    if let Some(wp) = args.w_prime_joules {
+        return (wp, "user_provided".to_string());
+    }
+    if let Some(weight) = context.training_context.profile.weight_kg {
+        if weight > 0.0 {
+            let wp = (weight * W_PRIME_PER_KG).floor() as i32;
+            return (wp, "estimated_from_weight".to_string());
+        }
+    }
+    (DEFAULT_W_PRIME_JOULES, "default".to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_w_prime_balance(
+    power_samples: &[Option<i32>],
+    cp_watts: i32,
+    w_prime_joules: i32,
+) -> (Vec<f64>, f64, f64, f64, f64, u32, u32, u32, u32, bool) {
+    let cp = cp_watts as f64;
+    let w_prime = w_prime_joules as f64;
+    let mut balance = w_prime;
+    let mut series = Vec::with_capacity(power_samples.len());
+    let mut min_balance = w_prime;
+    let mut max_deficit = 0.0f64;
+    let mut time_above_90 = 0u32;
+    let mut time_50_to_90 = 0u32;
+    let mut time_10_to_50 = 0u32;
+    let mut time_below_10 = 0u32;
+    let mut depleted = false;
+
+    for sample in power_samples {
+        if let Some(power) = sample {
+            let p = *power as f64;
+            if p > cp {
+                balance -= p - cp;
+                if balance <= 0.0 {
+                    balance = 0.0;
+                    depleted = true;
+                }
+            } else if balance < w_prime {
+                let tau = w_prime / (cp - p);
+                balance = w_prime - (w_prime - balance) * (-1.0 / tau).exp();
+            }
+
+            if balance < min_balance {
+                min_balance = balance;
+            }
+            let deficit = w_prime - balance;
+            if deficit > max_deficit {
+                max_deficit = deficit;
+            }
+
+            let pct = balance / w_prime;
+            if pct >= 0.9 {
+                time_above_90 += 1;
+            } else if pct >= 0.5 {
+                time_50_to_90 += 1;
+            } else if pct >= 0.1 {
+                time_10_to_50 += 1;
+            } else {
+                time_below_10 += 1;
+            }
+        }
+
+        series.push(balance);
+    }
+
+    let start_balance = w_prime;
+    let end_balance = *series.last().unwrap_or(&w_prime);
+
+    (
+        series,
+        start_balance,
+        end_balance,
+        min_balance,
+        max_deficit,
+        time_above_90,
+        time_50_to_90,
+        time_10_to_50,
+        time_below_10,
+        depleted,
+    )
+}

--- a/src/domain/llm_tools/w_prime_balance/response.rs
+++ b/src/domain/llm_tools/w_prime_balance/response.rs
@@ -62,6 +62,9 @@ fn sample_balance_series(series: &[f64], max_points: usize) -> Vec<f64> {
     if max_points == 0 || series.is_empty() {
         return Vec::new();
     }
+    if max_points == 1 {
+        return vec![round_1(*series.last().unwrap_or(&0.0))];
+    }
     if series.len() <= max_points {
         return series.iter().map(|&v| round_1(v)).collect();
     }

--- a/src/domain/llm_tools/w_prime_balance/response.rs
+++ b/src/domain/llm_tools/w_prime_balance/response.rs
@@ -1,0 +1,76 @@
+use serde_json::json;
+
+const MAX_BALANCE_SERIES_POINTS: usize = 256;
+
+pub(super) struct WPrimeBalanceOutput {
+    pub(super) date: String,
+    pub(super) workout_id: String,
+    pub(super) workout_name: Option<String>,
+    pub(super) cp_watts: i32,
+    pub(super) w_prime_joules: i32,
+    pub(super) cp_source: String,
+    pub(super) w_prime_source: String,
+    pub(super) sample_count: usize,
+    pub(super) valid_power_samples: usize,
+    pub(super) balance_series: Vec<f64>,
+    pub(super) start_balance: f64,
+    pub(super) end_balance: f64,
+    pub(super) min_balance: f64,
+    pub(super) max_deficit: f64,
+    pub(super) time_above_90: u32,
+    pub(super) time_50_to_90: u32,
+    pub(super) time_10_to_50: u32,
+    pub(super) time_below_10: u32,
+    pub(super) depleted: bool,
+}
+
+pub(super) fn build_w_prime_balance_response(output: &WPrimeBalanceOutput) -> String {
+    let sampled = sample_balance_series(&output.balance_series, MAX_BALANCE_SERIES_POINTS);
+
+    let mut resp = json!({
+        "date": output.date,
+        "workout_id": output.workout_id,
+        "cp_watts": output.cp_watts,
+        "w_prime_joules": output.w_prime_joules,
+        "cp_source": output.cp_source,
+        "w_prime_source": output.w_prime_source,
+        "sample_count": output.sample_count,
+        "sample_period_seconds": 1,
+        "valid_power_samples": output.valid_power_samples,
+        "summary": {
+            "start_w_prime_balance": round_1(output.start_balance),
+            "end_w_prime_balance": round_1(output.end_balance),
+            "min_w_prime_balance": round_1(output.min_balance),
+            "max_deficit_joules": round_1(output.max_deficit),
+            "time_above_90_percent_seconds": output.time_above_90,
+            "time_50_to_90_percent_seconds": output.time_50_to_90,
+            "time_10_to_50_percent_seconds": output.time_10_to_50,
+            "time_below_10_percent_seconds": output.time_below_10,
+            "w_prime_depleted": output.depleted,
+        },
+        "w_prime_balance_series": sampled,
+    });
+
+    if let Some(ref name) = output.workout_name {
+        resp["workout_name"] = json!(name);
+    }
+
+    resp.to_string()
+}
+
+fn sample_balance_series(series: &[f64], max_points: usize) -> Vec<f64> {
+    if max_points == 0 || series.is_empty() {
+        return Vec::new();
+    }
+    if series.len() <= max_points {
+        return series.iter().map(|&v| round_1(v)).collect();
+    }
+    let last = series.len() - 1;
+    (0..max_points)
+        .map(|i| round_1(series[i * last / (max_points - 1)]))
+        .collect()
+}
+
+fn round_1(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}

--- a/src/domain/llm_tools/w_prime_balance/tests.rs
+++ b/src/domain/llm_tools/w_prime_balance/tests.rs
@@ -124,6 +124,13 @@ fn extract_power_samples_negative_to_none() {
 }
 
 #[test]
+fn extract_power_samples_large_integer_to_none() {
+    let workout = make_workout(vec![i32::MAX as i64 + 1, 250]);
+    let samples = extract_power_samples(&workout).unwrap();
+    assert_eq!(samples, vec![None, Some(250)]);
+}
+
+#[test]
 fn extract_power_samples_no_watts_stream() {
     let workout = make_workout_no_streams();
     let result = extract_power_samples(&workout);
@@ -399,6 +406,20 @@ fn parse_args_invalid_json() {
     let result = parse_args("not json");
     assert!(result.is_err());
     assert!(result.err().unwrap().contains("invalid arguments"));
+}
+
+#[test]
+fn parse_args_rejects_non_positive_cp_watts() {
+    let result = parse_args(r#"{"date":"2026-05-05","cp_watts":0}"#);
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("invalid cp_watts"));
+}
+
+#[test]
+fn parse_args_rejects_non_positive_w_prime_joules() {
+    let result = parse_args(r#"{"date":"2026-05-05","w_prime_joules":-1}"#);
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("invalid w_prime_joules"));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/domain/llm_tools/w_prime_balance/tests.rs
+++ b/src/domain/llm_tools/w_prime_balance/tests.rs
@@ -1,0 +1,638 @@
+use super::*;
+use crate::domain::{
+    completed_workouts::{
+        CompletedWorkout, CompletedWorkoutDetails, CompletedWorkoutMetrics, CompletedWorkoutSeries,
+        CompletedWorkoutStream,
+    },
+    training_context::TrainingContext,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_details() -> CompletedWorkoutDetails {
+    CompletedWorkoutDetails {
+        intervals: Vec::new(),
+        interval_groups: Vec::new(),
+        streams: Vec::new(),
+        interval_summary: Vec::new(),
+        skyline_chart: Vec::new(),
+        power_zone_times: Vec::new(),
+        heart_rate_zone_times: Vec::new(),
+        pace_zone_times: Vec::new(),
+        gap_zone_times: Vec::new(),
+    }
+}
+
+fn details_with_stream(stream: CompletedWorkoutStream) -> CompletedWorkoutDetails {
+    CompletedWorkoutDetails {
+        streams: vec![stream],
+        ..empty_details()
+    }
+}
+
+fn watts_stream(values: Vec<i64>) -> CompletedWorkoutStream {
+    CompletedWorkoutStream {
+        stream_type: "watts".to_string(),
+        name: None,
+        primary_series: Some(CompletedWorkoutSeries::Integers(values)),
+        secondary_series: None,
+        value_type_is_array: false,
+        custom: false,
+        all_null: false,
+    }
+}
+
+fn make_workout(watts: Vec<i64>) -> CompletedWorkout {
+    CompletedWorkout::new(
+        "test-workout".to_string(),
+        "user-1".to_string(),
+        "2026-01-01T12:00:00".to_string(),
+        None,
+        None,
+        Some("Test Ride".to_string()),
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        CompletedWorkoutMetrics::default(),
+        details_with_stream(watts_stream(watts)),
+        None,
+    )
+}
+
+fn make_workout_no_streams() -> CompletedWorkout {
+    CompletedWorkout::new(
+        "test-workout".to_string(),
+        "user-1".to_string(),
+        "2026-01-01T12:00:00".to_string(),
+        None,
+        None,
+        Some("No Streams".to_string()),
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        CompletedWorkoutMetrics::default(),
+        empty_details(),
+        None,
+    )
+}
+
+fn test_context(ftp: Option<i32>, weight_kg: Option<f64>) -> ToolExecutionContext {
+    let mut tc = TrainingContext::default();
+    tc.history.ftp_current = ftp;
+    tc.profile.weight_kg = weight_kg;
+    ToolExecutionContext {
+        user_id: "test-user".to_string(),
+        training_context: tc,
+        today: "2026-05-05".to_string(),
+        data_port: None,
+    }
+}
+
+fn args(date: &str) -> WPrimeBalanceArgs {
+    WPrimeBalanceArgs {
+        date: date.to_string(),
+        workout_id: None,
+        cp_watts: None,
+        w_prime_joules: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// extract_power_samples
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_power_samples_integers() {
+    let workout = make_workout(vec![100, 200, 300]);
+    let samples = extract_power_samples(&workout).unwrap();
+    assert_eq!(samples, vec![Some(100), Some(200), Some(300)]);
+}
+
+#[test]
+fn extract_power_samples_negative_to_none() {
+    let workout = make_workout(vec![-1, 0, 100]);
+    let samples = extract_power_samples(&workout).unwrap();
+    assert_eq!(samples, vec![None, Some(0), Some(100)]);
+}
+
+#[test]
+fn extract_power_samples_no_watts_stream() {
+    let workout = make_workout_no_streams();
+    let result = extract_power_samples(&workout);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("no watts"));
+}
+
+// ---------------------------------------------------------------------------
+// estimate_cp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn estimate_cp_user_provided() {
+    let ctx = test_context(Some(300), None);
+    let mut a = args("2026-01-01");
+    a.cp_watts = Some(280);
+    let (cp, source) = estimate_cp(&a, &ctx);
+    assert_eq!(cp, 280);
+    assert_eq!(source, "user_provided");
+}
+
+#[test]
+fn estimate_cp_from_ftp() {
+    let ctx = test_context(Some(300), None);
+    let a = args("2026-01-01");
+    let (cp, source) = estimate_cp(&a, &ctx);
+    assert_eq!(cp, 270); // floor(300 * 0.90)
+    assert_eq!(source, "estimated_from_ftp");
+}
+
+#[test]
+fn estimate_cp_default_when_no_ftp() {
+    let ctx = test_context(None, None);
+    let a = args("2026-01-01");
+    let (cp, source) = estimate_cp(&a, &ctx);
+    assert_eq!(cp, DEFAULT_CP_WATTS);
+    assert_eq!(source, "default");
+}
+
+#[test]
+fn estimate_cp_default_when_ftp_zero() {
+    let ctx = test_context(Some(0), None);
+    let a = args("2026-01-01");
+    let (cp, source) = estimate_cp(&a, &ctx);
+    assert_eq!(cp, DEFAULT_CP_WATTS);
+    assert_eq!(source, "default");
+}
+
+// ---------------------------------------------------------------------------
+// estimate_w_prime
+// ---------------------------------------------------------------------------
+
+#[test]
+fn estimate_w_prime_user_provided() {
+    let ctx = test_context(None, None);
+    let mut a = args("2026-01-01");
+    a.w_prime_joules = Some(22000);
+    let (wp, source) = estimate_w_prime(&a, &ctx);
+    assert_eq!(wp, 22000);
+    assert_eq!(source, "user_provided");
+}
+
+#[test]
+fn estimate_w_prime_from_weight() {
+    let ctx = test_context(None, Some(70.0));
+    let a = args("2026-01-01");
+    let (wp, source) = estimate_w_prime(&a, &ctx);
+    assert_eq!(wp, 19600); // floor(70.0 * 280.0)
+    assert_eq!(source, "estimated_from_weight");
+}
+
+#[test]
+fn estimate_w_prime_default_when_no_weight() {
+    let ctx = test_context(None, None);
+    let a = args("2026-01-01");
+    let (wp, source) = estimate_w_prime(&a, &ctx);
+    assert_eq!(wp, DEFAULT_W_PRIME_JOULES);
+    assert_eq!(source, "default");
+}
+
+#[test]
+fn estimate_w_prime_default_when_weight_zero() {
+    let ctx = test_context(None, Some(0.0));
+    let a = args("2026-01-01");
+    let (wp, source) = estimate_w_prime(&a, &ctx);
+    assert_eq!(wp, DEFAULT_W_PRIME_JOULES);
+    assert_eq!(source, "default");
+}
+
+// ---------------------------------------------------------------------------
+// compute_w_prime_balance — algorithm correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn balance_stays_full_when_power_below_cp() {
+    // 5 seconds at 200W, CP=250 -> no expenditure, already fully charged
+    let samples: Vec<Option<i32>> = vec![Some(200); 5];
+    let (series, start, end, min, deficit, a90, s50, s10, b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!((start - 20_000.0).abs() < 0.1);
+    assert!((end - 20_000.0).abs() < 0.1);
+    assert!((min - 20_000.0).abs() < 0.1);
+    assert!((deficit - 0.0).abs() < 0.1);
+    assert_eq!(a90, 5);
+    assert_eq!(s50, 0);
+    assert_eq!(s10, 0);
+    assert_eq!(b10, 0);
+    assert!(!depleted);
+    assert_eq!(series.len(), 5);
+}
+
+#[test]
+fn balance_depletes_linearly_above_cp() {
+    // 10 seconds at 300W, CP=250 -> expenditure = 50 J/s
+    let samples: Vec<Option<i32>> = vec![Some(300); 10];
+    let (series, _start, end, min, deficit, a90, s50, s10, b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    let expected_end = 20_000.0 - 10.0 * 50.0;
+    assert!((end - expected_end).abs() < 0.1);
+    assert!((min - expected_end).abs() < 0.1);
+    assert!((deficit - 500.0).abs() < 0.1);
+    assert!(!depleted);
+    assert_eq!(a90, 10);
+    assert_eq!(s50, 0);
+    assert_eq!(s10, 0);
+    assert_eq!(b10, 0);
+    assert_eq!(series.len(), 10);
+}
+
+#[test]
+fn balance_never_goes_below_zero() {
+    // 500 seconds at 300W, CP=250, W'=20000 -> would be -5000 without clamp
+    let samples: Vec<Option<i32>> = vec![Some(300); 500];
+    let (series, _start, end, min, deficit, _a90, _s50, _s10, _b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!((end - 0.0).abs() < 0.1);
+    assert!((min - 0.0).abs() < 0.1);
+    assert!((deficit - 20_000.0).abs() < 0.1);
+    assert!(depleted);
+    assert!(series.iter().all(|&v| v >= -0.01));
+}
+
+#[test]
+fn balance_recovers_exponentially_below_cp() {
+    // 100s at 300W (deplete), then 100s at 200W (recover), CP=250, W'=20000
+    let mut samples = vec![Some(300); 100];
+    samples.extend(vec![Some(200); 100]);
+
+    let (series, _start, end, min, deficit, _a90, _s50, _s10, _b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    let expected_after_depletion = 15_000.0;
+    let expected_end = 20_000.0 - 5_000.0 * (-0.25f64).exp();
+
+    assert!(!depleted);
+    assert!((end - expected_end).abs() < 1.0);
+    assert!((min - expected_after_depletion).abs() < 1.0);
+    assert!(end > min + 1000.0);
+    assert!((deficit - 5_000.0).abs() < 1.0);
+    assert_eq!(series.len(), 200);
+}
+
+#[test]
+fn balance_does_not_recover_beyond_w_prime() {
+    // 50s at 300W, then 1000s at 0W (coasting), CP=250, W'=20000
+    let mut samples = vec![Some(300); 50];
+    samples.extend(vec![Some(0); 1000]);
+
+    let (series, _start, end, _min, _deficit, _a90, _s50, _s10, _b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!(!depleted);
+    assert!((end - 20_000.0).abs() < 1.0);
+    for &v in &series {
+        assert!(v <= 20_000.0 + 0.01, "balance exceeded W': {v}");
+    }
+}
+
+#[test]
+fn null_samples_do_not_change_balance() {
+    let samples = vec![Some(300), Some(300), None, Some(300)];
+    let (series, _start, _end, _min, _deficit, _a90, _s50, _s10, _b10, _depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert_eq!(series.len(), 4);
+    assert!((series[0] - 19_950.0).abs() < 0.1);
+    assert!((series[1] - 19_900.0).abs() < 0.1);
+    assert!((series[2] - 19_900.0).abs() < 0.1);
+    assert!((series[3] - 19_850.0).abs() < 0.1);
+}
+
+#[test]
+fn empty_samples_returns_empty_series() {
+    let samples: Vec<Option<i32>> = Vec::new();
+    let (series, start, end, min, deficit, a90, s50, s10, b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!(series.is_empty());
+    assert!((start - 20_000.0).abs() < 0.1);
+    assert!((end - 20_000.0).abs() < 0.1);
+    assert!((min - 20_000.0).abs() < 0.1);
+    assert!((deficit - 0.0).abs() < 0.1);
+    assert_eq!(a90, 0);
+    assert_eq!(s50, 0);
+    assert_eq!(s10, 0);
+    assert_eq!(b10, 0);
+    assert!(!depleted);
+}
+
+#[test]
+fn time_buckets_are_mutually_exclusive_and_exhaustive() {
+    let samples: Vec<Option<i32>> = vec![Some(300); 500];
+    let (_series, _start, _end, _min, _deficit, a90, s50, s10, b10, depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!(depleted);
+    assert_eq!(a90 + s50 + s10 + b10, 500);
+    assert!(a90 > 0);
+    assert!(s50 > 0);
+    assert!(s10 > 0);
+    assert!(b10 > 0);
+}
+
+#[test]
+fn constant_power_exactly_at_cp_no_change() {
+    let samples: Vec<Option<i32>> = vec![Some(250); 10];
+    let (series, _start, end, _min, _deficit, _a90, _s50, _s10, _b10, _depleted) =
+        compute_w_prime_balance(&samples, 250, 20_000);
+
+    assert!((end - 20_000.0).abs() < 0.1);
+    for &v in &series {
+        assert!((v - 20_000.0).abs() < 0.1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// parse_args
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_args_valid_date() {
+    let result = parse_args(r#"{"date":"2026-05-05"}"#).expect("valid args");
+    assert_eq!(result.date, "2026-05-05");
+    assert!(result.workout_id.is_none());
+    assert!(result.cp_watts.is_none());
+    assert!(result.w_prime_joules.is_none());
+}
+
+#[test]
+fn parse_args_with_all_fields() {
+    let result = parse_args(
+        r#"{"date":"2026-05-05","workout_id":"abc","cp_watts":270,"w_prime_joules":22000}"#,
+    )
+    .expect("valid args");
+    assert_eq!(result.date, "2026-05-05");
+    assert_eq!(result.workout_id, Some("abc".to_string()));
+    assert_eq!(result.cp_watts, Some(270));
+    assert_eq!(result.w_prime_joules, Some(22000));
+}
+
+#[test]
+fn parse_args_invalid_date() {
+    let result = parse_args(r#"{"date":"not-a-date"}"#);
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("invalid date"));
+}
+
+#[test]
+fn parse_args_invalid_json() {
+    let result = parse_args("not json");
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("invalid arguments"));
+}
+
+// ---------------------------------------------------------------------------
+// preview_arguments
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preview_shows_date_only() {
+    let tool = WPrimeBalance;
+    let preview = tool.preview_arguments(r#"{"date":"2026-05-05"}"#);
+    assert_eq!(preview, Some("date 2026-05-05".to_string()));
+}
+
+#[test]
+fn preview_shows_workout_id() {
+    let tool = WPrimeBalance;
+    let preview = tool.preview_arguments(r#"{"date":"2026-05-05","workout_id":"abc123"}"#);
+    assert_eq!(preview, Some("date 2026-05-05 workout abc123".to_string()));
+}
+
+#[test]
+fn preview_shows_cp_and_w_prime() {
+    let tool = WPrimeBalance;
+    let preview =
+        tool.preview_arguments(r#"{"date":"2026-05-05","cp_watts":270,"w_prime_joules":22000}"#);
+    assert_eq!(
+        preview,
+        Some("date 2026-05-05 CP=270W W'=22000J".to_string())
+    );
+}
+
+#[test]
+fn preview_none_for_invalid_date() {
+    let tool = WPrimeBalance;
+    let preview = tool.preview_arguments(r#"{"date":"bad"}"#);
+    assert_eq!(preview, None);
+}
+
+// ---------------------------------------------------------------------------
+// select_workout
+// ---------------------------------------------------------------------------
+
+fn sample_workout(id: &str, date: &str) -> CompletedWorkout {
+    CompletedWorkout::new(
+        id.to_string(),
+        "user-1".to_string(),
+        format!("{date}T12:00:00"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        CompletedWorkoutMetrics::default(),
+        empty_details(),
+        None,
+    )
+}
+
+#[test]
+fn select_workout_single_match() {
+    let workouts = vec![sample_workout("w1", "2026-01-01")];
+    let a = WPrimeBalanceArgs {
+        date: "2026-01-01".to_string(),
+        workout_id: None,
+        cp_watts: None,
+        w_prime_joules: None,
+    };
+    let result = select_workout(&a, workouts).unwrap();
+    assert_eq!(result.completed_workout_id, "w1");
+}
+
+#[test]
+fn select_workout_by_id() {
+    let workouts = vec![
+        sample_workout("w1", "2026-01-01"),
+        sample_workout("w2", "2026-01-01"),
+    ];
+    let a = WPrimeBalanceArgs {
+        date: "2026-01-01".to_string(),
+        workout_id: Some("w2".to_string()),
+        cp_watts: None,
+        w_prime_joules: None,
+    };
+    let result = select_workout(&a, workouts).unwrap();
+    assert_eq!(result.completed_workout_id, "w2");
+}
+
+#[test]
+fn select_workout_not_found_by_id() {
+    let workouts = vec![sample_workout("w1", "2026-01-01")];
+    let a = WPrimeBalanceArgs {
+        date: "2026-01-01".to_string(),
+        workout_id: Some("nonexistent".to_string()),
+        cp_watts: None,
+        w_prime_joules: None,
+    };
+    let result = select_workout(&a, workouts);
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("not found"));
+}
+
+#[test]
+fn select_workout_empty_list() {
+    let a = WPrimeBalanceArgs {
+        date: "2026-01-01".to_string(),
+        workout_id: None,
+        cp_watts: None,
+        w_prime_joules: None,
+    };
+    let result = select_workout(&a, Vec::new());
+    assert!(result.is_err());
+    assert!(result.err().unwrap().contains("no completed workouts"));
+}
+
+#[test]
+fn select_workout_multiple_without_id() {
+    let workouts = vec![
+        sample_workout("w1", "2026-01-01"),
+        sample_workout("w2", "2026-01-01"),
+    ];
+    let a = WPrimeBalanceArgs {
+        date: "2026-01-01".to_string(),
+        workout_id: None,
+        cp_watts: None,
+        w_prime_joules: None,
+    };
+    let result = select_workout(&a, workouts);
+    assert!(result.is_err());
+    assert!(result
+        .err()
+        .unwrap()
+        .contains("multiple completed workouts"));
+}
+
+// ---------------------------------------------------------------------------
+// LlmTool trait — is_available, name, prompt_guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_name_is_get_w_prime_balance() {
+    assert_eq!(WPrimeBalance.name(), "get_w_prime_balance");
+}
+
+#[test]
+fn tool_available_when_data_port_present() {
+    let mut ctx = test_context(None, None);
+    ctx.data_port = Some(std::sync::Arc::new(NoopDataPort));
+    assert!(WPrimeBalance.is_available(&ctx));
+}
+
+#[test]
+fn tool_unavailable_when_data_port_absent() {
+    let ctx = test_context(None, None);
+    assert!(!WPrimeBalance.is_available(&ctx));
+}
+
+#[test]
+fn prompt_guidance_includes_post_race() {
+    let guidance = WPrimeBalance.prompt_guidance().unwrap();
+    assert!(guidance.contains("post-race analysis"));
+    assert!(guidance.contains("anaerobic capacity depletion"));
+    assert!(guidance.contains("pacing strategy"));
+}
+
+#[test]
+fn tool_definition_has_correct_schema() {
+    let def = WPrimeBalance.definition();
+    assert_eq!(def.name, "get_w_prime_balance");
+    assert!(def.description.contains("W-prime"));
+    assert!(def.description.contains("Skiba"));
+    let schema: serde_json::Value = serde_json::from_str(&def.input_schema_json).unwrap();
+    assert_eq!(schema["type"], "object");
+    let required = schema["required"].as_array().unwrap();
+    assert_eq!(required.len(), 1);
+    assert_eq!(required[0], "date");
+}
+
+// ---------------------------------------------------------------------------
+// NoopDataPort for availability tests
+// ---------------------------------------------------------------------------
+
+struct NoopDataPort;
+
+impl crate::domain::llm_tools::GetSelectedWorkoutDataPort for NoopDataPort {
+    fn list_completed_by_date_range(
+        &self,
+        _user_id: &str,
+        _oldest: &str,
+        _newest: &str,
+    ) -> crate::domain::completed_workouts::BoxFuture<
+        Result<Vec<CompletedWorkout>, crate::domain::completed_workouts::CompletedWorkoutError>,
+    > {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
+    fn list_planned_by_date_range(
+        &self,
+        _user_id: &str,
+        _oldest: &str,
+        _newest: &str,
+    ) -> crate::domain::planned_workouts::BoxFuture<
+        Result<
+            Vec<crate::domain::planned_workouts::PlannedWorkout>,
+            crate::domain::planned_workouts::PlannedWorkoutError,
+        >,
+    > {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
+    fn list_races_by_date_range(
+        &self,
+        _user_id: &str,
+        _oldest: &str,
+        _newest: &str,
+    ) -> crate::domain::races::BoxFuture<
+        Result<Vec<crate::domain::races::Race>, crate::domain::races::RaceError>,
+    > {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
+    fn find_summaries_by_workout_ids(
+        &self,
+        _user_id: &str,
+        _workout_ids: Vec<String>,
+    ) -> crate::domain::workout_summary::BoxFuture<
+        Result<
+            Vec<crate::domain::workout_summary::WorkoutSummary>,
+            crate::domain::workout_summary::WorkoutSummaryError,
+        >,
+    > {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+}


### PR DESCRIPTION
Estimates CP from FTP (90%) and W' from body weight (280 J/kg) when not explicitly provided. Computes per-second W' balance using the Skiba differential model: linear expenditure above CP, exponential recovery below CP. Returns sampled time series (max 256 points) and summary statistics including time-at-depletion buckets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added W′ (W-prime) balance tool: computes per-sample balance series, summary metrics, depletion stats and time-in-threshold breakdowns for completed workouts.
  * Supports user-provided CP/W′ or derives values from training context when not provided.
* **Tests**
  * Comprehensive unit tests covering data extraction, CP/W′ estimation, balance computation, argument parsing, selection logic and tool availability/guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->