### PR TITLE
fix: harden workout summary coach evidence hierarchy

### DIFF
--- a/docs/superpowers/plans/2026-05-22-workout-summary-coach-prompt-hardening.md
+++ b/docs/superpowers/plans/2026-05-22-workout-summary-coach-prompt-hardening.md
@@ -1,0 +1,478 @@
+# Workout Summary Coach Prompt Hardening Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change the workout-summary coach prompt so the LLM evaluates post-workout execution primarily from `bl`, `pc`, and `c5`, treats aggregate metrics as secondary context only, and uses tools only when those packed signals are insufficient for a confident conclusion.
+
+**Architecture:** Keep the change local to the existing workout-summary LLM adapter and tool guidance layer. Do not change training-context payload shape or orchestration; instead, strengthen the coach’s evidence hierarchy in the base prompt and tool usage guidance, then lock it in with focused prompt-level tests.
+
+**Tech Stack:** Rust, existing LLM adapter prompt assembly, domain LLM tools, Rust unit/integration-style adapter tests.
+
+---
+
+### Scope Summary
+
+This plan should touch only the prompt and prompt-guidance surfaces already used by `WorkoutSummaryChat`, plus focused tests.
+
+Expected code areas:
+- `src/adapters/llm/workout_summary_coach.rs`
+- `src/domain/llm_tools/mod.rs`
+- `tests/llm_adapters/coaching.rs`
+- possibly one `src/domain/llm_tools/*` test if guidance text is asserted there
+- `reviewers.md`
+- `tasks/lessons.md`
+- `docs/superpowers/plans/2026-05-22-workout-summary-coach-prompt-hardening.md`
+- after implementation: `graphify-out/**` via `./scripts/rebuild_graphify.sh`
+
+Non-goals:
+- no backend prefetch of completed workout detail
+- no training-context schema change
+- no new tools
+- no parser/schema changes for coach output
+
+---
+
+### Task 1: Confirm Current Prompt and Guidance Baseline
+
+**Files:**
+- Read: `src/adapters/llm/workout_summary_coach.rs`
+- Read: `src/domain/llm_tools/mod.rs`
+- Read: `tests/llm_adapters/coaching.rs`
+- Read: `src/domain/training_context/service/tests/builder/rendering.rs`
+
+- [ ] **Step 1: Re-read the current workout coach system prompt**
+  
+  Verify the current base prompt in `src/adapters/llm/workout_summary_coach.rs` does all of the following today:
+  - describes coaching tone
+  - requires JSON-only output
+  - mentions packed training context
+  - does not yet define an evidence hierarchy for `bl`, `pc`, `c5`
+  - does not yet explicitly forbid interval-execution judgments from `NP` / `avg power` / `IF` / `VI` / `TSS` alone
+
+- [ ] **Step 2: Re-read current tool guidance assembly**
+  
+  Verify in `src/domain/llm_tools/mod.rs`:
+  - `with_tool_prompt_guidance(...)` appends tool instructions after the base system prompt
+  - current generic rule says “call it instead of guessing”
+  - tool guidance is scope-aware and provider-aware
+  - `WorkoutSummaryChat` has access to `get_selected_workout` and `selected_workout_power_curve`
+
+- [ ] **Step 3: Reconfirm packed-context semantics**
+  
+  Reconfirm from `src/domain/training_context/service/tests/builder/rendering.rs` that:
+  - `bl` exists in packed context
+  - `pc` exists in packed context
+  - `c5` exists in packed context
+  - full raw per-sample power series is not guaranteed in packed context
+  - therefore the prompt must treat `bl` + `pc` + `c5` as primary local evidence, with tools as escalation
+
+- [ ] **Step 4: Reconfirm existing prompt tests**
+  
+  Identify which current tests in `tests/llm_adapters/coaching.rs` already assert prompt text and can be extended instead of adding redundant new files.
+
+---
+
+### Task 2: Add Failing Prompt-Level Tests For Evidence Hierarchy
+
+**Files:**
+- Modify: `tests/llm_adapters/coaching.rs`
+
+- [ ] **Step 1: Add a failing test for primary evidence hierarchy**
+  
+  Add a test that asserts the built workout-summary system prompt explicitly says execution quality should be judged primarily from `bl`, `pc`, and `c5`.
+
+  Test intent:
+  ```rust
+  #[tokio::test]
+  async fn llm_workout_coach_prioritizes_bl_pc_c5_for_execution_quality() {
+      let chat_port = Arc::new(CapturingChatPort::default());
+      let coach = LlmWorkoutCoach::new(
+          chat_port.clone(),
+          Arc::new(FixedGeminiConfigProvider),
+          Arc::new(StubTrainingContextBuilder),
+          FixedClock,
+      );
+
+      coach
+          .reply("user-1", &sample_summary(), "How did I do?", None)
+          .await
+          .unwrap();
+
+      let prompt = &chat_port.requests()[0].system_prompt;
+      assert!(prompt.contains("bl"));
+      assert!(prompt.contains("pc"));
+      assert!(prompt.contains("c5"));
+      assert!(prompt.contains("primary evidence"));
+  }
+  ```
+
+- [ ] **Step 2: Add a failing test for anti-aggregate rule**
+  
+  Add a test that asserts the prompt explicitly forbids judging interval execution from aggregate metrics alone.
+
+  Test intent:
+  ```rust
+  #[tokio::test]
+  async fn llm_workout_coach_forbids_interval_judgment_from_aggregate_metrics_alone() {
+      let chat_port = Arc::new(CapturingChatPort::default());
+      let coach = LlmWorkoutCoach::new(
+          chat_port.clone(),
+          Arc::new(FixedGeminiConfigProvider),
+          Arc::new(StubTrainingContextBuilder),
+          FixedClock,
+      );
+
+      coach
+          .reply("user-1", &sample_summary(), "How did I do?", None)
+          .await
+          .unwrap();
+
+      let prompt = &chat_port.requests()[0].system_prompt;
+      assert!(prompt.contains("NP"));
+      assert!(prompt.contains("average power"));
+      assert!(prompt.contains("must not"));
+      assert!(prompt.contains("interval execution"));
+  }
+  ```
+
+- [ ] **Step 3: Add a failing test for tool escalation rule**
+  
+  Add a test that asserts the prompt tells the model to escalate to tools only when `bl`/`pc`/`c5` are insufficient.
+
+  Test intent:
+  ```rust
+  #[tokio::test]
+  async fn llm_workout_coach_uses_tools_only_when_bl_pc_c5_are_insufficient() {
+      let chat_port = Arc::new(CapturingChatPort::default());
+      let coach = LlmWorkoutCoach::new(
+          chat_port.clone(),
+          Arc::new(FixedGeminiConfigProvider),
+          Arc::new(StubTrainingContextBuilder),
+          FixedClock,
+      )
+      .with_data_port(Arc::new(crate::support::EmptySelectedWorkoutDataPort));
+
+      coach
+          .reply("user-1", &sample_summary(), "How did I do?", None)
+          .await
+          .unwrap();
+
+      let prompt = &chat_port.requests()[0].system_prompt;
+      assert!(prompt.contains("if bl, pc, and c5 are not sufficient"));
+      assert!(prompt.contains("get_selected_workout"));
+  }
+  ```
+
+- [ ] **Step 4: Run the focused adapter test file and confirm failure**
+  
+  Run:
+  ```bash
+  cargo test --test llm_adapters coaching -- --nocapture
+  ```
+  
+  Expected:
+  - new assertions fail because the prompt text does not yet contain the new rules
+  - no unrelated failures introduced
+
+---
+
+### Task 3: Harden The Workout Summary Coach Base Prompt
+
+**Files:**
+- Modify: `src/adapters/llm/workout_summary_coach.rs`
+- Test: `tests/llm_adapters/coaching.rs`
+
+- [ ] **Step 1: Update `WORKOUT_COACH_SYSTEM_PROMPT_BASE` with evidence hierarchy**
+  
+  Extend the prompt with explicit guidance like this, adapted to the repo’s existing wording and style:
+
+  ```rust
+  const WORKOUT_COACH_SYSTEM_PROMPT_BASE: &str = "You are an AI cycling coach helping an athlete reflect on one completed workout. Use the packed training context as factual background. Be direct, adult, and concise. Do not flatter, hedge, or act like a yes-man. Challenge weak reasoning when the context does not support it. Keep the conversation focused and practical rather than digressive. In your first reply after a workout, ask all follow-up questions you genuinely need at once instead of stretching them across many turns. The athlete should still feel coached, not interrogated. Ask concrete questions about the workout limiter, legs, breathing, fueling, sleep, stress, pain, readiness for the next days, and any plan constraints when relevant. Add other questions only when the workout characteristics clearly justify them. For completed interval workouts, judge execution quality primarily from the packed workout evidence: `bl` describes the intended block structure and targets, `pc` describes the executed power pattern, and `c5` is supporting cadence evidence. Compare `pc` against `bl` first when deciding whether blocks were actually hit. Use `c5` to support conclusions about control, rhythm, and stability, not as the only basis for execution quality. Treat aggregate metrics such as NP, average power, IF, VI, and TSS as secondary context for the whole session, not as sufficient proof that interval blocks were or were not executed correctly. Do not conclude that interval execution was poor only because whole-workout averages were dragged down by recovery valleys, coasting, zeros, terrain, or wind. If the packed evidence is not sufficient for a confident execution judgment, use the available workout tools to inspect higher-fidelity workout data before making a strong claim. If you already have enough information to generate the plan, say that clearly and tell the athlete to save the summary. Return your final answer as JSON only matching the workout summary coach reply schema. The summary may use markdown. Questions may be an empty array when you are ready. Do not output any text outside the JSON object. Do not invent details beyond the provided context.";
+  ```
+
+- [ ] **Step 2: Keep the change minimal**
+  
+  Do not:
+  - change `build_stable_context(...)`
+  - change `build_volatile_context(...)`
+  - change request assembly
+  - change tool-loop orchestration
+
+  Only refine prompt semantics.
+
+- [ ] **Step 3: Re-run focused prompt tests**
+  
+  Run:
+  ```bash
+  cargo test --test llm_adapters coaching -- --nocapture
+  ```
+  
+  Expected:
+  - the three new prompt tests pass
+  - existing coaching prompt tests still pass
+
+---
+
+### Task 4: Harden Tool Guidance For Workout Summary Chat
+
+**Files:**
+- Modify: `src/domain/llm_tools/mod.rs`
+- Possibly modify: `src/domain/llm_tools/get_selected_workout/mod.rs`
+- Possibly modify: `src/domain/llm_tools/selected_workout_power_curve/mod.rs`
+
+- [ ] **Step 1: Prefer the smallest correct place for the guidance change**
+  
+  First inspect whether the cleanest change is:
+  - updating the tool-specific `prompt_guidance()` strings in each tool module, or
+  - introducing a scope-specific guidance suffix inside `src/domain/llm_tools/mod.rs`
+
+  Prefer the smaller change that avoids changing tool semantics for other scopes unless needed.
+
+- [ ] **Step 2: Adjust `get_selected_workout` guidance**
+  
+  Update guidance so it explicitly matches this fallback role:
+
+  ```rust
+  Some(
+      "use for a specific date when packed workout evidence such as bl, pc, and c5 is not sufficient to judge completed-workout execution confidently; prefer this before making a strong execution claim from aggregate metrics alone",
+  )
+  ```
+
+  If this wording would incorrectly affect other scopes, instead append a `WorkoutSummaryChat`-specific sentence in `tool_prompt_guidance_for_scope(...)`.
+
+- [ ] **Step 3: Adjust `selected_workout_power_curve` guidance**
+  
+  Update guidance so it does not look like the primary tool for target-compliance judgment:
+
+  ```rust
+  Some(
+      "use after selecting a completed workout when the answer needs mean-max power or duration-specific power facts; this complements execution analysis but does not replace comparing planned blocks against packed workout evidence or higher-fidelity workout detail",
+  )
+  ```
+
+- [ ] **Step 4: Preserve generic tool behavior**
+  
+  Do not:
+  - change tool availability rules
+  - change tool schemas
+  - change execution logic
+  - change provider support rules
+
+  This task is guidance-only.
+
+- [ ] **Step 5: Add or update focused tests for guidance text**
+  
+  If existing tests already assert tool-guidance text in `src/domain/llm_tools/mod.rs`, extend them. Otherwise add a focused test asserting the generated prompt for `WorkoutSummaryChat` mentions:
+  - `get_selected_workout`
+  - insufficiency of `bl`, `pc`, `c5`
+  - not guessing from aggregate metrics
+  - `selected_workout_power_curve` as supplemental, not primary for block-hit judgment
+
+- [ ] **Step 6: Run focused tool-guidance tests**
+  
+  Run:
+  ```bash
+  cargo test llm_tools:: -- --nocapture
+  ```
+  
+  If that selector is too broad in practice, run the narrowest relevant target that covers the modified guidance assertions.
+
+  Expected:
+  - updated guidance tests pass
+  - no tool execution behavior changes
+
+---
+
+### Task 5: Run Targeted Verification For The Full Prompt Path
+
+**Files:**
+- Read-only verification across:
+  - `src/adapters/llm/workout_summary_coach.rs`
+  - `src/domain/llm_tools/mod.rs`
+  - `tests/llm_adapters/coaching.rs`
+
+- [ ] **Step 1: Run the full adapter test binary**
+  
+  Run:
+  ```bash
+  cargo test --test llm_adapters -- --nocapture
+  ```
+  
+  Expected:
+  - adapter tests pass
+  - no regressions in existing prompt/content assertions
+
+- [ ] **Step 2: Run formatting check**
+  
+  Run:
+  ```bash
+  cargo fmt --all --check
+  ```
+  
+  Expected:
+  - no formatting issues
+
+- [ ] **Step 3: Run clippy with CI flags**
+  
+  Run:
+  ```bash
+  cargo clippy --all-targets --all-features -- -D warnings
+  ```
+  
+  Expected:
+  - clean pass
+  - no lint regressions from prompt-test changes
+
+- [ ] **Step 4: Run architecture verification required by repo**
+  
+  Run:
+  ```bash
+  bun run verify:arch
+  ```
+  
+  Expected:
+  - pass
+  - confirms no architecture-boundary regression from the prompt-only change
+
+---
+
+### Task 6: Review Loop And Regression Challenge
+
+**Files:**
+- Review changed files only
+
+- [ ] **Step 1: Strict reviewer pass**
+  
+  Manually inspect for:
+  - any wording that still allows aggregate metrics to overrule `bl`/`pc`/`c5`
+  - any wording that accidentally makes tool calls mandatory every time
+  - any wording that implies `c5` alone can prove block execution
+
+- [ ] **Step 2: Very strict reviewer pass**
+  
+  Manually inspect for:
+  - accidental spillover of guidance to unrelated coach scopes
+  - contradictions between base prompt and tool guidance
+  - test wording that is too brittle to minor phrasing edits
+
+- [ ] **Step 3: Nitpicker pass**
+  
+  Manually inspect for:
+  - duplicated phrases in prompt
+  - awkward wording like “primary evidence” repeated too many times
+  - vague phrases like “better data” instead of “higher-fidelity workout data”
+
+- [ ] **Step 4: Re-run the smallest relevant verification after any review edits**
+  
+  If review changes only prompt strings:
+  ```bash
+  cargo test --test llm_adapters coaching -- --nocapture
+  ```
+  
+  If guidance text also changed:
+  ```bash
+  cargo test --test llm_adapters -- --nocapture
+  ```
+
+---
+
+### Task 7: Record The Lesson And Review History
+
+**Files:**
+- Modify: `reviewers.md`
+- Modify: `tasks/lessons.md`
+
+- [ ] **Step 1: Add a `reviewers.md` entry for this failure mode**
+  
+  Add a new top entry capturing:
+  - Source: user
+  - Scope: workout-summary coach prompt
+  - Problem: model inferred poor interval execution from whole-session aggregate metrics even though packed context contained stronger execution evidence (`bl`, `pc`, `c5`)
+  - Fix: prompt now prioritizes `bl`, `pc`, `c5` for execution judgment and uses tools only when that evidence is insufficient
+  - Prevention: before shipping any workout-analysis prompt change, verify the evidence hierarchy explicitly prefers interval/block evidence over whole-session averages
+
+- [ ] **Step 2: Add a reusable lesson to `tasks/lessons.md`**
+  
+  Add a short reusable lesson along the lines of:
+  - for interval workouts, whole-session aggregates are summary context, not proof of block execution quality
+  - if packed context contains stronger local execution signals, prompt those first
+  - tools should resolve uncertainty, not replace good primary evidence selection
+
+- [ ] **Step 3: Keep both entries concise and reusable**
+  
+  Do not mention one-off conversational details. Make them reusable for future prompt design and review.
+
+---
+
+### Task 8: Final Repo-Specific Completion Steps
+
+**Files:**
+- Regenerated: `graphify-out/**` via script
+- Optional plan notes: `docs/superpowers/plans/2026-05-22-workout-summary-coach-prompt-hardening.md`
+
+- [ ] **Step 1: Rebuild graphify after code changes**
+  
+  Run:
+  ```bash
+  ./scripts/rebuild_graphify.sh
+  ```
+  
+  Expected:
+  - graph rebuild completes successfully
+  - `graphify-out/GRAPH_REPORT.md` refreshes
+
+- [ ] **Step 2: Re-run the shortest confidence check after graph rebuild if no code changed during rebuild**
+  
+  Run:
+  ```bash
+  cargo test --test llm_adapters coaching -- --nocapture
+  ```
+  
+  Expected:
+  - still green
+
+- [ ] **Step 3: Inspect final diff**
+  
+  Run:
+  ```bash
+  git diff -- src/adapters/llm/workout_summary_coach.rs src/domain/llm_tools/mod.rs tests/llm_adapters/coaching.rs reviewers.md tasks/lessons.md
+  ```
+  
+  Expected:
+  - only prompt/guidance/tests/lessons changes
+  - no unrelated edits
+
+---
+
+### Suggested Commit Strategy
+
+Use small commits if implementing incrementally:
+
+1. `test: cover workout summary execution evidence hierarchy`
+2. `fix: prioritize packed execution signals in workout coach prompt`
+3. `docs: record prompt evidence-hierarchy lesson`
+
+If doing one commit, keep it similarly scoped:
+- `fix: harden workout summary coach execution prompt`
+
+---
+
+### Execution Notes
+
+Key implementation guardrails:
+- prefer `bl`, `pc`, `c5` as the explicit evidence hierarchy
+- keep aggregate metrics secondary by instruction, not removed from context
+- do not force tool usage for every reply
+- keep the change local and minimal
+- keep tests focused on prompt semantics, not model behavior randomness
+
+Key success criteria:
+- prompt explicitly defines `bl`/`pc`/`c5` as primary evidence for interval-workout execution quality
+- prompt explicitly rejects whole-session aggregates as sufficient proof of missed interval targets
+- prompt explicitly allows tools as escalation when packed evidence is insufficient
+- existing workout-summary JSON-output contract remains unchanged
+
+### Recommended execution mode
+
+1. Subagent-Driven (recommended): implement task-by-task with reviews between tasks.
+2. Inline Execution: execute directly in one session with checkpoints after tests and prompt/guidance changes.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,18 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-22 | user | workout-summary tool guidance evidence hierarchy
+
+- Problem: workout-summary tool guidance listed the available workout tools but did not make the evidence hierarchy explicit enough. It did not clearly say that `get_selected_workout` is the fallback when packed execution evidence (`bl`, `pc`, `c5`) is not enough for a confident judgment, and it did not clearly demote `selected_workout_power_curve` to a supplemental source for duration-specific power facts rather than the primary basis for deciding whether planned interval blocks were hit.
+- Fix: kept the change guidance-only and scoped it to `ToolScope::WorkoutSummaryChat` inside `src/domain/llm_tools/mod.rs`, adding two explicit workout-summary-only guidance lines while leaving tool schemas, tool availability, execution, and provider behavior unchanged. Added narrow source-level tests to lock the wording and guard against leaking the workout-summary evidence rules into other tool scopes.
+- Prevention: when the base prompt already carries an evidence hierarchy, mirror any tool-level clarifications in the narrowest scope that actually needs them instead of broadening generic tool guidance for every chat mode. For workout-summary guidance specifically, keep `get_selected_workout` framed as the fallback for insufficient packed evidence and keep `selected_workout_power_curve` framed as supplemental rather than interval-hit adjudication.
+
+### 2026-05-22 | user | workout-summary prompt evidence hierarchy review follow-up
+
+- Problem: the new workout-summary prompt said to use workout tools when packed evidence was insufficient even though the same prompt can be used on providers or runtime contexts without available tools, and the added evidence-hierarchy assertions duplicated nearly the same literal prompt text in both the source-file unit test and the adapter-path test.
+- Fix: changed the prompt to make higher-fidelity inspection the generic fallback and mention workout tools only when they are available, while keeping the packed-evidence hierarchy and anti-aggregate rules intact. Reduced test brittleness by keeping the detailed prompt-contract assertions in the source-file unit test and leaving the adapter-path test with representative assertions that prove the outbound request still carries the contract.
+- Prevention: when adding prompt instructions about optional capabilities like tools, verify the prompt text stays true for providers and runtime paths where that capability is unavailable. For prompt regressions, avoid copying the full literal contract into multiple layers of tests; keep the exact wording checks closest to prompt construction and use lighter transport-path assertions elsewhere.
+
 ### 2026-05-15 | user | workout-summary polls schemars follow-up
 
 - Problem: Workout-summary poll feedback left three review risks: `CoachQuestionnaire.tsx` carried the whole questionnaire UI in one component, the workout-summary coach prompt duplicated a hand-written JSON reply contract instead of deriving it from the Rust shape being deserialized, and the parser treated plain-text LLM replies as invalid instead of preserving a usable coach reply without questionnaire questions.

