### PR TITLE
refactor: share scheduler checkpoint parsing helpers

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-13 | Copilot | PR #227 parse_required_json_value success-path coverage
+
+- Problem: the extracted `parse_required_json_value(...)` helper had regression coverage for missing and invalid input, but no success-path test proving a valid required checkpoint parses correctly. Because the helper now sits under multiple scheduler-backed flows, that left a small but real coverage gap in the shared wrapper itself.
+- Fix: added `parse_required_json_value_parses_value_when_present` in `src/domain/task_scheduler/handler.rs` to assert the helper returns the decoded checkpoint for valid JSON input.
+- Prevention: when extracting a shared parse helper that has both optional and required wrappers, cover all three branches in the helper's own tests: missing, invalid, and valid-success input. Do not rely on sibling optional-helper tests to prove the required-success path indirectly.
+
 ### 2026-05-13 | user | issue 226 shell-quoted GitHub REST body corruption and PR creation fallback
 
 - Problem: the first direct REST call that created issue `#226` embedded Markdown with backticks inside a shell-quoted payload, so zsh performed command substitution and stripped inline code and file paths from the posted body. A later `gh pr create` attempt also assumed CLI auth existed and then hit the known host pressure path by triggering extra verification before failing on missing auth.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-13 | user | issue 226 shell-quoted GitHub REST body corruption and PR creation fallback
+
+- Problem: the first direct REST call that created issue `#226` embedded Markdown with backticks inside a shell-quoted payload, so zsh performed command substitution and stripped inline code and file paths from the posted body. A later `gh pr create` attempt also assumed CLI auth existed and then hit the known host pressure path by triggering extra verification before failing on missing auth.
+- Fix: repaired the issue body with a second REST API call that built the JSON safely via `jq --arg`, preserving all Markdown and inline code. Recorded the shell-quoting/auth lesson and kept the branch flow on direct git plus REST API instead of depending on unauthenticated `gh` commands.
+- Prevention: when posting Markdown to GitHub from shell, never place backticks inside ordinary shell string literals. Encode the body with `jq`, a file, or another non-shell-expanding path first. Before using `gh pr create`, check `gh auth status` explicitly and prefer REST API fallbacks when auth or host stability is uncertain.
+
 ### 2026-05-12 | Copilot | PR #222 Mongo round-trip test correction-phase state confusion
 
 - Problem: the new Mongo round-trip test for completed tool-loop state reused the same `LlmToolLoopState` value for initial and correction phases, even though the raw plan/correction texts differed. That made assertions confusing and weakened coverage — a mapper bug that accidentally copies initial state into `correction_tool_loop_state` would not be caught.

--- a/src/domain/athlete_summary/service/scheduler.rs
+++ b/src/domain/athlete_summary/service/scheduler.rs
@@ -8,9 +8,10 @@ use crate::domain::{
         deserialize_llm_error, serialize_llm_error, SerializedLlmError, LLM_REQUEST_TIMEOUT_SECONDS,
     },
     task_scheduler::{
-        build_scheduled_task, scheduled_task_handler, BuildScheduledTaskError,
-        NewScheduledTaskInput, ResultTaskHandler, RetryStrategy, ScheduledTask,
-        ScheduledTaskExecutor, SharedTaskHandler, TaskRepository, TaskRunOutcome,
+        build_scheduled_task, parse_failed_or_error_message, parse_optional_json_value,
+        parse_required_json_value, scheduled_task_handler, serialize_json_value,
+        BuildScheduledTaskError, NewScheduledTaskInput, ResultTaskHandler, RetryStrategy,
+        ScheduledTask, ScheduledTaskExecutor, SharedTaskHandler, TaskRepository, TaskRunOutcome,
         TaskSchedulerError, TaskSchedulerService, TaskWorkerRepository,
     },
 };
@@ -98,36 +99,15 @@ fn deserialize_athlete_summary_error(error: SerializedAthleteSummaryError) -> At
     }
 }
 
