### PR TITLE
refactor: share provider transcript merge retry helper

### DIFF
--- a/docs/superpowers/plans/2026-05-14-shared-provider-transcript-merge-helper.md
+++ b/docs/superpowers/plans/2026-05-14-shared-provider-transcript-merge-helper.md
@@ -1,0 +1,299 @@
+# Shared Provider Transcript Merge Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract one shared `merge_provider_transcript_with_retry(...)` helper so workout-summary and coach-conversation provider-transcript persistence use the same optimistic retry and compare-and-set merge behavior.
+
+**Architecture:** Keep the shared retry/merge logic in `src/domain/llm/persistence.rs` and keep workflow-specific repository reads, timestamp computation, and repository writes in the existing services. Prefer a closure-based helper over a new shared repository trait so the extraction stays inside the existing domain boundaries and does not widen the port surface.
+
+**Tech Stack:** Rust 2021, Tokio, tracing, existing hexagonal domain ports, cargo fmt, clippy, focused Rust integration tests.
+
+---
+
+## File Map
+
+- Create/expand: `src/domain/llm/persistence.rs`
+- Modify: `src/domain/workout_summary/service/internals/recovery.rs`
+- Modify: `src/domain/coach_conversation/service/internals/persistence.rs`
+- Modify: `src/domain/workout_summary/service/use_cases/chat.rs`
+- Modify: `src/domain/coach_conversation/service/use_cases.rs`
+- Verify existing support stays unchanged: `src/domain/workout_summary/service/internals/messaging.rs`
+- Verify existing support stays unchanged: `src/domain/coach_conversation/service/internals/persistence.rs`
+- Test: `tests/workout_summary_service/messaging.rs`
+- Test: `tests/calendar_coach_service/transcript_persistence.rs`
+
+### Design Constraints
+
+- Keep `src/domain/llm/persistence.rs` as the only shared home for transcript-merge retry behavior.
+- Do not add a new shared repository trait unless the closure-based helper proves impossible.
+- Preserve current retry semantics exactly:
+  - `POST_PROVIDER_WRITE_ATTEMPTS == 2`
+  - `backoff_base_ms == 25`
+  - retry only on retryable repository/CAS errors
+  - re-read latest persisted transcript on each retry before merging
+- Keep workflow-specific timestamp generation in the existing workflow helpers so `next_provider_transcript_updated_at_epoch_seconds(...)` behavior does not drift.
+- Do not change persist-before-side-effects ordering in either reply workflow.
+
+### Task 1: Add Shared Transcript Merge Retry Helper
+
+**Files:**
+- Modify: `src/domain/llm/persistence.rs`
+
+- [ ] **Step 1: Add focused shared types for latest transcript snapshot and merge-retry inputs**
+
+Add a small helper snapshot type near the existing retry types so callers can pass their latest persisted transcript state without creating a new repository abstraction.
+
+```rust
+pub struct ProviderTranscriptSnapshot {
+    pub provider_transcript: Vec<LlmChatMessage>,
+    pub expected_updated_at_epoch_seconds: i64,
+}
+```
+
+- [ ] **Step 2: Add the shared `merge_provider_transcript_with_retry(...)` helper**
+
+Implement a new helper in `src/domain/llm/persistence.rs` that wraps `retry_persist(...)`, reloads the latest transcript on each attempt, merges with `merge_provider_transcript_entries(...)`, and then delegates persistence to a caller-supplied closure.
+
+Target shape:
+
+```rust
+pub async fn merge_provider_transcript_with_retry<TLoad, TPersist, LoadFut, PersistFut, E>(
+    config: RetryConfig,
+    incoming_provider_transcript: Vec<LlmChatMessage>,
+    is_retryable: impl Fn(&E) -> bool,
+    mut load_latest: TLoad,
+    mut persist_merged: TPersist,
+    ctx: &RetryContext,
+) -> Result<(), E>
+where
+    TLoad: FnMut() -> LoadFut,
+    TPersist: FnMut(ProviderTranscriptSnapshot, Vec<LlmChatMessage>) -> PersistFut,
+    LoadFut: Future<Output = Result<ProviderTranscriptSnapshot, E>> + Send,
+    PersistFut: Future<Output = Result<(), E>> + Send,
+    E: std::fmt::Display,
+{
+    retry_persist(config, is_retryable, || {
+        let incoming_provider_transcript = incoming_provider_transcript.clone();
+        Box::pin(async {
+            let latest = load_latest().await?;
+            let merged = merge_provider_transcript_entries(
+                latest.provider_transcript.clone(),
+                &incoming_provider_transcript,
+            );
+            persist_merged(latest, merged).await
+        })
+    }, ctx)
+    .await
+}
+```
+
+The exact generic names can vary, but the semantics above must hold.
+
+- [ ] **Step 3: Add helper unit tests directly in `src/domain/llm/persistence.rs`**
+
+Add tests that verify the helper itself, not just the downstream workflows.
+
+Coverage targets:
+
+```rust
+#[tokio::test]
+async fn merge_provider_transcript_with_retry_reloads_latest_state_after_retryable_conflict() {
+    // first persist attempt returns retryable repository error
+    // second load sees transcript containing "Concurrent update"
+    // final persisted transcript contains both previous and incoming messages
+}
+
+#[tokio::test]
+async fn merge_provider_transcript_with_retry_does_not_retry_non_retryable_error() {
+    // first persist attempt returns non-retryable error
+    // helper returns immediately
+    // load/persist counters show only one attempt
+}
+```
+
+- [ ] **Step 4: Run focused helper tests**
+
+Run:
+
+```bash
+cargo test merge_provider_transcript_with_retry -- --nocapture
+```
+
+Expected: both new helper tests pass.
+
+### Task 2: Switch Workout Summary To The Shared Helper
+
+**Files:**
+- Modify: `src/domain/workout_summary/service/internals/recovery.rs`
+- Verify no behavior change needed in: `src/domain/workout_summary/service/internals/messaging.rs`
+- Test: `tests/workout_summary_service/messaging.rs`
+
+- [ ] **Step 1: Replace the local transcript merge loop in workout summary**
+
+Update `src/domain/workout_summary/service/internals/recovery.rs` so the method named `merge_provider_transcript_with_retry(...)` delegates to the new shared helper instead of duplicating the retry loop inline.
+
+The workflow should still:
+
+```rust
+let summary = svc.get_existing_summary(&uid, &wid).await?;
+let latest = ProviderTranscriptSnapshot {
+    provider_transcript: summary.provider_transcript,
+    expected_updated_at_epoch_seconds: summary.updated_at_epoch_seconds,
+};
+svc.replace_provider_transcript(
+    &uid,
+    &wid,
+    latest.expected_updated_at_epoch_seconds,
+    merged,
+).await
+```
+
+- [ ] **Step 2: Keep retry configuration and error classification unchanged**
+
+Preserve the existing values:
+
+```rust
+RetryConfig {
+    max_attempts: POST_PROVIDER_WRITE_ATTEMPTS,
+    backoff_base_ms: 25,
+}
+```
+
+and:
+
+```rust
+|e| matches!(e, WorkoutSummaryError::Repository(_))
+```
+
+- [ ] **Step 3: Re-run the existing workout summary transcript persistence regression**
+
+Run:
+
+```bash
+cargo test --test workout_summary_service generate_coach_reply_retries_provider_transcript_write_after_compare_and_set_conflict -- --nocapture
+```
+
+Expected: pass, with the final stored transcript still containing `Turn 0`, `Concurrent summary update`, and the new reply turn.
+
+### Task 3: Switch Coach Conversation To The Shared Helper
+
+**Files:**
+- Modify: `src/domain/coach_conversation/service/internals/persistence.rs`
+- Modify if import cleanup is needed: `src/domain/coach_conversation/service/use_cases.rs`
+- Test: `tests/calendar_coach_service/transcript_persistence.rs`
+
+- [ ] **Step 1: Replace the local transcript merge loop in coach conversation**
+
+Update `src/domain/coach_conversation/service/internals/persistence.rs` so its local `merge_provider_transcript_with_retry(...)` method delegates to the shared helper.
+
+The caller-specific closures should still do:
+
+```rust
+let latest = svc
+    .conversations
+    .find_by_user_id_and_conversation_id(&uid, &cid)
+    .await?
+    .ok_or(CoachConversationError::NotFound)?;
+
+let latest = ProviderTranscriptSnapshot {
+    provider_transcript: latest.provider_transcript.clone(),
+    expected_updated_at_epoch_seconds: latest.updated_at_epoch_seconds,
+};
+```
+
+and persist with the existing `replace_provider_transcript(&latest_conversation, merged)` path or an equivalent path that preserves current timestamp logic.
+
+- [ ] **Step 2: Preserve current tracing and failure behavior at the use-case layer**
+
+Do not change the higher-level failure mapping in:
+
+```rust
+src/domain/coach_conversation/service/use_cases.rs
+```
+
+The use case must still convert transcript persistence failure into:
+
+```rust
+LlmError::Internal(format!(
+    "failed to persist provider transcript after provider response: {error}"
+))
+```
+
+- [ ] **Step 3: Re-run the existing calendar coach transcript persistence regression**
+
+Run:
+
+```bash
+cargo test --test calendar_coach_service calendar_coach_retries_provider_transcript_write_after_compare_and_set_conflict -- --nocapture
+```
+
+Expected: pass, with the final stored transcript still containing `Turn 0`, `Concurrent calendar update`, and `Coach reply`.
+
+### Task 4: Final Verification And Graph Refresh
+
+**Files:**
+- Modify only if verification or imports force small cleanup in the files above
+- Refresh generated graph output after code changes
+
+- [ ] **Step 1: Run formatting check**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: no formatting diffs.
+
+- [ ] **Step 2: Run clippy for the touched Rust codebase**
+
+Run:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: `Finished` or success output with zero warnings promoted to errors.
+
+- [ ] **Step 3: Run architecture verification**
+
+Run:
+
+```bash
+bun run verify:arch
+```
+
+Expected: architecture verification succeeds.
+
+- [ ] **Step 4: Refresh graphify output required by repo instructions**
+
+Run:
+
+```bash
+./scripts/rebuild_graphify.sh
+```
+
+Expected: `graphify-out/` refresh completes without errors.
+
+- [ ] **Step 5: Review the diff narrowly before asking for review or committing**
+
+Run:
+
+```bash
+git diff -- src/domain/llm/persistence.rs \
+  src/domain/workout_summary/service/internals/recovery.rs \
+  src/domain/coach_conversation/service/internals/persistence.rs \
+  src/domain/workout_summary/service/use_cases/chat.rs \
+  src/domain/coach_conversation/service/use_cases.rs \
+  tests/workout_summary_service/messaging.rs \
+  tests/calendar_coach_service/transcript_persistence.rs
+```
+
+Expected: only the planned helper extraction and targeted test updates appear.
+
+## Notes For The Implementer
+
+- The smallest correct extraction is closure-based. Resist introducing a new `ProviderTranscriptMergeRepository` trait unless the compiler proves the closure version unworkable.
+- Keep the workflow-local methods named `merge_provider_transcript_with_retry(...)` if that keeps call sites stable; they can become thin wrappers over the shared helper.
+- Do not move timestamp computation into the generic helper. That detail belongs to the workflow-specific repository write helpers that already own `updated_at` semantics.
+- Do not widen the helper to handle unrelated operation persistence. This task is only about shared provider-transcript merge retry behavior.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-14 | CodeRabbit | PR #232 shared provider transcript merge helper
+
+- Problem: the extracted `merge_provider_transcript_with_retry(...)` helper retried retryable `persist_merged(...)` failures but returned immediately on retryable `load_latest()` errors, so a transient repository read failure during transcript reload skipped the intended retry/backoff path.
+- Fix: changed `src/domain/llm/persistence.rs` to route the whole load-merge-persist operation through the existing shared `retry_persist(...)` loop, so retryable `load_latest()` and `persist_merged(...)` errors now share the same retry semantics. Kept the focused regression `merge_provider_transcript_with_retry_retries_retryable_load_error` to lock the bug fix in place.
+- Prevention: when extracting a retry helper around a multi-step optimistic-write flow, verify every fallible step that belongs to one retry attempt stays inside the retry closure. Do not leave `load_latest()` or other preparatory repository reads outside the retry loop if their retryable failures should reload and retry the full write attempt.
+
 ### 2026-05-13 | CodeRabbit | PR #229 shared public tool materialization fresh-response coverage
 
 - Problem: after the recovery-suite split on PR #229, `calendar_coach_marks_fresh_tool_only_response_as_failed` still checked only the failed status and missed the persisted `public_tool_call_ids`, leaving the fresh tool-only path with weaker coverage than the mirrored recovery tests.

