### PR TITLE
Fix DeepSeek reasoning_content lost between conversation turns

### DIFF
--- a/src/adapters/mongo/coach_conversation_messages.rs
+++ b/src/adapters/mongo/coach_conversation_messages.rs
@@ -29,6 +29,8 @@ struct CoachConversationMessageDocument {
     content: String,
     #[serde(default)]
     tool_call: Option<crate::domain::workout_summary::PublicToolCall>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
     created_at_epoch_seconds: i64,
     #[serde(default)]
     created_at: Option<DateTime>,
@@ -174,6 +176,7 @@ fn map_domain_to_document(message: &CoachConversationMessage) -> CoachConversati
         role: role_as_str(&message.role).to_string(),
         content: message.content.clone(),
         tool_call: message.tool_call.clone(),
+        reasoning_content: message.reasoning_content.clone(),
         created_at_epoch_seconds: message.created_at_epoch_seconds,
         created_at: optional_epoch_seconds_to_bson_datetime(
             Some(message.created_at_epoch_seconds),
@@ -193,6 +196,7 @@ fn map_document_to_domain(
         role: map_role(document.role)?,
         content: document.content,
         tool_call: document.tool_call,
+        reasoning_content: document.reasoning_content,
         created_at_epoch_seconds: resolve_required_epoch_seconds(
             document.created_at,
             Some(document.created_at_epoch_seconds),

--- a/src/domain/coach_conversation/model.rs
+++ b/src/domain/coach_conversation/model.rs
@@ -106,6 +106,8 @@ pub struct CoachConversationMessage {
     pub role: CoachConversationMessageRole,
     pub content: String,
     pub tool_call: Option<PublicToolCall>,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
     pub created_at_epoch_seconds: i64,
 }
 

--- a/src/domain/coach_conversation/service/internals/messaging.rs
+++ b/src/domain/coach_conversation/service/internals/messaging.rs
@@ -26,6 +26,7 @@ where
         content: String,
         message_id: Option<String>,
         tool_call: Option<PublicToolCall>,
+        reasoning_content: Option<String>,
     ) -> Result<CoachConversationMessage, CoachConversationError> {
         if conversation.status == CoachConversationStatus::Archived {
             return Err(CoachConversationError::Archived);
@@ -46,6 +47,7 @@ where
                 role,
                 content,
                 tool_call,
+                reasoning_content,
                 created_at_epoch_seconds: self.clock.now_epoch_seconds(),
             })
             .await?;
@@ -72,6 +74,7 @@ where
             format!("Tool call: {}", tool_call.name),
             Some(tool_call.id.clone()),
             Some(tool_call),
+            None,
         )
         .await
     }

--- a/src/domain/coach_conversation/service/internals/recovery.rs
+++ b/src/domain/coach_conversation/service/internals/recovery.rs
@@ -113,6 +113,7 @@ where
                 .await?;
             return Err(CoachConversationError::Llm(error));
         };
+        let reasoning_content = recovered_reasoning_content(operation);
 
         let coach_message_id = operation.reply_message_id.clone().ok_or_else(|| {
             CoachConversationError::Repository(
@@ -126,7 +127,7 @@ where
                 content,
                 Some(coach_message_id),
                 None,
-                None,
+                reasoning_content,
             )
             .await?;
         let completed = operation.mark_completed_from_existing_message(
@@ -180,4 +181,13 @@ where
 
 fn recovered_assistant_reply_text(operation: &CoachConversationReplyOperation) -> Option<String> {
     last_nonempty_assistant_content(&operation.provider_transcript)
+}
+
+fn recovered_reasoning_content(operation: &CoachConversationReplyOperation) -> Option<String> {
+    operation
+        .provider_transcript
+        .iter()
+        .rev()
+        .find(|m| m.role == LlmMessageRole::Assistant)
+        .and_then(|m| m.reasoning_content.clone())
 }

--- a/src/domain/coach_conversation/service/internals/recovery.rs
+++ b/src/domain/coach_conversation/service/internals/recovery.rs
@@ -126,6 +126,7 @@ where
                 content,
                 Some(coach_message_id),
                 None,
+                None,
             )
             .await?;
         let completed = operation.mark_completed_from_existing_message(

--- a/src/domain/coach_conversation/service/transcript.rs
+++ b/src/domain/coach_conversation/service/transcript.rs
@@ -69,7 +69,7 @@ pub(super) fn build_calendar_conversation(
                 content: message.content.clone(),
                 tool_calls: Vec::new(),
                 tool_call_id: None,
-                reasoning_content: None,
+                reasoning_content: message.reasoning_content.clone(),
             }),
             CoachConversationMessageRole::Tool | CoachConversationMessageRole::System => None,
         })

--- a/src/domain/coach_conversation/service/use_cases.rs
+++ b/src/domain/coach_conversation/service/use_cases.rs
@@ -255,6 +255,7 @@ where
                     content,
                     None,
                     None,
+                    None,
                 )
                 .await?;
             let messages = service.list_messages(&user_id, &conversation_id).await?;