-fn parse_completed_checkpoint(
-    task: &ScheduledTask,
-) -> Result<Option<CompletedAthleteSummaryTaskCheckpoint>, AthleteSummaryError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value(value).map_err(|error| {
-                AthleteSummaryError::Repository(format!(
-                    "invalid completed athlete summary checkpoint: {error}"
-                ))
-            })
-        })
-        .transpose()
-}
-
 fn parse_failed_checkpoint(
     task: &ScheduledTask,
 ) -> Result<Option<AthleteSummaryError>, AthleteSummaryError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value::<SerializedAthleteSummaryError>(value)
-                .map(deserialize_athlete_summary_error)
-                .map_err(|error| {
-                    AthleteSummaryError::Repository(format!(
-                        "invalid failed athlete summary checkpoint: {error}"
-                    ))
-                })
-        })
-        .transpose()
+    parse_optional_json_value::<SerializedAthleteSummaryError, AthleteSummaryError>(
+        task.checkpoint.clone(),
+        "invalid failed athlete summary checkpoint",
+        AthleteSummaryError::Repository,
+    )
+    .map(|error| error.map(deserialize_athlete_summary_error))
 }
 
 fn build_non_force_dedupe_key(user_id: &str, refresh_window_start_epoch_seconds: i64) -> String {
@@ -139,14 +119,13 @@ fn build_force_dedupe_key(user_id: &str, task_id: &str) -> String {
 }
 
 fn build_completed_checkpoint(user_id: &str) -> Result<serde_json::Value, AthleteSummaryError> {
-    serde_json::to_value(CompletedAthleteSummaryTaskCheckpoint {
-        user_id: user_id.to_string(),
-    })
-    .map_err(|error| {
-        AthleteSummaryError::Repository(format!(
-            "failed to serialize completed athlete summary checkpoint: {error}"
-        ))
-    })
+    serialize_json_value(
+        &CompletedAthleteSummaryTaskCheckpoint {
+            user_id: user_id.to_string(),
+        },
+        "failed to serialize completed athlete summary checkpoint",
+        AthleteSummaryError::Repository,
+    )
 }
 
 struct AthleteSummaryGenerateTaskExecutor<Base> {
@@ -254,24 +233,21 @@ where
     }
 
     fn parse_completed(&self, task: &ScheduledTask) -> Result<Self::Completed, Self::Error> {
-        parse_completed_checkpoint(task)?.ok_or_else(|| {
-            AthleteSummaryError::Repository(
-                "completed athlete summary task missing persisted checkpoint".to_string(),
-            )
-        })
+        parse_required_json_value(
+            task.checkpoint.clone(),
+            "completed athlete summary task missing persisted checkpoint",
+            "invalid completed athlete summary checkpoint",
+            AthleteSummaryError::Repository,
+        )
     }
 
     fn parse_failed(&self, task: &ScheduledTask) -> Result<Self::Error, Self::Error> {
-        Ok(parse_failed_checkpoint(task)?.unwrap_or_else(|| {
-            task.error_message
-                .clone()
-                .map(AthleteSummaryError::Repository)
-                .unwrap_or_else(|| {
-                    AthleteSummaryError::Repository(
-                        "athlete summary task failed without an error message".to_string(),
-                    )
-                })
-        }))
+        Ok(parse_failed_or_error_message(
+            parse_failed_checkpoint(task)?,
+            task.error_message.clone(),
+            "athlete summary task failed without an error message",
+            AthleteSummaryError::Repository,
+        ))
     }
 
     fn finish(&self, _: Self::Completed) -> BoxFuture<Result<Self::Output, Self::Error>> {

--- a/src/domain/coach_conversation/service/scheduler.rs
+++ b/src/domain/coach_conversation/service/scheduler.rs
@@ -9,7 +9,8 @@ use crate::domain::{
         LLM_REQUEST_TIMEOUT_SECONDS,
     },
     task_scheduler::{
-        build_scheduled_task, scheduled_task_handler, BuildScheduledTaskError,
+        build_scheduled_task, parse_failed_or_error_message, parse_optional_json_value,
+        parse_required_json_value, scheduled_task_handler, BuildScheduledTaskError,
         NewScheduledTaskInput, ResultTaskHandler, RetryStrategy, ScheduledTask,
         ScheduledTaskExecutor, SharedTaskHandler, TaskRepository, TaskRunOutcome,
         TaskSchedulerError, TaskSchedulerService, TaskWorkerRepository,
@@ -127,18 +128,12 @@ fn deserialize_coach_conversation_error(
 fn parse_failed_checkpoint(
     task: &ScheduledTask,
 ) -> Result<Option<CoachConversationError>, CoachConversationError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value::<SerializedCoachConversationError>(value)
-                .map(deserialize_coach_conversation_error)
-                .map_err(|error| {
-                    CoachConversationError::Repository(format!(
-                        "invalid failed coach conversation task checkpoint: {error}"
-                    ))
-                })
-        })
-        .transpose()
+    parse_optional_json_value::<SerializedCoachConversationError, CoachConversationError>(
+        task.checkpoint.clone(),
+        "invalid failed coach conversation task checkpoint",
+        CoachConversationError::Repository,
+    )
+    .map(|error| error.map(deserialize_coach_conversation_error))
 }
 
 #[derive(Clone)]
@@ -167,34 +162,21 @@ where
     }
 
     fn parse_completed(&self, task: &ScheduledTask) -> Result<Self::Completed, Self::Error> {
-        task.checkpoint
-            .clone()
-            .ok_or_else(|| {
-                CoachConversationError::Repository(
-                    "completed coach conversation reply task missing persisted checkpoint"
-                        .to_string(),
-                )
-            })
-            .and_then(|value| {
-                serde_json::from_value(value).map_err(|error| {
-                    CoachConversationError::Repository(format!(
-                        "invalid completed coach conversation reply task checkpoint: {error}"
-                    ))
-                })
-            })
+        parse_required_json_value(
+            task.checkpoint.clone(),
+            "completed coach conversation reply task missing persisted checkpoint",
+            "invalid completed coach conversation reply task checkpoint",
+            CoachConversationError::Repository,
+        )
     }
 
     fn parse_failed(&self, task: &ScheduledTask) -> Result<Self::Error, Self::Error> {
-        Ok(parse_failed_checkpoint(task)?.unwrap_or_else(|| {
-            task.error_message
-                .clone()
-                .map(CoachConversationError::Repository)
-                .unwrap_or_else(|| {
-                    CoachConversationError::Repository(
-                        "coach conversation reply task failed without an error message".to_string(),
-                    )
-                })
-        }))
+        Ok(parse_failed_or_error_message(
+            parse_failed_checkpoint(task)?,
+            task.error_message.clone(),
+            "coach conversation reply task failed without an error message",
+            CoachConversationError::Repository,
+        ))
     }
 
     fn finish(&self, completed: Self::Completed) -> BoxFuture<Result<Self::Output, Self::Error>> {
@@ -561,6 +543,65 @@ fn map_build_scheduled_task_error(error: BuildScheduledTaskError) -> CoachConver
 mod tests {
     use super::*;
     use crate::domain::task_scheduler::{RetryStrategy, TaskStatus};
+
+    #[test]
+    fn parse_failed_returns_repository_error_message_when_checkpoint_missing() {
+        let task = ScheduledTask {
+            id: "task-1".to_string(),
+            user_id: "user-1".to_string(),
+            task_type: COACH_CONVERSATION_REPLY_TASK_TYPE.to_string(),
+            status: TaskStatus::Failed,
+            payload: serde_json::json!({}),
+            checkpoint: None,
+            retry_strategy: RetryStrategy::Never,
+            dedupe_key: "dedupe-1".to_string(),
+            error_message: Some("raw failure".to_string()),
+            attempt_count: 1,
+            next_attempt_at_epoch_seconds: 0,
+            claimed_by: None,
+            lease_expires_at_epoch_seconds: None,
+            last_heartbeat_at_epoch_seconds: None,
+            execution_timeout_seconds: 1,
+            timed_out_at_epoch_seconds: None,
+            leader_only: false,
+            created_at_epoch_seconds: 0,
+            updated_at_epoch_seconds: 0,
+            started_at_epoch_seconds: None,
+            finished_at_epoch_seconds: Some(0),
+        };
+
+        let parsed = parse_failed_or_error_message(
+            parse_failed_checkpoint(&task).expect("missing checkpoint should still parse"),
+            task.error_message.clone(),
+            "coach conversation reply task failed without an error message",
+            CoachConversationError::Repository,
+        );
+
+        assert_eq!(
+            parsed,
+            CoachConversationError::Repository("raw failure".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_completed_requires_valid_checkpoint_json() {
+        let error = parse_required_json_value::<
+            CompletedCoachConversationReplyTaskCheckpoint,
+            CoachConversationError,
+        >(
+            Some(serde_json::json!({ "coach_message": "invalid" })),
+            "completed coach conversation reply task missing persisted checkpoint",
+            "invalid completed coach conversation reply task checkpoint",
+            CoachConversationError::Repository,
+        )
+        .expect_err("invalid checkpoint should fail");
+
+        assert!(matches!(
+            error,
+            CoachConversationError::Repository(message)
+                if message.starts_with("invalid completed coach conversation reply task checkpoint: ")
+        ));
+    }
 
     #[test]
     fn parse_failed_restores_serialized_llm_error_from_task_checkpoint() {

--- a/src/domain/task_scheduler/handler.rs
+++ b/src/domain/task_scheduler/handler.rs
@@ -512,6 +512,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_required_json_value_parses_value_when_present() {
+        let parsed = parse_required_json_value::<StubCheckpoint, StubError>(
+            Some(json!({ "value": "ok" })),
+            "missing checkpoint",
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect("valid required value should parse");
+
+        assert_eq!(
+            parsed,
+            StubCheckpoint {
+                value: "ok".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn parse_required_json_value_maps_invalid_json_error() {
         let error = parse_required_json_value::<StubCheckpoint, StubError>(
             Some(json!({ "value": 5 })),

--- a/src/domain/task_scheduler/handler.rs
+++ b/src/domain/task_scheduler/handler.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
 
 use super::{BoxFuture, NewTask, RetryStrategy, ScheduledTask, TaskHandler, TaskRunOutcome};
 
@@ -80,6 +81,58 @@ where
     .map_err(BuildScheduledTaskError::Scheduler)
 }
 
+pub(crate) fn parse_optional_json_value<T, E>(
+    value: Option<Value>,
+    invalid_message: &str,
+    map_error: fn(String) -> E,
+) -> Result<Option<T>, E>
+where
+    T: DeserializeOwned,
+{
+    value
+        .map(|value| {
+            serde_json::from_value(value)
+                .map_err(|error| map_error(format!("{invalid_message}: {error}")))
+        })
+        .transpose()
+}
+
+pub(crate) fn parse_required_json_value<T, E>(
+    value: Option<Value>,
+    missing_message: &str,
+    invalid_message: &str,
+    map_error: fn(String) -> E,
+) -> Result<T, E>
+where
+    T: DeserializeOwned,
+{
+    parse_optional_json_value(value, invalid_message, map_error)?
+        .ok_or_else(|| map_error(missing_message.to_string()))
+}
+
+pub(crate) fn parse_failed_or_error_message<E>(
+    parsed_error: Option<E>,
+    error_message: Option<String>,
+    missing_error_message: &str,
+    map_error: fn(String) -> E,
+) -> E {
+    parsed_error
+        .or_else(|| error_message.map(map_error))
+        .unwrap_or_else(|| map_error(missing_error_message.to_string()))
+}
+
+pub(crate) fn serialize_json_value<T, E>(
+    value: &T,
+    serialize_error_message: &str,
+    map_error: fn(String) -> E,
+) -> Result<Value, E>
+where
+    T: Serialize,
+{
+    serde_json::to_value(value)
+        .map_err(|error| map_error(format!("{serialize_error_message}: {error}")))
+}
+
 #[derive(Debug)]
 pub(crate) enum BuildScheduledTaskError {
     SerializePayload(serde_json::Error),
@@ -140,6 +193,7 @@ where
 #[cfg(test)]
 mod tests {
     use serde::{Deserialize, Serialize};
+    use serde_json::json;
 
     use super::*;
     use crate::domain::task_scheduler::{RetryStrategy, TaskSchedulerError};
@@ -159,6 +213,11 @@ mod tests {
 
     #[derive(Clone, Deserialize, Serialize)]
     struct StubPayload {
+        value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+    struct StubCheckpoint {
         value: String,
     }
 
@@ -396,5 +455,130 @@ mod tests {
             BuildScheduledTaskError::Scheduler(TaskSchedulerError::Validation(message))
                 if message == "task id is required"
         ));
+    }
+
+    #[test]
+    fn parse_optional_json_value_returns_none_when_value_missing() {
+        let parsed = parse_optional_json_value::<StubCheckpoint, StubError>(
+            None,
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect("missing optional value should succeed");
+
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn parse_optional_json_value_parses_value_when_present() {
+        let parsed = parse_optional_json_value::<StubCheckpoint, StubError>(
+            Some(json!({ "value": "ok" })),
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect("valid value should parse");
+
+        assert_eq!(
+            parsed,
+            Some(StubCheckpoint {
+                value: "ok".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_optional_json_value_maps_invalid_json_error() {
+        let error = parse_optional_json_value::<StubCheckpoint, StubError>(
+            Some(json!({ "value": 5 })),
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect_err("invalid value should fail");
+
+        assert!(error.message.starts_with("invalid checkpoint: "));
+    }
+
+    #[test]
+    fn parse_required_json_value_returns_missing_error_when_absent() {
+        let error = parse_required_json_value::<StubCheckpoint, StubError>(
+            None,
+            "missing checkpoint",
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect_err("missing required value should fail");
+
+        assert_eq!(error.message, "missing checkpoint");
+    }
+
+    #[test]
+    fn parse_required_json_value_maps_invalid_json_error() {
+        let error = parse_required_json_value::<StubCheckpoint, StubError>(
+            Some(json!({ "value": 5 })),
+            "missing checkpoint",
+            "invalid checkpoint",
+            stub_error,
+        )
+        .expect_err("invalid required value should fail");
+
+        assert!(error.message.starts_with("invalid checkpoint: "));
+    }
+
+    #[test]
+    fn parse_failed_or_error_message_prefers_parsed_error() {
+        let error = parse_failed_or_error_message::<StubError>(
+            Some(StubError {
+                message: "typed failure".to_string(),
+                retryable: false,
+                retry_delay_seconds: None,
+            }),
+            Some("raw failure".to_string()),
+            "missing failure",
+            stub_error,
+        );
+
+        assert_eq!(error.message, "typed failure");
+    }
+
+    #[test]
+    fn parse_failed_or_error_message_falls_back_to_error_message() {
+        let error = parse_failed_or_error_message::<StubError>(
+            None,
+            Some("raw failure".to_string()),
+            "missing failure",
+            stub_error,
+        );
+
+        assert_eq!(error.message, "raw failure");
+    }
+
+    #[test]
+    fn parse_failed_or_error_message_returns_missing_message_when_empty() {
+        let error =
+            parse_failed_or_error_message::<StubError>(None, None, "missing failure", stub_error);
+
+        assert_eq!(error.message, "missing failure");
+    }
+
+    #[test]
+    fn serialize_json_value_serializes_struct() {
+        let value = serialize_json_value(
+            &StubCheckpoint {
+                value: "ok".to_string(),
+            },
+            "serialize failed",
+            stub_error,
+        )
+        .expect("serializable checkpoint should succeed");
+
+        assert_eq!(value, json!({ "value": "ok" }));
+    }
+
+    fn stub_error(message: String) -> StubError {
+        StubError {
+            message,
+            retryable: false,
+            retry_delay_seconds: None,
+        }
     }
 }

--- a/src/domain/task_scheduler/mod.rs
+++ b/src/domain/task_scheduler/mod.rs
@@ -5,8 +5,9 @@ mod service;
 mod worker;
 
 pub(crate) use handler::{
-    build_scheduled_task, scheduled_task_handler, BuildScheduledTaskError, NewScheduledTaskInput,
-    ScheduledTaskExecutor,
+    build_scheduled_task, parse_failed_or_error_message, parse_optional_json_value,
+    parse_required_json_value, scheduled_task_handler, serialize_json_value,
+    BuildScheduledTaskError, NewScheduledTaskInput, ScheduledTaskExecutor,
 };
 pub use model::{
     NewTask, RetryStrategy, ScheduledTask, TaskCheckpointRequest, TaskClaimRequest,

--- a/src/domain/training_plan/service/scheduler.rs
+++ b/src/domain/training_plan/service/scheduler.rs
@@ -7,9 +7,10 @@ use crate::domain::{
     identity::{Clock, IdGenerator},
     llm::LLM_REQUEST_TIMEOUT_SECONDS,
     task_scheduler::{
-        build_scheduled_task, scheduled_task_handler, BuildScheduledTaskError,
-        NewScheduledTaskInput, ResultTaskHandler, RetryStrategy, ScheduledTask,
-        ScheduledTaskExecutor, SharedTaskHandler, TaskRepository, TaskRunOutcome,
+        build_scheduled_task, parse_failed_or_error_message, parse_optional_json_value,
+        parse_required_json_value, scheduled_task_handler, serialize_json_value,
+        BuildScheduledTaskError, NewScheduledTaskInput, ResultTaskHandler, RetryStrategy,
+        ScheduledTask, ScheduledTaskExecutor, SharedTaskHandler, TaskRepository, TaskRunOutcome,
         TaskSchedulerError, TaskSchedulerService, TaskWorkerRepository,
     },
     workout_summary::WorkoutRecap,
@@ -90,50 +91,28 @@ fn deserialize_training_plan_error(error: SerializedTrainingPlanError) -> Traini
     }
 }
 
-fn parse_completed_checkpoint(
-    task: &ScheduledTask,
-) -> Result<Option<CompletedTrainingPlanTaskCheckpoint>, TrainingPlanError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value(value).map_err(|error| {
-                TrainingPlanError::Repository(format!(
-                    "invalid completed training plan checkpoint: {error}"
-                ))
-            })
-        })
-        .transpose()
-}
-
 fn parse_failed_checkpoint(
     task: &ScheduledTask,
 ) -> Result<Option<TrainingPlanError>, TrainingPlanError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value::<SerializedTrainingPlanError>(value)
-                .map(deserialize_training_plan_error)
-                .map_err(|error| {
-                    TrainingPlanError::Repository(format!(
-                        "invalid failed training plan checkpoint: {error}"
-                    ))
-                })
-        })
-        .transpose()
+    parse_optional_json_value::<SerializedTrainingPlanError, TrainingPlanError>(
+        task.checkpoint.clone(),
+        "invalid failed training plan checkpoint",
+        TrainingPlanError::Repository,
+    )
+    .map(|error| error.map(deserialize_training_plan_error))
 }
 
 fn build_completed_checkpoint(
     generated: &GeneratedTrainingPlan,
 ) -> Result<serde_json::Value, TrainingPlanError> {
-    serde_json::to_value(CompletedTrainingPlanTaskCheckpoint {
-        operation_key: generated.snapshot.operation_key.clone(),
-        was_generated: generated.was_generated,
-    })
-    .map_err(|error| {
-        TrainingPlanError::Repository(format!(
-            "failed to serialize completed training plan checkpoint: {error}"
-        ))
-    })
+    serialize_json_value(
+        &CompletedTrainingPlanTaskCheckpoint {
+            operation_key: generated.snapshot.operation_key.clone(),
+            was_generated: generated.was_generated,
+        },
+        "failed to serialize completed training plan checkpoint",
+        TrainingPlanError::Repository,
+    )
 }
 
 struct TrainingPlanGenerateTaskExecutor<Base> {
@@ -267,24 +246,21 @@ where
     }
 
     fn parse_completed(&self, task: &ScheduledTask) -> Result<Self::Completed, Self::Error> {
-        parse_completed_checkpoint(task)?.ok_or_else(|| {
-            TrainingPlanError::Repository(
-                "completed training plan task missing persisted checkpoint".to_string(),
-            )
-        })
+        parse_required_json_value(
+            task.checkpoint.clone(),
+            "completed training plan task missing persisted checkpoint",
+            "invalid completed training plan checkpoint",
+            TrainingPlanError::Repository,
+        )
     }
 
     fn parse_failed(&self, task: &ScheduledTask) -> Result<Self::Error, Self::Error> {
-        Ok(parse_failed_checkpoint(task)?.unwrap_or_else(|| {
-            task.error_message
-                .clone()
-                .map(TrainingPlanError::Repository)
-                .unwrap_or_else(|| {
-                    TrainingPlanError::Repository(
-                        "training plan task failed without an error message".to_string(),
-                    )
-                })
-        }))
+        Ok(parse_failed_or_error_message(
+            parse_failed_checkpoint(task)?,
+            task.error_message.clone(),
+            "training plan task failed without an error message",
+            TrainingPlanError::Repository,
+        ))
     }
 
     fn finish(&self, completed: Self::Completed) -> BoxFuture<Result<Self::Output, Self::Error>> {

--- a/src/domain/workout_summary/service/scheduler/checkpoint.rs
+++ b/src/domain/workout_summary/service/scheduler/checkpoint.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::domain::task_scheduler::{parse_optional_json_value, serialize_json_value};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct CompletedCoachReplyTaskCheckpoint {
@@ -38,30 +39,23 @@ pub(crate) fn parse_terminal_coach_reply_checkpoint(
 pub(crate) fn serialize_completed_coach_reply_checkpoint(
     reply: &CoachReply,
 ) -> Result<serde_json::Value, WorkoutSummaryError> {
-    serde_json::to_value(CompletedCoachReplyTaskCheckpoint {
-        coach_message: reply.coach_message.clone(),
-        athlete_summary_was_regenerated: reply.athlete_summary_was_regenerated,
-    })
-    .map_err(|error| {
-        WorkoutSummaryError::Repository(format!(
-            "failed to serialize completed coach reply checkpoint: {error}"
-        ))
-    })
+    serialize_json_value(
+        &CompletedCoachReplyTaskCheckpoint {
+            coach_message: reply.coach_message.clone(),
+            athlete_summary_was_regenerated: reply.athlete_summary_was_regenerated,
+        },
+        "failed to serialize completed coach reply checkpoint",
+        WorkoutSummaryError::Repository,
+    )
 }
 
 pub(crate) fn parse_terminal_task_error(
     task: &ScheduledTask,
 ) -> Result<Option<WorkoutSummaryError>, WorkoutSummaryError> {
-    task.checkpoint
-        .clone()
-        .map(|value| {
-            serde_json::from_value::<SerializedWorkoutSummaryError>(value)
-                .map(deserialize_workout_summary_error)
-                .map_err(|error| {
-                    WorkoutSummaryError::Repository(format!(
-                        "invalid failed workout summary coach reply checkpoint: {error}"
-                    ))
-                })
-        })
-        .transpose()
+    parse_optional_json_value::<SerializedWorkoutSummaryError, WorkoutSummaryError>(
+        task.checkpoint.clone(),
+        "invalid failed workout summary coach reply checkpoint",
+        WorkoutSummaryError::Repository,
+    )
+    .map(|error| error.map(deserialize_workout_summary_error))
 }

--- a/src/domain/workout_summary/service/scheduler/wrapper.rs
+++ b/src/domain/workout_summary/service/scheduler/wrapper.rs
@@ -1,6 +1,6 @@
 use super::checkpoint::{parse_terminal_coach_reply_checkpoint, parse_terminal_task_error};
 use super::*;
-use crate::domain::task_scheduler::ResultTaskHandler;
+use crate::domain::task_scheduler::{parse_failed_or_error_message, ResultTaskHandler};
 use crate::domain::workout_summary::SaveSummaryResult;
 
 #[derive(Clone)]
@@ -37,16 +37,12 @@ where
     }
 
     fn parse_failed(&self, task: &ScheduledTask) -> Result<Self::Error, Self::Error> {
-        Ok(parse_terminal_task_error(task)?.unwrap_or_else(|| {
-            task.error_message
-                .clone()
-                .map(WorkoutSummaryError::Repository)
-                .unwrap_or_else(|| {
-                    WorkoutSummaryError::Repository(
-                        "coach reply task failed without an error message".to_string(),
-                    )
-                })
-        }))
+        Ok(parse_failed_or_error_message(
+            parse_terminal_task_error(task)?,
+            task.error_message.clone(),
+            "coach reply task failed without an error message",
+            WorkoutSummaryError::Repository,
+        ))
     }
 
     fn finish(&self, completed: Self::Completed) -> BoxFuture<Result<Self::Output, Self::Error>> {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -55,6 +55,8 @@
 
 - For recovery-critical LLM tool-loop checkpoints, verify three separate boundaries: the terminal state is checkpointed before returning, checkpoint failure prevents a false success, and recovery from the checkpoint avoids a second provider call.
 - When restoring untracked files from `git stash -u`, use the stash's untracked parent (`stash@{n}^3`) and verify the restored file is non-empty before moving on.
+- When sending GitHub issue or PR bodies through shell commands, do not embed Markdown backticks inside double-quoted or `$'...'` shell strings. Build the JSON payload with a safe encoder such as `jq --arg` or a file input first, or shell expansion will silently corrupt paths and inline-code text.
+- Before relying on `gh pr create`, verify GitHub CLI auth explicitly and remember that repo hooks may still run extra verification commands. If auth is missing or the hook path is risky on this host, fall back to direct GitHub REST API calls with already-available credentials.
 
 
 - Before changing Intervals event payload field semantics, inspect the OpenAPI schema for the exact endpoint and method. For event create/update, `description` is the string field used by the existing planned-workout sync flow, while documented `workout_doc` is an object and must not be populated with the repo's canonical workout text string just because local DTOs expose that name.


### PR DESCRIPTION
## Summary
- extract small shared task scheduler helpers for optional and required JSON checkpoint parsing, failed-task fallback resolution, and checkpoint serialization
- reuse those helpers across athlete summary, coach conversation, training plan, and workout summary scheduler wrappers while keeping feature-specific error mapping local
- add focused helper and coach-conversation regression tests for invalid checkpoint parsing and raw error-message fallback

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `sh ./scripts/verify_arch.sh`

## Notes
- follow-up issue: #226
- `graphify-out/**` was regenerated locally but intentionally left out of the commit and PR to keep the review scoped to source changes
- targeted `cargo test` binaries on this host still hit the repo's known SIGKILL pressure path, so verification relied on the passing rust, clippy, and arch gates that ran fresh in commit and push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub API issue/PR body corruption caused by certain shell quoting/backticks.

* **Documentation**
  * Added notes on shell-escaping best practices for API payloads.
  * Added guidance to verify CLI auth before creating pull requests.

* **Refactor**
  * Consolidated JSON parsing/serialization helpers across task schedulers.
  * Standardized error mapping and checkpoint handling across services.

* **Tests**
  * Added unit tests covering parsing/serialization and failure-case behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/227)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->