--- a/src/domain/coach_conversation/service/internals/persistence.rs
+++ b/src/domain/coach_conversation/service/internals/persistence.rs
@@ -1,7 +1,10 @@
 use crate::domain::coach_conversation::CoachConversationReplyOperation;
 use crate::domain::llm::{
-    merge_provider_transcript_entries, next_provider_transcript_updated_at_epoch_seconds,
-    persistence::{retry_persist, RetryConfig, RetryContext},
+    next_provider_transcript_updated_at_epoch_seconds,
+    persistence::{
+        merge_provider_transcript_with_retry, retry_persist, ProviderTranscriptSnapshot,
+        RetryConfig, RetryContext,
+    },
     LlmChatMessage, LlmError,
 };
 
@@ -22,10 +25,10 @@ where
         operation: &CoachConversationReplyOperation,
         write_label: &'static str,
     ) -> Result<(), CoachConversationError> {
-        let service = self.clone();
         let user_id = conversation.user_id.clone();
         let conversation_id = conversation.conversation_id.clone();
         let provider_transcript = operation.provider_transcript.clone();
+        let service = self.clone();
         let ctx = RetryContext {
             write_label,
             user_message_id: operation.user_message_id.clone(),
@@ -34,7 +37,7 @@ where
             operation_status: None,
         };
 
-        retry_persist(
+        merge_provider_transcript_with_retry(
             RetryConfig {
                 max_attempts: POST_PROVIDER_WRITE_ATTEMPTS,
                 backoff_base_ms: 25,
@@ -44,18 +47,24 @@ where
                 let svc = service.clone();
                 let uid = user_id.clone();
                 let cid = conversation_id.clone();
-                let pt = provider_transcript.clone();
                 Box::pin(async move {
                     let latest = svc
                         .conversations
                         .find_by_user_id_and_conversation_id(&uid, &cid)
                         .await?
                         .ok_or(CoachConversationError::NotFound)?;
-                    let merged =
-                        merge_provider_transcript_entries(latest.provider_transcript.clone(), &pt);
-                    svc.replace_provider_transcript(&latest, merged).await
+                    let provider_transcript = latest.provider_transcript.clone();
+                    Ok(ProviderTranscriptSnapshot {
+                        latest_state: latest,
+                        provider_transcript,
+                    })
                 })
             },
+            |latest, merged| {
+                let svc = service.clone();
+                Box::pin(async move { svc.replace_provider_transcript(&latest, merged).await })
+            },
+            &provider_transcript,
             &ctx,
         )
         .await

--- a/src/domain/llm/persistence.rs
+++ b/src/domain/llm/persistence.rs
@@ -95,7 +95,32 @@ where
         let ProviderTranscriptSnapshot {
             latest_state,
             provider_transcript,
-        } = load_latest().await?;
+        } = match load_latest().await {
+            Ok(snapshot) => snapshot,
+            Err(error) if is_retryable(&error) => {
+                if attempt == config.max_attempts {
+                    return Err(error);
+                }
+
+                warn!(
+                    scope = %ctx.scope_value,
+                    scope_label = ctx.scope_label,
+                    user_message_id = %ctx.user_message_id,
+                    attempt,
+                    max_attempts = config.max_attempts,
+                    write_label = ctx.write_label,
+                    operation_status = ctx.operation_status,
+                    error = %error,
+                    "retrying write after repository error"
+                );
+                tokio::time::sleep(Duration::from_millis(
+                    config.backoff_base_ms * attempt as u64,
+                ))
+                .await;
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         let merged =
             merge_provider_transcript_entries(provider_transcript, pending_provider_transcript);
 
@@ -321,6 +346,68 @@ mod tests {
         assert_eq!(
             *load_count.lock().expect("load count lock should succeed"),
             1
+        );
+        assert_eq!(
+            *persist_count
+                .lock()
+                .expect("persist count lock should succeed"),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_provider_transcript_with_retry_retries_retryable_load_error() {
+        let load_count = Arc::new(Mutex::new(0usize));
+        let persist_count = Arc::new(Mutex::new(0usize));
+        let load_count_for_loader = load_count.clone();
+        let persist_count_for_persist = persist_count.clone();
+        let ctx = RetryContext {
+            write_label: "merge_provider_transcript_with_retry_test",
+            user_message_id: "message-1".to_string(),
+            scope_label: "scope_id",
+            scope_value: "scope-1".to_string(),
+            operation_status: None,
+        };
+
+        let result: Result<(), TestError> = merge_provider_transcript_with_retry(
+            RetryConfig {
+                max_attempts: 2,
+                backoff_base_ms: 0,
+            },
+            |error| matches!(error, TestError::Retryable(_)),
+            move || {
+                let load_count = load_count_for_loader.clone();
+                Box::pin(async move {
+                    let mut calls = load_count.lock().expect("load count lock should succeed");
+                    *calls += 1;
+                    if *calls == 1 {
+                        return Err(TestError::Retryable("transient load failure"));
+                    }
+                    Ok(ProviderTranscriptSnapshot {
+                        latest_state: (),
+                        provider_transcript: vec![LlmChatMessage::assistant("persisted assistant")],
+                    })
+                })
+            },
+            move |_, _| {
+                let persist_count = persist_count_for_persist.clone();
+                Box::pin(async move {
+                    let mut calls = persist_count
+                        .lock()
+                        .expect("persist count lock should succeed");
+                    *calls += 1;
+                    Ok(())
+                })
+            },
+            &[LlmChatMessage::assistant("pending assistant")],
+            &ctx,
+        )
+        .await;
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            *load_count.lock().expect("load count lock should succeed"),
+            2
         );
         assert_eq!(
             *persist_count

--- a/src/domain/llm/persistence.rs
+++ b/src/domain/llm/persistence.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use tracing::{info, warn};
 
-use super::BoxFuture;
+use super::{merge_provider_transcript_entries, BoxFuture, LlmChatMessage};
 
 pub struct RetryConfig {
     pub max_attempts: usize,
@@ -15,6 +15,11 @@ pub struct RetryContext {
     pub scope_label: &'static str,
     pub scope_value: String,
     pub operation_status: Option<String>,
+}
+
+pub struct ProviderTranscriptSnapshot<T> {
+    pub latest_state: T,
+    pub provider_transcript: Vec<LlmChatMessage>,
 }
 
 pub async fn retry_persist<T, E>(
@@ -68,4 +73,260 @@ where
     }
 
     unreachable!("retry loop exhausted with max_attempts >= 1")
+}
+
+pub async fn merge_provider_transcript_with_retry<T, S, E, LoadLatest, PersistMerged>(
+    config: RetryConfig,
+    is_retryable: impl Fn(&E) -> bool,
+    load_latest: LoadLatest,
+    persist_merged: PersistMerged,
+    pending_provider_transcript: &[LlmChatMessage],
+    ctx: &RetryContext,
+) -> Result<T, E>
+where
+    E: std::fmt::Display,
+    LoadLatest: FnMut() -> BoxFuture<Result<ProviderTranscriptSnapshot<S>, E>>,
+    PersistMerged: FnMut(S, Vec<LlmChatMessage>) -> BoxFuture<Result<T, E>>,
+{
+    let mut load_latest = load_latest;
+    let mut persist_merged = persist_merged;
+
+    for attempt in 1..=config.max_attempts {
+        let ProviderTranscriptSnapshot {
+            latest_state,
+            provider_transcript,
+        } = load_latest().await?;
+        let merged =
+            merge_provider_transcript_entries(provider_transcript, pending_provider_transcript);
+
+        match persist_merged(latest_state, merged).await {
+            Ok(value) => {
+                if attempt > 1 {
+                    info!(
+                        scope = %ctx.scope_value,
+                        scope_label = ctx.scope_label,
+                        user_message_id = %ctx.user_message_id,
+                        attempt,
+                        max_attempts = config.max_attempts,
+                        write_label = ctx.write_label,
+                        "recovered write after retry"
+                    );
+                }
+                return Ok(value);
+            }
+            Err(error) if is_retryable(&error) => {
+                if attempt == config.max_attempts {
+                    return Err(error);
+                }
+
+                warn!(
+                    scope = %ctx.scope_value,
+                    scope_label = ctx.scope_label,
+                    user_message_id = %ctx.user_message_id,
+                    attempt,
+                    max_attempts = config.max_attempts,
+                    write_label = ctx.write_label,
+                    operation_status = ctx.operation_status,
+                    error = %error,
+                    "retrying write after repository error"
+                );
+                tokio::time::sleep(Duration::from_millis(
+                    config.backoff_base_ms * attempt as u64,
+                ))
+                .await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("retry loop exhausted with max_attempts >= 1")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::domain::llm::LlmChatMessage;
+
+    use super::{
+        merge_provider_transcript_with_retry, ProviderTranscriptSnapshot, RetryConfig, RetryContext,
+    };
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum TestError {
+        Retryable(&'static str),
+        NonRetryable(&'static str),
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Retryable(message) | Self::NonRetryable(message) => write!(f, "{message}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn merge_provider_transcript_with_retry_reloads_latest_state_after_retryable_conflict() {
+        let state = Arc::new(Mutex::new(vec![LlmChatMessage::assistant(
+            "persisted assistant",
+        )]));
+        let load_count = Arc::new(Mutex::new(0usize));
+        let persist_count = Arc::new(Mutex::new(0usize));
+        let persisted_attempts = Arc::new(Mutex::new(Vec::new()));
+        let load_state = state.clone();
+        let persist_state = state.clone();
+        let load_count_for_loader = load_count.clone();
+        let persist_count_for_persist = persist_count.clone();
+        let persisted_attempts_for_persist = persisted_attempts.clone();
+        let pending = vec![LlmChatMessage::tool("tool-1", "tool output")];
+        let ctx = RetryContext {
+            write_label: "merge_provider_transcript_with_retry_test",
+            user_message_id: "message-1".to_string(),
+            scope_label: "scope_id",
+            scope_value: "scope-1".to_string(),
+            operation_status: None,
+        };
+
+        let result = merge_provider_transcript_with_retry(
+            RetryConfig {
+                max_attempts: 2,
+                backoff_base_ms: 0,
+            },
+            |error| matches!(error, TestError::Retryable(_)),
+            move || {
+                let state = load_state.clone();
+                let load_count = load_count_for_loader.clone();
+                Box::pin(async move {
+                    let mut calls = load_count.lock().expect("load count lock should succeed");
+                    *calls += 1;
+                    Ok(ProviderTranscriptSnapshot {
+                        latest_state: (),
+                        provider_transcript: state
+                            .lock()
+                            .expect("state lock should succeed")
+                            .clone(),
+                    })
+                })
+            },
+            move |(), merged| {
+                let state = persist_state.clone();
+                let persist_count = persist_count_for_persist.clone();
+                let persisted_attempts = persisted_attempts_for_persist.clone();
+                Box::pin(async move {
+                    persisted_attempts
+                        .lock()
+                        .expect("persisted attempts lock should succeed")
+                        .push(merged.clone());
+                    let mut persist_calls = persist_count
+                        .lock()
+                        .expect("persist count lock should succeed");
+                    let mut latest = state.lock().expect("state lock should succeed");
+                    if *persist_calls == 0 {
+                        *persist_calls += 1;
+                        *latest = vec![
+                            LlmChatMessage::assistant("persisted assistant"),
+                            LlmChatMessage::assistant("other writer message"),
+                        ];
+                        return Err(TestError::Retryable("compare-and-set conflict"));
+                    }
+                    *latest = merged;
+                    Ok(())
+                })
+            },
+            &pending,
+            &ctx,
+        )
+        .await;
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            *load_count.lock().expect("load count lock should succeed"),
+            2
+        );
+        assert_eq!(
+            persisted_attempts
+                .lock()
+                .expect("persisted attempts lock should succeed")
+                .clone(),
+            vec![
+                vec![
+                    LlmChatMessage::assistant("persisted assistant"),
+                    LlmChatMessage::tool("tool-1", "tool output"),
+                ],
+                vec![
+                    LlmChatMessage::assistant("persisted assistant"),
+                    LlmChatMessage::assistant("other writer message"),
+                    LlmChatMessage::tool("tool-1", "tool output"),
+                ],
+            ]
+        );
+        assert_eq!(
+            state.lock().expect("state lock should succeed").clone(),
+            vec![
+                LlmChatMessage::assistant("persisted assistant"),
+                LlmChatMessage::assistant("other writer message"),
+                LlmChatMessage::tool("tool-1", "tool output"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_provider_transcript_with_retry_does_not_retry_non_retryable_error() {
+        let load_count = Arc::new(Mutex::new(0usize));
+        let persist_count = Arc::new(Mutex::new(0usize));
+        let load_count_for_loader = load_count.clone();
+        let persist_count_for_persist = persist_count.clone();
+        let ctx = RetryContext {
+            write_label: "merge_provider_transcript_with_retry_test",
+            user_message_id: "message-1".to_string(),
+            scope_label: "scope_id",
+            scope_value: "scope-1".to_string(),
+            operation_status: None,
+        };
+
+        let result: Result<(), TestError> = merge_provider_transcript_with_retry(
+            RetryConfig {
+                max_attempts: 3,
+                backoff_base_ms: 0,
+            },
+            |error| matches!(error, TestError::Retryable(_)),
+            move || {
+                let load_count = load_count_for_loader.clone();
+                Box::pin(async move {
+                    let mut calls = load_count.lock().expect("load count lock should succeed");
+                    *calls += 1;
+                    Ok(ProviderTranscriptSnapshot {
+                        latest_state: (),
+                        provider_transcript: vec![LlmChatMessage::assistant("persisted assistant")],
+                    })
+                })
+            },
+            move |_, _| {
+                let persist_count = persist_count_for_persist.clone();
+                Box::pin(async move {
+                    let mut calls = persist_count
+                        .lock()
+                        .expect("persist count lock should succeed");
+                    *calls += 1;
+                    Err(TestError::NonRetryable("permanent failure"))
+                })
+            },
+            &[LlmChatMessage::assistant("pending assistant")],
+            &ctx,
+        )
+        .await;
+
+        assert_eq!(result, Err(TestError::NonRetryable("permanent failure")));
+        assert_eq!(
+            *load_count.lock().expect("load count lock should succeed"),
+            1
+        );
+        assert_eq!(
+            *persist_count
+                .lock()
+                .expect("persist count lock should succeed"),
+            1
+        );
+    }
 }

--- a/src/domain/workout_summary/service/internals/recovery.rs
+++ b/src/domain/workout_summary/service/internals/recovery.rs
@@ -1,7 +1,10 @@
 use crate::domain::{
     llm::{
-        last_nonempty_assistant_content, merge_provider_transcript_entries,
-        persistence::{retry_persist, RetryConfig, RetryContext},
+        last_nonempty_assistant_content,
+        persistence::{
+            merge_provider_transcript_with_retry, retry_persist, ProviderTranscriptSnapshot,
+            RetryConfig, RetryContext,
+        },
     },
     llm_tools::public_tool_call_from_llm,
     public_tool_calls::materialization::materialize_public_tool_calls_idempotently,
@@ -26,10 +29,10 @@ where
         operation: &CoachReplyOperation,
         write_label: &'static str,
     ) -> Result<(), WorkoutSummaryError> {
-        let service = self.clone();
         let user_id = user_id.to_string();
         let workout_id = workout_id.to_string();
         let provider_transcript = operation.provider_transcript.clone();
+        let service = self.clone();
         let ctx = RetryContext {
             write_label,
             user_message_id: operation.user_message_id.clone(),
@@ -38,7 +41,7 @@ where
             operation_status: None,
         };
 
-        retry_persist(
+        merge_provider_transcript_with_retry(
             RetryConfig {
                 max_attempts: POST_PROVIDER_WRITE_ATTEMPTS,
                 backoff_base_ms: 25,
@@ -48,20 +51,29 @@ where
                 let svc = service.clone();
                 let uid = user_id.clone();
                 let wid = workout_id.clone();
-                let pt = provider_transcript.clone();
                 Box::pin(async move {
                     let summary = svc.get_existing_summary(&uid, &wid).await?;
-                    let merged =
-                        merge_provider_transcript_entries(summary.provider_transcript, &pt);
+                    Ok(ProviderTranscriptSnapshot {
+                        latest_state: summary.updated_at_epoch_seconds,
+                        provider_transcript: summary.provider_transcript,
+                    })
+                })
+            },
+            |expected_updated_at_epoch_seconds, merged| {
+                let svc = service.clone();
+                let uid = user_id.clone();
+                let wid = workout_id.clone();
+                Box::pin(async move {
                     svc.replace_provider_transcript(
                         &uid,
                         &wid,
-                        summary.updated_at_epoch_seconds,
+                        expected_updated_at_epoch_seconds,
                         merged,
                     )
                     .await
                 })
             },
+            &provider_transcript,
             &ctx,
         )
         .await

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -55,6 +55,7 @@
 
 ## Small Review Fixes
 
+- When extracting a shared retry helper for a read-merge-write flow, keep the entire retryable attempt inside the retry closure, including the fresh read. If `load_latest()` lives outside the retry loop, transient read failures will bypass the intended retry/backoff semantics and the helper no longer matches its callers' optimistic-retry contract.
 - For recovery-critical LLM tool-loop checkpoints, verify three separate boundaries: the terminal state is checkpointed before returning, checkpoint failure prevents a false success, and recovery from the checkpoint avoids a second provider call.
 - When restoring untracked files from `git stash -u`, use the stash's untracked parent (`stash@{n}^3`) and verify the restored file is non-empty before moving on.
 - When sending GitHub issue or PR bodies through shell commands, do not embed Markdown backticks inside double-quoted or `$'...'` shell strings. Build the JSON payload with a safe encoder such as `jq --arg` or a file input first, or shell expansion will silently corrupt paths and inline-code text.
@@ -215,3 +216,9 @@
 
 - When adding a new field to a shared API schema (backend DTO, frontend Zod schema, or request/response type), grep for every place the old fields are enumerated and add the new one. Common places to miss: frontend payload builders, frontend API extraction functions, TypeScript discriminated unions, backend match arms, backend `apply_field_update` calls, test fixture builders, and mock data objects.
 - A schema update alone is not enough if the code that serializes, extracts, or transforms the payload still iterates over the old field set. Add a focused end-to-end test that exercises the new field through the full stack (UI → API → backend → response → UI) to catch gaps in payload plumbing.
+
+## 2026-05-13 - Verify remote branch before claiming push succeeded
+
+- Problem: I said the branch was pushed even though `origin/feat/shared-public-tool-materialization` was still behind the local commit.
+- Rule: After every push, confirm with a fresh remote comparison such as `git fetch origin` plus local vs remote SHA check before telling the user it is on GitHub.
+- Reusable check: `git push origin HEAD:<branch> && git fetch origin && printf "LOCAL %s\nREMOTE %s\n" "$(git rev-parse HEAD)" "$(git rev-parse origin/<branch>)"`


### PR DESCRIPTION
## Summary

- extract a shared `merge_provider_transcript_with_retry(...)` helper in `src/domain/llm/persistence.rs`
- switch workout-summary and coach-conversation transcript persistence paths to the shared optimistic retry/CAS merge flow
- add focused helper coverage and keep workflow-specific error mapping and timestamp writes unchanged

## Test Plan

- [x] `cargo check --tests`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `bun run verify:arch`
- [x] `./scripts/rebuild_graphify.sh`
- [ ] `cargo test merge_provider_transcript_with_retry -- --nocapture` (`SIGKILL` on this host after successful compile)
- [ ] `cargo test --test workout_summary_service generate_coach_reply_retries_provider_transcript_write_after_compare_and_set_conflict -- --exact --test-threads=1 --nocapture` (`SIGKILL` on this host after successful compile)
- [ ] `cargo test --test calendar_coach_service calendar_coach_retries_provider_transcript_write_after_compare_and_set_conflict -- --exact --test-threads=1 --nocapture` (`SIGKILL` on this host after successful compile)

Closes #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated provider-transcript merge and conflict resolution logic into a centralized utility to improve code consistency and maintainability across services.

* **Documentation**
  * Added architectural planning documentation for the shared transcript merge helper implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/232)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->