### PR TITLE
fix: resolve workout summary external id aliases

### DIFF
--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-27 | user | completed workout summary alias lookup after regeneration/edit
+
+- Problem: the completed-workout detail modal loads recap text through `GET /api/completed-workouts/{activity_id}/summary`, which passes an activity-scoped id like `i151959404` into workout-summary resolution. For the 2026-05-27 ride, the workout summary document persisted the recap under the Wahoo/external alias `459893292`, while the completed-workout target resolver exposed only the preferred/source activity id plus the canonical completed-workout id. That left the real external alias out of `equivalent_workout_ids`, so recap reads could return `404` even though Mongo still contained `workout_recap_text`.
+- Fix: updated `CompletedWorkoutTargetAdapter` to include `CompletedWorkout.external_id` in `ResolvedCompletedWorkoutTarget.equivalent_workout_ids`, and added a focused adapter regression that resolves an Intervals activity id to the source id, canonical completed-workout id, and external id alias together.
+- Prevention: when workout-summary lookup depends on completed-workout alias resolution, include every persisted identity that can legitimately key the same workout summary document, not only the preferred/source id and canonical completed-workout id. For imported completed workouts that may exist in both Intervals and Wahoo forms, verify recap reads from one provider id still find summaries saved under the other provider's alias.
+
 ### 2026-05-27 | Copilot | PR #253 training plan repair retry narrowing
 
 - Problem: the first JSON-envelope repair implementation retried on every `invalid training plan llm json` failure, which was too broad because it also covered semantically invalid envelopes such as missing `plan` or wrong field types. The repair prompt also embedded the previous assistant content inside triple-backtick fences, which could corrupt the prompt when the original provider reply itself contained triple backticks.

--- a/src/adapters/workout_summary_completed_target.rs
+++ b/src/adapters/workout_summary_completed_target.rs
@@ -56,6 +56,11 @@ where
                         if !equivalent_workout_ids.contains(&completed_workout_id) {
                             equivalent_workout_ids.push(completed_workout_id);
                         }