@@ -330,6 +331,7 @@ where
                     coach_content,
                     Some(coach_message_id),
                     None,
+                    llm_output.response.message.reasoning_content.clone(),
                 )
                 .await?;
             let completed_reply =

--- a/tests/calendar_coach_rest.rs
+++ b/tests/calendar_coach_rest.rs
@@ -328,6 +328,7 @@ mod shared {
                     role: CoachConversationMessageRole::User,
                     content,
                     tool_call: None,
+                    reasoning_content: None,
                     created_at_epoch_seconds: 1_700_000_000,
                 };
                 let coach_message = CoachConversationMessage {
@@ -337,6 +338,7 @@ mod shared {
                     role: CoachConversationMessageRole::Coach,
                     content: format!("Coach reply to: {}", user_message.content),
                     tool_call: None,
+                    reasoning_content: None,
                     created_at_epoch_seconds: 1_700_000_001,
                 };
                 stored.messages.push(user_message.clone());
@@ -392,6 +394,7 @@ mod shared {
                     role: CoachConversationMessageRole::User,
                     content,
                     tool_call: None,
+                    reasoning_content: None,
                     created_at_epoch_seconds: 1_700_000_000,
                 };
                 stored.messages.push(user_message.clone());
@@ -462,6 +465,7 @@ mod shared {
                         role: CoachConversationMessageRole::Tool,
                         content: format!("Tool call: {}", tool_call.name),
                         tool_call: Some(tool_call),
+                        reasoning_content: None,
                         created_at_epoch_seconds: 1_700_000_001,
                     });
                 }
@@ -473,6 +477,7 @@ mod shared {
                     role: CoachConversationMessageRole::Coach,
                     content: format!("Coach reply to: {}", user_message.content),
                     tool_call: None,
+                    reasoning_content: None,
                     created_at_epoch_seconds: 1_700_000_001,
                 };
                 stored.messages.push(coach_message.clone());

--- a/tests/calendar_coach_service.rs
+++ b/tests/calendar_coach_service.rs
@@ -822,6 +822,7 @@ async fn calendar_coach_reuses_completed_operation_without_duplicate_llm_call() 
         role: CoachConversationMessageRole::Coach,
         content: "Recovered calendar reply".to_string(),
         tool_call: None,
+        reasoning_content: None,
         created_at_epoch_seconds: 1_700_000_001,
     };
     messages
@@ -969,6 +970,7 @@ async fn calendar_coach_follow_up_replays_last_hidden_assistant_tool_calls() {
                 role: CoachConversationMessageRole::User,
                 content: "Need recovery advice".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 1,
             },
             CoachConversationMessage {
@@ -983,6 +985,7 @@ async fn calendar_coach_follow_up_replays_last_hidden_assistant_tool_calls() {
                     arguments_json: r#"{\"week\":\"2026-W18\"}"#.to_string(),
                     arguments_preview: None,
                 }),
+                reasoning_content: None,
                 created_at_epoch_seconds: 2,
             },
             CoachConversationMessage {
@@ -992,6 +995,7 @@ async fn calendar_coach_follow_up_replays_last_hidden_assistant_tool_calls() {
                 role: CoachConversationMessageRole::Coach,
                 content: "Coach reply".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 3,
             },
         ])),
@@ -1091,6 +1095,7 @@ async fn calendar_coach_follow_up_replays_multiple_hidden_assistant_turns_with_t
                 role: CoachConversationMessageRole::User,
                 content: "First question".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 1,
             },
             CoachConversationMessage {
@@ -1100,6 +1105,7 @@ async fn calendar_coach_follow_up_replays_multiple_hidden_assistant_turns_with_t
                 role: CoachConversationMessageRole::Coach,
                 content: "First answer".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 2,
             },
             CoachConversationMessage {
@@ -1109,6 +1115,7 @@ async fn calendar_coach_follow_up_replays_multiple_hidden_assistant_turns_with_t
                 role: CoachConversationMessageRole::User,
                 content: "Second question".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 3,
             },
             CoachConversationMessage {
@@ -1118,6 +1125,7 @@ async fn calendar_coach_follow_up_replays_multiple_hidden_assistant_turns_with_t
                 role: CoachConversationMessageRole::Coach,
                 content: "Second answer".to_string(),
                 tool_call: None,
+                reasoning_content: None,
                 created_at_epoch_seconds: 4,
             },
         ])),


### PR DESCRIPTION
CoachConversationMessage did not store reasoning_content, so when rebuilding the LLM conversation for a subsequent user message, all previous DeepSeek assistant messages lost their reasoning_content. DeepSeek thinking models require this field to be echoed back or the API rejects the request with: 'The reasoning_content in the thinking mode must be passed back to the API.'

Changes:
- Add reasoning_content field to CoachConversationMessage domain model
- Add reasoning_content to CoachConversationMessageDocument (Mongo)
- Update append_message to accept and store reasoning_content
- Pass reasoning_content from LLM output when creating coach messages
- Use reasoning_content from stored messages in build_calendar_conversation