--- a/src/adapters/llm/workout_summary_coach.rs
+++ b/src/adapters/llm/workout_summary_coach.rs
@@ -245,7 +245,7 @@ where
     }
 }
 
-const WORKOUT_COACH_SYSTEM_PROMPT_BASE: &str = "You are an AI cycling coach helping an athlete reflect on one completed workout. Use the packed training context as factual background. Be direct, adult, and concise. Do not flatter, hedge, or act like a yes-man. Challenge weak reasoning when the context does not support it. Keep the conversation focused and practical rather than digressive. In your first reply after a workout, ask all follow-up questions you genuinely need at once instead of stretching them across many turns. The athlete should still feel coached, not interrogated. Ask concrete questions about the workout limiter, legs, breathing, fueling, sleep, stress, pain, readiness for the next days, and any plan constraints when relevant. Add other questions only when the workout characteristics clearly justify them. You may also ask about nutrition, race strategy, or the desired direction of the next 14 days when that would materially improve the next plan. If you already have enough information to generate the plan, say that clearly and tell the athlete to save the summary. Return your final answer as JSON only matching the workout summary coach reply schema. The summary may use markdown. Questions may be an empty array when you are ready. Do not output any text outside the JSON object. Do not invent details beyond the provided context.";
+const WORKOUT_COACH_SYSTEM_PROMPT_BASE: &str = "You are an AI cycling coach helping an athlete reflect on one completed workout. Use the packed training context as factual background. Be direct, adult, and concise. Do not flatter, hedge, or act like a yes-man. Challenge weak reasoning when the context does not support it. Keep the conversation focused and practical rather than digressive. In your first reply after a workout, ask all follow-up questions you genuinely need at once instead of stretching them across many turns. The athlete should still feel coached, not interrogated. Ask concrete questions about the workout limiter, legs, breathing, fueling, sleep, stress, pain, readiness for the next days, and any plan constraints when relevant. Add other questions only when the workout characteristics clearly justify them. You may also ask about nutrition, race strategy, or the desired direction of the next 14 days when that would materially improve the next plan. For completed interval workouts, judge execution quality primarily from packed workout evidence: bl as intended block structure/targets, pc as executed power pattern, and c5 as supporting cadence evidence. Aggregate metrics like NP, average power, IF, VI, and TSS are secondary context only and are not sufficient proof that interval blocks were or were not executed correctly. Do not conclude poor interval execution just because whole-workout averages were lowered by recovery valleys, coasting, zeros, terrain, or wind. If the packed evidence is insufficient for a confident execution judgment, inspect higher-fidelity data before making a strong claim. When workout tools are available, use them for that fallback. If you already have enough information to generate the plan, say that clearly and tell the athlete to save the summary. Return your final answer as JSON only matching the workout summary coach reply schema. The summary may use markdown. Questions may be an empty array when you are ready. Do not output any text outside the JSON object. Do not invent details beyond the provided context.";
 
 fn build_stable_context(
     summary: &WorkoutSummary,
@@ -340,6 +340,25 @@ mod tests {
         assert!(prompt.contains(r#""questions""#));
         assert!(prompt.contains(r#""freeTextLabel""#));
         assert!(prompt.contains(r#""additionalProperties": false"#));
+        assert!(prompt.contains(
+            "For completed interval workouts, judge execution quality primarily from packed workout evidence"
+        ));
+        assert!(prompt.contains("bl as intended block structure/targets"));
+        assert!(prompt.contains("pc as executed power pattern"));
+        assert!(prompt.contains("c5 as supporting cadence evidence"));
+        assert!(prompt.contains(
+            "Aggregate metrics like NP, average power, IF, VI, and TSS are secondary context only"
+        ));
+        assert!(prompt.contains(
+            "are not sufficient proof that interval blocks were or were not executed correctly"
+        ));
+        assert!(prompt.contains(
+            "Do not conclude poor interval execution just because whole-workout averages were lowered by recovery valleys, coasting, zeros, terrain, or wind"
+        ));
+        assert!(prompt.contains("When workout tools are available, use them for that fallback"));
+        assert!(!prompt.contains(
+            "If the packed evidence is insufficient for a confident execution judgment, use the available workout tools to inspect higher-fidelity data before making a strong claim"
+        ));
     }
 
     #[test]

--- a/src/domain/llm_tools/mod.rs
+++ b/src/domain/llm_tools/mod.rs
@@ -541,13 +541,20 @@ fn tool_prompt_guidance_for_scope(
     provider: &LlmProvider,
     tool_context: &ToolExecutionContext,
 ) -> String {
-    let guidance_lines: Vec<String> = available_tools_for_scope(scope, provider, tool_context)
+    let available_tools = available_tools_for_scope(scope, provider, tool_context);
+    let available_tool_names = available_tools
+        .iter()
+        .map(|tool| tool.name())
+        .collect::<Vec<_>>();
+    let mut guidance_lines: Vec<String> = available_tools
         .into_iter()
         .filter_map(|tool| {
             tool.prompt_guidance()
                 .map(|guidance| format!("- `{}`: {guidance}", tool.name()))
         })
         .collect();
+
+    guidance_lines.extend(scope_specific_tool_guidance(scope, &available_tool_names));
 
     if guidance_lines.is_empty() {
         return String::new();
@@ -557,6 +564,39 @@ fn tool_prompt_guidance_for_scope(
         "Tool usage guidance: when a tool can provide more specific or up-to-date facts than the packed context, call it instead of guessing. Use these tools deliberately:\n{}",
         guidance_lines.join("\n")
     )
+}
+
+fn scope_specific_tool_guidance(
+    scope: ToolScope,
+    available_tool_names: &[&'static str],
+) -> Vec<String> {
+    if scope != ToolScope::WorkoutSummaryChat {
+        return Vec::new();
+    }
+
+    let mut guidance = Vec::new();
+    let selected_workout_tool_name = GetSelectedWorkout.name();
+    let power_curve_tool_name = SelectedWorkoutPowerCurve.name();
+    let has_selected_workout = available_tool_names.contains(&selected_workout_tool_name);
+    let has_power_curve = available_tool_names.contains(&power_curve_tool_name);
+
+    if has_selected_workout {
+        guidance.push(
+            format!(
+                "- For workout-summary execution judgments, `{selected_workout_tool_name}` is the fallback when packed evidence like bl, pc, and c5 is insufficient for a confident call."
+            ),
+        );
+    }
+
+    if has_power_curve {
+        guidance.push(
+            format!(
+                "- `{power_curve_tool_name}` is supplemental for duration-specific power facts and not the primary basis for deciding whether planned interval blocks were hit."
+            ),
+        );
+    }
+
+    guidance
 }
 
 fn provider_supports_tools(provider: &LlmProvider) -> bool {
@@ -684,6 +724,49 @@ mod tests {
     }
 
     #[test]
+    fn workout_summary_prompt_guidance_prioritizes_selected_workout_over_power_curve_for_execution_judgment(
+    ) {
+        let prompt = with_tool_prompt_guidance(
+            "Base prompt.",
+            ToolScope::WorkoutSummaryChat,
+            &LlmProvider::OpenAi,
+            &sample_tool_context(true),
+        );
+
+        let selected_workout_line = prompt_line_containing(&prompt, "`get_selected_workout`")
+            .expect("workout-summary prompt should include selected-workout fallback guidance");
+        let power_curve_line = prompt_line_containing(&prompt, "`selected_workout_power_curve`")
+            .expect("workout-summary prompt should include power-curve guidance");
+
+        assert!(prompt.contains("Tool usage guidance"));
+        assert!(prompt.contains("workout-summary execution judgments"));
+        assert!(selected_workout_line.contains("fallback"));
+        assert!(selected_workout_line.contains("bl, pc, and c5"));
+        assert!(selected_workout_line.contains("insufficient"));
+        assert!(power_curve_line.contains("supplemental"));
+        assert!(power_curve_line.contains("duration-specific power facts"));
+        assert!(power_curve_line.contains("not the primary basis"));
+    }
+
+    #[test]
+    fn calendar_coach_prompt_guidance_does_not_include_workout_summary_specific_evidence_rules() {
+        let prompt = with_tool_prompt_guidance(
+            "Base prompt.",
+            ToolScope::CalendarCoachChat,
+            &LlmProvider::OpenAi,
+            &sample_tool_context(true),
+        );
+
+        assert!(!prompt.contains("For workout-summary execution judgments"));
+        assert!(prompt_line_containing(&prompt, "`get_selected_workout`")
+            .is_some_and(|line| !line.contains("fallback")));
+        assert!(
+            prompt_line_containing(&prompt, "`selected_workout_power_curve`")
+                .is_some_and(|line| !line.contains("supplemental"))
+        );
+    }
+
+    #[test]
     fn tool_loop_rejects_runtime_calls_for_tools_not_available_in_scope() {
         let response = futures::executor::block_on(run_tool_loop(
             Arc::new(SingleResponseLlmChatPort::tool_call("get_selected_workout")),
@@ -725,6 +808,10 @@ mod tests {
             }),
             planned_workout_update_port: None,
         }
+    }
+
+    fn prompt_line_containing<'a>(prompt: &'a str, needle: &str) -> Option<&'a str> {
+        prompt.lines().find(|line| line.contains(needle))
     }
 
     #[derive(Clone)]

--- a/src/domain/llm_tools/mod.rs
+++ b/src/domain/llm_tools/mod.rs
@@ -733,9 +733,18 @@ mod tests {
             &sample_tool_context(true),
         );
 
-        let selected_workout_line = prompt_line_containing(&prompt, "`get_selected_workout`")
+        let selected_workout_line = prompt
+            .lines()
+            .find(|line| {
+                line.contains("`get_selected_workout`")
+                    && line.contains("workout-summary execution judgments")
+            })
             .expect("workout-summary prompt should include selected-workout fallback guidance");
-        let power_curve_line = prompt_line_containing(&prompt, "`selected_workout_power_curve`")
+        let power_curve_line = prompt
+            .lines()
+            .find(|line| {
+                line.contains("`selected_workout_power_curve`") && line.contains("supplemental")
+            })
             .expect("workout-summary prompt should include power-curve guidance");
 
         assert!(prompt.contains("Tool usage guidance"));
@@ -758,12 +767,13 @@ mod tests {
         );
 
         assert!(!prompt.contains("For workout-summary execution judgments"));
-        assert!(prompt_line_containing(&prompt, "`get_selected_workout`")
-            .is_some_and(|line| !line.contains("fallback")));
-        assert!(
-            prompt_line_containing(&prompt, "`selected_workout_power_curve`")
-                .is_some_and(|line| !line.contains("supplemental"))
-        );
+        assert!(!prompt.lines().any(|line| {
+            line.contains("`get_selected_workout`")
+                && line.contains("workout-summary execution judgments")
+        }));
+        assert!(!prompt.lines().any(|line| {
+            line.contains("`selected_workout_power_curve`") && line.contains("supplemental")
+        }));
     }
 
     #[test]
@@ -808,10 +818,6 @@ mod tests {
             }),
             planned_workout_update_port: None,
         }
-    }
-
-    fn prompt_line_containing<'a>(prompt: &'a str, needle: &str) -> Option<&'a str> {
-        prompt.lines().find(|line| line.contains(needle))
     }
 
     #[derive(Clone)]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -56,6 +56,10 @@
 
 ## Small Review Fixes
 
+- For scope-specific tool guidance, do not key follow-up logic off duplicated raw tool-name string literals if the tool types are already in scope. Derive the names from the tool implementations so guidance stays aligned with future rename-safe changes.
+- Prompt-guidance tests should assert the contract at the line or phrase level, not full sentence literals, when wording can legitimately tighten during review. Keep the assertions strong enough to prove fallback-vs-supplemental semantics without pinning every connective word.
+- For prompt contracts shared across tool-capable and no-tool providers, do not write unconditional instructions like "use workout tools" into the base prompt. Phrase the fallback generically first, then mention tools only when available so the prompt stays true in Gemini/no-data-port paths too.
+- When testing prompt wording, keep the exact literal contract assertions in one place near prompt construction and use only representative transport-path assertions elsewhere. Duplicating every sentence across unit and adapter tests makes review-driven wording changes noisy and brittle.
 - When extracting a shared retry helper for a read-merge-write flow, keep the entire retryable attempt inside the retry closure, including the fresh read. If `load_latest()` lives outside the retry loop, transient read failures will bypass the intended retry/backoff semantics and the helper no longer matches its callers' optimistic-retry contract.
 - For recovery-critical LLM tool-loop checkpoints, verify three separate boundaries: the terminal state is checkpointed before returning, checkpoint failure prevents a false success, and recovery from the checkpoint avoids a second provider call.
 - When restoring untracked files from `git stash -u`, use the stash's untracked parent (`stash@{n}^3`) and verify the restored file is non-empty before moving on.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -56,6 +56,7 @@
 
 ## Small Review Fixes
 
+- When prompt guidance includes both a generic tool-description line and a scope-specific line for the same tool, tests must target the scope-specific discriminator too. Matching the first line that mentions the tool name will often grab the generic guidance and produce a false failure.
 - For scope-specific tool guidance, do not key follow-up logic off duplicated raw tool-name string literals if the tool types are already in scope. Derive the names from the tool implementations so guidance stays aligned with future rename-safe changes.
 - Prompt-guidance tests should assert the contract at the line or phrase level, not full sentence literals, when wording can legitimately tighten during review. Keep the assertions strong enough to prove fallback-vs-supplemental semantics without pinning every connective word.
 - For prompt contracts shared across tool-capable and no-tool providers, do not write unconditional instructions like "use workout tools" into the base prompt. Phrase the fallback generically first, then mention tools only when available so the prompt stays true in Gemini/no-data-port paths too.

--- a/tests/llm_adapters/coaching.rs
+++ b/tests/llm_adapters/coaching.rs
@@ -145,6 +145,12 @@ async fn llm_workout_coach_describes_power_compression_in_system_prompt() {
     assert!(requests[0]
         .system_prompt
         .contains("c5=cadence values in 5-second buckets"));
+    assert!(requests[0].system_prompt.contains(
+        "For completed interval workouts, judge execution quality primarily from packed workout evidence"
+    ));
+    assert!(requests[0].system_prompt.contains(
+        "Aggregate metrics like NP, average power, IF, VI, and TSS are secondary context only and are not sufficient proof"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
fix: harden workout summary coach evidence hierarchy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workout coach gives clearer, more accurate judgments of interval execution using packed workout evidence and treats aggregate session metrics as secondary.
  * Better fallback behavior when workout tools or specific data are unavailable; tool guidance adapts to available capabilities.

* **Documentation**
  * Added plan and team guidance for hardening coach prompts and prompt-testing practices.

* **Tests**
  * Extended tests to assert new coaching guidance and fallback wording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->