+                        if let Some(external_id) = workout.external_id {
+                            if !equivalent_workout_ids.contains(&external_id) {
+                                equivalent_workout_ids.push(external_id);
+                            }
+                        }
 
                         ResolvedCompletedWorkoutTarget {
                             preferred_workout_id,
@@ -88,5 +93,140 @@ where
             .await
             .map_err(|error| WorkoutSummaryError::Repository(error.to_string())),
         Err(error) => Err(WorkoutSummaryError::Repository(error.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompletedWorkoutTargetAdapter;
+    use crate::domain::{
+        completed_workouts::{
+            BoxFuture as CompletedWorkoutBoxFuture, CompletedWorkout, CompletedWorkoutDetails,
+            CompletedWorkoutError, CompletedWorkoutMetrics, CompletedWorkoutRepository,
+        },
+        workout_summary::CompletedWorkoutTargetUseCases,
+    };
+
+    #[derive(Clone)]
+    struct StubCompletedWorkoutRepository {
+        workout: CompletedWorkout,
+    }
+
+    impl CompletedWorkoutRepository for StubCompletedWorkoutRepository {
+        fn find_by_user_id_and_completed_workout_id(
+            &self,
+            user_id: &str,
+            completed_workout_id: &str,
+        ) -> CompletedWorkoutBoxFuture<Result<Option<CompletedWorkout>, CompletedWorkoutError>>
+        {
+            let workout = self.workout.clone();
+            let user_id = user_id.to_string();
+            let completed_workout_id = completed_workout_id.to_string();
+            Box::pin(async move {
+                Ok((workout.user_id == user_id
+                    && workout.completed_workout_id == completed_workout_id)
+                    .then_some(workout))
+            })
+        }
+
+        fn find_by_user_id_and_source_activity_id(
+            &self,
+            user_id: &str,
+            source_activity_id: &str,
+        ) -> CompletedWorkoutBoxFuture<Result<Option<CompletedWorkout>, CompletedWorkoutError>>
+        {
+            let workout = self.workout.clone();
+            let user_id = user_id.to_string();
+            let source_activity_id = source_activity_id.to_string();
+            Box::pin(async move {
+                Ok((workout.user_id == user_id
+                    && workout.source_activity_id.as_deref() == Some(source_activity_id.as_str()))
+                .then_some(workout))
+            })
+        }
+
+        fn find_latest_by_user_id(
+            &self,
+            _user_id: &str,
+        ) -> CompletedWorkoutBoxFuture<Result<Option<CompletedWorkout>, CompletedWorkoutError>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn list_by_user_id(
+            &self,
+            _user_id: &str,
+        ) -> CompletedWorkoutBoxFuture<Result<Vec<CompletedWorkout>, CompletedWorkoutError>>
+        {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn list_by_user_id_and_date_range(
+            &self,
+            _user_id: &str,
+            _oldest: &str,
+            _newest: &str,
+        ) -> CompletedWorkoutBoxFuture<Result<Vec<CompletedWorkout>, CompletedWorkoutError>>
+        {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn upsert(
+            &self,
+            workout: CompletedWorkout,
+        ) -> CompletedWorkoutBoxFuture<Result<CompletedWorkout, CompletedWorkoutError>> {
+            Box::pin(async move { Ok(workout) })
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_completed_workout_target_includes_external_id_alias() {
+        let repository = StubCompletedWorkoutRepository {
+            workout: CompletedWorkout {
+                completed_workout_id: "wahoo-workout:459893292".to_string(),
+                user_id: "user-1".to_string(),
+                start_date_local: "2026-05-27T13:10:35.000Z".to_string(),
+                source_activity_id: Some("i151959404".to_string()),
+                planned_workout_id: None,
+                name: Some("Aerobic Endurance".to_string()),
+                description: None,
+                activity_type: Some("Ride".to_string()),
+                external_id: Some("459893292".to_string()),
+                trainer: false,
+                duration_seconds: Some(5283),
+                distance_meters: Some(44_718.45),
+                metrics: CompletedWorkoutMetrics::default(),
+                details: CompletedWorkoutDetails {
+                    intervals: Vec::new(),
+                    interval_groups: Vec::new(),
+                    streams: Vec::new(),
+                    interval_summary: Vec::new(),
+                    skyline_chart: Vec::new(),
+                    power_zone_times: Vec::new(),
+                    heart_rate_zone_times: Vec::new(),
+                    pace_zone_times: Vec::new(),
+                    gap_zone_times: Vec::new(),
+                },
+                details_unavailable_reason: None,
+                power_curve_5s: None,
+            },
+        };
+        let adapter = CompletedWorkoutTargetAdapter::new(repository);
+
+        let resolved = adapter
+            .resolve_completed_workout_target("user-1", "i151959404")
+            .await
+            .expect("resolver should succeed")
+            .expect("target should resolve");
+
+        assert_eq!(resolved.preferred_workout_id, "i151959404");
+        assert_eq!(
+            resolved.equivalent_workout_ids,
+            vec![
+                "i151959404".to_string(),
+                "wahoo-workout:459893292".to_string(),
+                "459893292".to_string(),
+            ]
+        );
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,11 @@
 # Lessons
 
+## 2026-05-27 - Completed workout alias sets must include provider external ids
+
+- If workout summaries are looked up from completed-workout ids coming from the UI, the alias set cannot stop at `source_activity_id` plus canonical completed-workout id. For imported workouts that exist in both Intervals and Wahoo identity spaces, the persisted summary may still be keyed by the provider external id.
+- Before concluding that a recap was deleted, inspect the live `workout_summaries` document and compare it against the exact id sent by the frontend summary endpoint. A missing recap in the UI can be a read-side alias gap even when Mongo still has `workout_recap_text`.
+- Reproduction for this class of bug should include dual identities for the same day/workout, for example one `intervals-activity:*` record and one `wahoo-workout:*`/external-id alias, then assert that reads from one id still find summaries persisted under the other.
+
 ## 2026-05-27 - LLM JSON envelope parsers must tolerate provider presentation noise
 
 - When a prompt asks for JSON, models may still wrap valid JSON in markdown fences, surround it with explanatory prose, or append harmless top-level metadata. Parser regressions should use the exact logged assistant content shape, not only ideal payloads.


### PR DESCRIPTION
## Summary
Fix completed-workout workout-summary lookup when the UI requests recap data by one provider activity id but the persisted workout summary is keyed by another provider alias for the same completed workout.

## What changed
- include  in workout-summary completed-target alias resolution
- add a focused adapter regression for Intervals activity id -> external id alias resolution
- record the bugfix in  and 

## Verification
- 
running 1 test
test adapters::workout_summary_completed_target::tests::resolve_completed_workout_target_includes_external_id_alias ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 788 filtered out; finished in 0.02s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 55 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 29 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 81 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 42 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 26 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 71 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 37 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 75 filtered out; finished in 0.00s
- 
running 4 tests
test completed_workouts::get_completed_workout_summary_returns_404_when_summary_is_missing ... ok
test completed_workouts::get_completed_workout_summary_returns_404_for_other_users_workout ... ok
test completed_workouts::get_completed_workout_summary_returns_404_when_recap_text_is_missing ... ok
test completed_workouts::get_completed_workout_summary_returns_recap_for_authenticated_user ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 77 filtered out; finished in 0.03s
- 
- 
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed completed workout summaries returning 404 errors due to incomplete workout identity resolution during lookups.

## Documentation
* Added documentation on workout identity resolution best practices for imported workouts across different providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->