### PR TITLE
fix: limit AI Coach workout summary fetch range

### DIFF
--- a/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
+++ b/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
@@ -172,6 +172,7 @@ describe('useWorkoutList', () => {
     expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
     expect(result.current.items).toHaveLength(2);
     expect(result.current.items[0]?.hasConversation).toBe(true);
+    expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-101', 'activity-102']);
   });
 
   it('keeps activities whose matched event has an unknown category', async () => {
@@ -234,6 +235,11 @@ describe('useWorkoutList', () => {
 
     expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
     expect(result.current.items).toHaveLength(6);
+    expect(listWorkoutSummaries).toHaveBeenNthCalledWith(
+      1,
+      '',
+      ['activity-200', 'activity-201', 'activity-202', 'activity-203', 'activity-204', 'activity-205'],
+    );
 
     act(() => {
       result.current.goToOlderWeek();
@@ -246,6 +252,21 @@ describe('useWorkoutList', () => {
     expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 16), new Date(2026, 2, 22)));
     expect(result.current.items[0]?.event?.name).toBe('Workout 7');
     expect(result.current.canGoToNewerWeek).toBe(true);
+    expect(listWorkoutSummaries).toHaveBeenNthCalledWith(
+      2,
+      '',
+      ['activity-206', 'activity-207', 'activity-208', 'activity-209'],
+    );
+
+    act(() => {
+      result.current.goToNewerWeek();
+    });
+
+    await waitFor(() => {
+      expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
+    });
+
+    expect(listWorkoutSummaries).toHaveBeenCalledTimes(2);
   });
 
   it('matches hinted activities to their event without leaving duplicates behind', async () => {
@@ -519,6 +540,60 @@ describe('useWorkoutList', () => {
     expect(result.current.items[0]?.id).toBe('activity-990');
     expect(result.current.items[0]?.summary?.workoutId).toBe('activity-990');
     expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-990']);
+  });
+
+  it('loads summaries only for the currently visible week', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-26T12:00:00Z'));
+
+    try {
+      vi.mocked(listEvents).mockResolvedValue([
+        {
+          ...eventFixture,
+          id: 701,
+          startDateLocal: '2026-03-30T09:00:00',
+          name: 'Next Week Ride',
+        },
+        {
+          ...eventFixture,
+          id: 702,
+          startDateLocal: '2026-03-24T09:00:00',
+          name: 'Current Week Ride',
+        },
+      ]);
+      vi.mocked(listActivities).mockResolvedValue([
+        {
+          ...activityFixture,
+          id: 'activity-next-week',
+          startDateLocal: '2026-03-30T09:00:00',
+          startDate: '2026-03-30T08:00:00Z',
+          name: 'Next Week Ride',
+        },
+        {
+          ...activityFixture,
+          id: 'activity-current-week',
+          startDateLocal: '2026-03-24T09:00:00',
+          startDate: '2026-03-24T08:00:00Z',
+          name: 'Current Week Ride',
+        },
+      ]);
+      vi.mocked(listWorkoutSummaries).mockResolvedValue([]);
+
+      const { result } = renderWorkoutListHook();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('ready');
+      });
+
+      expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
+      expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-current-week']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('uses an activity-only item when no related event exists', async () => {

--- a/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
+++ b/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
@@ -436,6 +436,50 @@ describe('useWorkoutList', () => {
     expect(result.current.items[0]?.hasSummary).toBe(false);
   });
 
+  it('chunks visible-week summary fetches to the backend batch limit', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-04-11T12:00:00Z'));
+
+    try {
+      const activities = Array.from({ length: 32 }, (_, index) => {
+        const day = String(11 - Math.floor(index / 8)).padStart(2, '0');
+        const hour = String(23 - (index % 8)).padStart(2, '0');
+        const id = `activity-batch-${String(index + 1).padStart(2, '0')}`;
+
+        return {
+          ...activityFixture,
+          id,
+          name: `Batch Ride ${index + 1}`,
+          startDateLocal: `2026-04-${day}T${hour}:00:00`,
+          startDate: `2026-04-${day}T${hour}:00:00Z`,
+        };
+      });
+      vi.mocked(listActivities).mockResolvedValue(activities);
+      vi.mocked(listEvents).mockResolvedValue([]);
+      vi.mocked(listWorkoutSummaries).mockResolvedValue([]);
+
+      const { result } = renderWorkoutListHook();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('ready');
+      });
+
+      expect(listWorkoutSummaries).toHaveBeenCalledTimes(2);
+      expect(listWorkoutSummaries).toHaveBeenNthCalledWith(
+        1,
+        '',
+        activities.slice(0, 31).map((activity) => activity.id),
+      );
+      expect(listWorkoutSummaries).toHaveBeenNthCalledWith(2, '', [activities[31]!.id]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('updates the matching item when a summary changes', async () => {
     vi.mocked(listActivities).mockResolvedValue([
       {
@@ -643,6 +687,7 @@ describe('useWorkoutList', () => {
 
       expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
       expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-current-week']);
+      expect(listWorkoutSummaries).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
+++ b/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
@@ -384,6 +384,58 @@ describe('useWorkoutList', () => {
     expect(listActivities).toHaveBeenCalledTimes(1);
   });
 
+  it('refresh clears stale visible-week summaries omitted by the next batch response', async () => {
+    vi.mocked(listActivities).mockResolvedValue([
+      {
+        ...activityFixture,
+        id: 'activity-refresh',
+        name: 'Refresh Ride',
+        startDateLocal: '2026-04-07T09:00:00',
+        startDate: '2026-04-07T08:00:00Z',
+      },
+    ]);
+    vi.mocked(listEvents).mockResolvedValue([
+      {
+        ...eventFixture,
+        id: 907,
+        name: 'Refresh Ride',
+        startDateLocal: '2026-04-07T09:00:00',
+      },
+    ]);
+    vi.mocked(listWorkoutSummaries)
+      .mockResolvedValueOnce([
+        {
+          id: 'summary-refresh',
+          workoutId: 'activity-refresh',
+          rpe: 5,
+          messages: [],
+          savedAtEpochSeconds: null,
+          createdAtEpochSeconds: 1,
+          updatedAtEpochSeconds: 2,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { result } = renderWorkoutListHook();
+
+    await waitFor(() => {
+      expect(result.current.state).toBe('ready');
+    });
+
+    expect(result.current.items[0]?.hasSummary).toBe(true);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe('ready');
+    });
+
+    expect(result.current.items[0]?.summary).toBeNull();
+    expect(result.current.items[0]?.hasSummary).toBe(false);
+  });
+
   it('updates the matching item when a summary changes', async () => {
     vi.mocked(listActivities).mockResolvedValue([
       {

--- a/frontend/src/features/coach/hooks/useWorkoutList.ts
+++ b/frontend/src/features/coach/hooks/useWorkoutList.ts
@@ -87,11 +87,9 @@ function inferEventIdHint(activity: IntervalActivity): string | null {
 function buildWorkoutItems(
   events: IntervalEvent[],
   activities: IntervalActivity[],
-  summaries: WorkoutSummary[],
 ): CoachWorkoutListItem[] {
   const eventsSorted = [...events].sort((left, right) => right.startDateLocal.localeCompare(left.startDateLocal));
   const activitiesSorted = [...activities].sort((left, right) => right.startDateLocal.localeCompare(left.startDateLocal));
-  const summariesById = new Map(summaries.map((summary) => [summary.workoutId, summary]));
   const activitiesByDate = new Map<string, IntervalActivity[]>();
   const eventsByDate = new Map<string, IntervalEvent[]>();
   const eventsByActualWorkoutActivityId = new Map<string, IntervalEvent[]>();
@@ -175,7 +173,6 @@ function buildWorkoutItems(
 
   const items: CoachWorkoutListItem[] = activitiesSorted.map((activity) => {
     const matchedEvent = activityEventMatches.get(activity.id) ?? null;
-    const summary = summariesById.get(activity.id) ?? null;
     const id = activity.id;
 
     return {
@@ -184,9 +181,9 @@ function buildWorkoutItems(
       startDateLocal: activity.startDateLocal,
       event: matchedEvent,
       activity,
-      summary,
-      hasSummary: summary !== null,
-      hasConversation: summary?.messages.some((message) => message.role === 'coach') ?? false,
+      summary: null,
+      hasSummary: false,
+      hasConversation: false,
     };
   });
 
@@ -195,16 +192,15 @@ function buildWorkoutItems(
       continue;
     }
 
-    const summary = summariesById.get(String(event.id)) ?? null;
     items.push({
-      id: summary?.workoutId ?? String(event.id),
+      id: String(event.id),
       source: 'event',
       startDateLocal: event.startDateLocal,
       event,
       activity: null,
-      summary,
-      hasSummary: summary !== null,
-      hasConversation: summary?.messages.some((message) => message.role === 'coach') ?? false,
+      summary: null,
+      hasSummary: false,
+      hasConversation: false,
     });
   }
 
@@ -223,36 +219,43 @@ function isWithinWeek(value: string, weekStart: Date): boolean {
   return dateKey >= weekStartKey && dateKey <= weekEndKey;
 }
 
-function applySummaryToItem(item: CoachWorkoutListItem, summary: WorkoutSummary): CoachWorkoutListItem {
-  if (item.activity) {
-    if (item.activity.id !== summary.workoutId) {
-      return item;
-    }
-
-    return {
-      ...item,
-      id: item.activity.id,
-      summary,
-      hasSummary: true,
-      hasConversation: summary.messages.some((message) => message.role === 'coach'),
-    };
-  }
-
-  const hasSummaryMatch = item.id === summary.workoutId
-    || item.summary?.workoutId === summary.workoutId
-    || String(item.event?.id ?? '') === summary.workoutId;
-
-  if (!hasSummaryMatch) {
-    return item;
-  }
-
+function withSummaryState(item: CoachWorkoutListItem, summary: WorkoutSummary | null): CoachWorkoutListItem {
   return {
     ...item,
-    id: summary.workoutId,
     summary,
-    hasSummary: true,
-    hasConversation: summary.messages.some((message) => message.role === 'coach'),
+    hasSummary: summary !== null,
+    hasConversation: summary?.messages.some((message) => message.role === 'coach') ?? false,
   };
+}
+
+function buildVisibleItems(
+  allItems: CoachWorkoutListItem[],
+  visibleWeekStart: Date,
+  summaryCache: Map<string, WorkoutSummary>,
+): CoachWorkoutListItem[] {
+  const todayDateKey = toDateKey(new Date());
+
+  return allItems
+    .filter(
+      (item) =>
+        item.source === 'activity'
+        && extractDateKey(item.startDateLocal) <= todayDateKey
+        && isWithinWeek(item.startDateLocal, visibleWeekStart),
+    )
+    .map((item) => withSummaryState(item, summaryCache.get(item.id) ?? null));
+}
+
+function mergeSummaryCache(
+  current: Map<string, WorkoutSummary>,
+  summaries: WorkoutSummary[],
+): Map<string, WorkoutSummary> {
+  const next = new Map(current);
+
+  for (const summary of summaries) {
+    next.set(summary.workoutId, summary);
+  }
+
+  return next;
 }
 
 function defaultVisibleWeekStart(items: CoachWorkoutListItem[], currentWeekStart: Date): Date {
@@ -269,12 +272,21 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   const [currentWeekStart, setCurrentWeekStart] = useState(() => getMondayOfWeek(new Date()));
   const [visibleWeekStart, setVisibleWeekStart] = useState(() => getMondayOfWeek(new Date()));
   const [allItems, setAllItems] = useState<CoachWorkoutListItem[]>([]);
-  const [items, setItems] = useState<CoachWorkoutListItem[]>([]);
+  const [summaryCache, setSummaryCache] = useState<Map<string, WorkoutSummary>>(() => new Map());
+  const [loadedSummaryIds, setLoadedSummaryIds] = useState<Set<string>>(() => new Set());
+  const [hasLoadedWorkouts, setHasLoadedWorkouts] = useState(false);
   const [state, setState] = useState<WorkoutListState>('loading');
   const [error, setError] = useState<string | null>(null);
   const currentWeekStartRef = useRef(currentWeekStart);
   const requestIdRef = useRef(0);
+  const summaryRequestIdRef = useRef(0);
   const contextErrorRef = useRef(contextError);
+
+  const items = useMemo(() => buildVisibleItems(allItems, visibleWeekStart, summaryCache), [
+    allItems,
+    visibleWeekStart,
+    summaryCache,
+  ]);
 
   useEffect(() => {
     contextErrorRef.current = contextError;
@@ -283,6 +295,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   const loadRecentWorkouts = useCallback(async () => {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    setHasLoadedWorkouts(false);
     setState('loading');
     setError(null);
 
@@ -312,17 +325,14 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
       const recentActivities = [...activities]
         .sort((left, right) => right.startDateLocal.localeCompare(left.startDateLocal))
         .slice(0, WORKOUT_LOOKBACK_WEEKS * WORKOUT_PAGE_SIZE);
-      const summaries = await listWorkoutSummaries(
-        apiBaseUrl,
-        recentActivities.map((activity) => activity.id),
-      );
-      const nextItems = buildWorkoutItems(workoutEvents, recentActivities, summaries);
+      const nextItems = buildWorkoutItems(workoutEvents, recentActivities);
 
       if (requestId !== requestIdRef.current) {
         return;
       }
 
       setAllItems(nextItems);
+      setLoadedSummaryIds(new Set());
       const nextVisibleWeekStart = defaultVisibleWeekStart(nextItems, latestCurrentWeekStart);
       const previousCurrentWeekStart = currentWeekStartRef.current;
       currentWeekStartRef.current = latestCurrentWeekStart;
@@ -334,7 +344,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
 
         return current;
       });
-      setState('ready');
+      setHasLoadedWorkouts(true);
     } catch (loadError) {
       if (requestId !== requestIdRef.current) {
         return;
@@ -360,16 +370,70 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   }, [loadRecentWorkouts]);
 
   useEffect(() => {
-    const todayDateKey = toDateKey(new Date());
-    setItems(
-      allItems.filter(
-        (item) =>
-          item.source === 'activity'
-          && extractDateKey(item.startDateLocal) <= todayDateKey
-          && isWithinWeek(item.startDateLocal, visibleWeekStart),
-      ),
-    );
-  }, [allItems, visibleWeekStart]);
+    if (!hasLoadedWorkouts) {
+      return;
+    }
+
+    const summaryTargetIds = items.map((item) => item.id);
+
+    if (summaryTargetIds.length === 0) {
+      setState('ready');
+      setError(null);
+      return;
+    }
+
+    const missingSummaryIds = summaryTargetIds.filter((workoutId) => !loadedSummaryIds.has(workoutId));
+
+    if (missingSummaryIds.length === 0) {
+      setState('ready');
+      setError(null);
+      return;
+    }
+
+    const requestId = summaryRequestIdRef.current + 1;
+    summaryRequestIdRef.current = requestId;
+    setState('loading');
+    setError(null);
+
+    void (async () => {
+      try {
+        const summaries = await listWorkoutSummaries(apiBaseUrl, missingSummaryIds);
+
+        if (requestId !== summaryRequestIdRef.current) {
+          return;
+        }
+
+        setSummaryCache((current) => mergeSummaryCache(current, summaries));
+        setLoadedSummaryIds((current) => {
+          const next = new Set(current);
+
+          for (const workoutId of missingSummaryIds) {
+            next.add(workoutId);
+          }
+
+          return next;
+        });
+        setState('ready');
+      } catch (loadError) {
+        if (requestId !== summaryRequestIdRef.current) {
+          return;
+        }
+
+        if (loadError instanceof AuthenticationError) {
+          window.location.href = '/';
+          return;
+        }
+
+        if (loadError instanceof HttpError && loadError.status === 422) {
+          setState('credentials-required');
+          return;
+        }
+
+        setState('error');
+        setError(loadError instanceof Error ? loadError.message : 'Unknown error');
+      }
+    })();
+  }, [apiBaseUrl, hasLoadedWorkouts, items, loadedSummaryIds]);
 
   const weekLabel = useMemo(() => {
     return formatRangeLabel(visibleWeekStart, addDays(visibleWeekStart, 6));
@@ -377,7 +441,12 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   const canGoToNewerWeek = visibleWeekStart < currentWeekStart;
 
   const replaceSummary = useCallback((summary: WorkoutSummary) => {
-    setAllItems((current) => current.map((item) => applySummaryToItem(item, summary)));
+    setSummaryCache((current) => mergeSummaryCache(current, [summary]));
+    setLoadedSummaryIds((current) => {
+      const next = new Set(current);
+      next.add(summary.workoutId);
+      return next;
+    });
   }, []);
 
   return {

--- a/frontend/src/features/coach/hooks/useWorkoutList.ts
+++ b/frontend/src/features/coach/hooks/useWorkoutList.ts
@@ -12,6 +12,7 @@ export type WorkoutListState = 'loading' | 'ready' | 'error' | 'credentials-requ
 
 const WORKOUT_PAGE_SIZE = 7;
 const WORKOUT_LOOKBACK_WEEKS = 12;
+const MAX_SUMMARY_BATCH_SIZE = 31;
 
 type UseWorkoutListOptions = {
   apiBaseUrl: string;
@@ -276,6 +277,16 @@ function replaceRequestedSummaries(
   return next;
 }
 
+function chunkWorkoutIds(workoutIds: string[]): string[][] {
+  const chunks: string[][] = [];
+
+  for (let index = 0; index < workoutIds.length; index += MAX_SUMMARY_BATCH_SIZE) {
+    chunks.push(workoutIds.slice(index, index + MAX_SUMMARY_BATCH_SIZE));
+  }
+
+  return chunks;
+}
+
 function defaultVisibleWeekStart(items: CoachWorkoutListItem[], currentWeekStart: Date): Date {
   if (items.some((item) => isWithinWeek(item.startDateLocal, currentWeekStart))) {
     return currentWeekStart;
@@ -416,7 +427,11 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
 
     void (async () => {
       try {
-        const summaries = await listWorkoutSummaries(apiBaseUrl, missingSummaryIds);
+        const summaries = (
+          await Promise.all(
+            chunkWorkoutIds(missingSummaryIds).map((workoutIds) => listWorkoutSummaries(apiBaseUrl, workoutIds)),
+          )
+        ).flat();
 
         if (requestId !== summaryRequestIdRef.current) {
           return;

--- a/frontend/src/features/coach/hooks/useWorkoutList.ts
+++ b/frontend/src/features/coach/hooks/useWorkoutList.ts
@@ -258,6 +258,24 @@ function mergeSummaryCache(
   return next;
 }
 
+function replaceRequestedSummaries(
+  current: Map<string, WorkoutSummary>,
+  requestedWorkoutIds: string[],
+  summaries: WorkoutSummary[],
+): Map<string, WorkoutSummary> {
+  const next = new Map(current);
+
+  for (const workoutId of requestedWorkoutIds) {
+    next.delete(workoutId);
+  }
+
+  for (const summary of summaries) {
+    next.set(summary.workoutId, summary);
+  }
+
+  return next;
+}
+
 function defaultVisibleWeekStart(items: CoachWorkoutListItem[], currentWeekStart: Date): Date {
   if (items.some((item) => isWithinWeek(item.startDateLocal, currentWeekStart))) {
     return currentWeekStart;
@@ -295,6 +313,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   const loadRecentWorkouts = useCallback(async () => {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    summaryRequestIdRef.current += 1;
     setHasLoadedWorkouts(false);
     setState('loading');
     setError(null);
@@ -403,7 +422,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
           return;
         }
 
-        setSummaryCache((current) => mergeSummaryCache(current, summaries));
+        setSummaryCache((current) => replaceRequestedSummaries(current, missingSummaryIds, summaries));
         setLoadedSummaryIds((current) => {
           const next = new Set(current);
 

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-28 | user + Copilot + CodeRabbit | PR #257 AI Coach weekly summary review follow-up
+
+- Problem: the first weekly-summary-range fix still had three review gaps: the frontend sent all visible-week ids in one request even though the backend now rejects batches above 31 ids, the visible-week regression test did not assert exclusivity and could still pass with an extra hidden fetch, and the backend error message hardcoded `31` instead of deriving it from the limit constant.
+- Fix: chunked visible-week summary fetches into `31`-id batches in `useWorkoutList`, added a focused frontend regression that exercises a dense 32-activity week plus a one-call assertion in the visible-week test, and changed the REST handler error payload to use a `String` so the max-id message is formatted from `MAX_LIST_SUMMARIES_WORKOUT_IDS`.
+- Prevention: whenever a backend endpoint gains a hard batch cap, audit all client call sites to batch to the same limit and add one regression that exceeds the cap from the client side. In tests that are meant to prove scope narrowing, assert call count as well as argument shape, and avoid hardcoding limit values in user-facing error strings when a local constant already defines the contract.
+
 ### 2026-05-28 | user | AI Coach weekly workout-summary range and batch limit
 
 - Problem: the AI Coach sidebar shows one visible week at a time, but `useWorkoutList` eagerly fetched workout summaries for a 12-week lookback window (`12 * 7 = 84` activities) on initial load. That widened `/api/workout-summaries` far beyond the visible date range and amplified an already expensive backend alias-resolution path, leading to timeout-prone `524` failures and an empty AI Coach tab.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-28 | user | AI Coach weekly workout-summary range and batch limit
+
+- Problem: the AI Coach sidebar shows one visible week at a time, but `useWorkoutList` eagerly fetched workout summaries for a 12-week lookback window (`12 * 7 = 84` activities) on initial load. That widened `/api/workout-summaries` far beyond the visible date range and amplified an already expensive backend alias-resolution path, leading to timeout-prone `524` failures and an empty AI Coach tab.
+- Fix: changed the frontend hook to fetch summary state only for workouts in the currently visible week, cache already loaded summaries by `workoutId`, and reuse that cache when paging back to previously visited weeks. Added frontend regressions for visible-week-only fetches and cache reuse, and added a REST guard that rejects `/api/workout-summaries` batches above 31 ids with a focused endpoint test.
+- Prevention: when a UI presents a concrete date range, do not preload status data for a much larger hidden history window unless the product explicitly requires it and the backend path is proven cheap. For batch sidebar/status endpoints, align request scope to the visible range first, then add a backend max-id guard so one client regression cannot fan out into timeout-scale work.
+
 ### 2026-05-28 | user | completed workout summary handler pre-check hid valid cross-source recap
 
 - Problem: even after the alias-aware workout-summary target resolution was fixed, `GET /api/completed-workouts/{activity_id}/summary` still performed a separate `completed_workout_service.get_completed_workout(...)` pre-check in the REST handler. That read path uses the authoritative completed-workout repository, which intentionally hides same-day duplicates and can prefer the Wahoo canonical workout over the Intervals alias. For the 2026-05-27 ride, the Intervals alias `i151959404` was therefore rejected at the handler boundary with `404` before the alias-aware `workout_summary_service.get_summary(...)` could resolve the existing recap stored under `459893292`.

--- a/src/adapters/rest/workout_summary/handlers.rs
+++ b/src/adapters/rest/workout_summary/handlers.rs
@@ -20,6 +20,8 @@ use super::{
     },
 };
 
+const MAX_LIST_SUMMARIES_WORKOUT_IDS: usize = 31;
+
 #[derive(Serialize)]
 struct ErrorResponse {
     error: &'static str,
@@ -105,6 +107,16 @@ pub async fn list_summaries(
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "workoutIds must contain at least one workout id",
+            }),
+        )
+            .into_response();
+    }
+
+    if workout_ids.len() > MAX_LIST_SUMMARIES_WORKOUT_IDS {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "workoutIds must contain at most 31 workout ids",
             }),
         )
             .into_response();

--- a/src/adapters/rest/workout_summary/handlers.rs
+++ b/src/adapters/rest/workout_summary/handlers.rs
@@ -24,7 +24,13 @@ const MAX_LIST_SUMMARIES_WORKOUT_IDS: usize = 31;
 
 #[derive(Serialize)]
 struct ErrorResponse {
-    error: &'static str,
+    error: String,
+}
+
+fn error_response(error: impl Into<String>) -> Json<ErrorResponse> {
+    Json(ErrorResponse {
+        error: error.into(),
+    })
 }
 
 pub(super) async fn resolve_user_id(
@@ -105,9 +111,7 @@ pub async fn list_summaries(
     if workout_ids.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "workoutIds must contain at least one workout id",
-            }),
+            error_response("workoutIds must contain at least one workout id"),
         )
             .into_response();
     }
@@ -115,9 +119,10 @@ pub async fn list_summaries(
     if workout_ids.len() > MAX_LIST_SUMMARIES_WORKOUT_IDS {
         return (
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "workoutIds must contain at most 31 workout ids",
-            }),
+            error_response(format!(
+                "workoutIds must contain at most {} workout ids",
+                MAX_LIST_SUMMARIES_WORKOUT_IDS
+            )),
         )
             .into_response();
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,8 @@
 - In `AI Coach`, preloading workout summaries for a 12-week history window caused `GET /api/workout-summaries` to send 84 ids even though the sidebar showed one week, which amplified backend alias-resolution cost and led to `524` timeouts.
 - When switching from eager preload to visible-range fetches, keep a small client-side cache of already loaded summary ids so paging back to a previously visited week does not re-fetch needlessly.
 - For batch endpoints that can be hit by UI regressions, add a hard server-side max-id guard even after fixing the client. UI correctness and backend blast-radius limits are separate protections.
+- After adding a server-side batch limit, audit the client path for the same limit immediately. A visible-range fetch can still exceed the cap on dense weeks if the client sends the whole week in one batch.
+- In scope-narrowing regressions, assert exact fetch count in addition to the requested ids so an extra hidden request cannot slip through while the argument assertion still passes.
 
 ## 2026-05-28 - Summary handlers must not pre-check through a narrower completed-workout reader
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,6 +12,13 @@
 - In this flow, mutating `workout.planned_workout_id` too early caused `persist_legacy_planned_workout_link(...)` to create a synthetic `Explicit` link, which incorrectly outranked real `Token` and `Heuristic` matches and overwrote legacy planned ids.
 - When canonical reuse and link persistence share one function, verify both outcomes explicitly after refactors: canonical record reuse and preserved `match_source` / legacy planned-id semantics.
 
+## 2026-05-28 - Visible-range UIs must not batch hidden history summaries
+
+- If a page presents one visible week or other explicit date window, fetch summary/status metadata only for entities in that visible range unless there is a confirmed product requirement for broader prefetch.
+- In `AI Coach`, preloading workout summaries for a 12-week history window caused `GET /api/workout-summaries` to send 84 ids even though the sidebar showed one week, which amplified backend alias-resolution cost and led to `524` timeouts.
+- When switching from eager preload to visible-range fetches, keep a small client-side cache of already loaded summary ids so paging back to a previously visited week does not re-fetch needlessly.
+- For batch endpoints that can be hit by UI regressions, add a hard server-side max-id guard even after fixing the client. UI correctness and backend blast-radius limits are separate protections.
+
 ## 2026-05-28 - Summary handlers must not pre-check through a narrower completed-workout reader
 
 - If a summary endpoint already delegates target validation and alias resolution to `WorkoutSummaryService`, do not add an extra `CompletedWorkoutReadService` existence check in the handler.

--- a/tests/workout_summary_rest/summary_endpoints.rs
+++ b/tests/workout_summary_rest/summary_endpoints.rs
@@ -249,6 +249,39 @@ async fn list_summaries_rejects_empty_workout_ids() {
 }
 
 #[tokio::test]
+async fn list_summaries_rejects_more_than_31_workout_ids() {
+    let app = workout_summary_test_app(
+        TestIdentityServiceWithSession::default(),
+        TestWorkoutSummaryService::default(),
+    )
+    .await;
+
+    let workout_ids = (1..=32)
+        .map(|index| format!("workout-{index}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/workout-summaries?workoutIds={workout_ids}"))
+                .header(header::COOKIE, session_cookie("session-1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body: Value = get_json(response).await;
+    assert_eq!(
+        body.get("error").and_then(Value::as_str),
+        Some("workoutIds must contain at most 31 workout ids")
+    );
+}
+
+#[tokio::test]
 async fn update_rpe_returns_updated_summary() {
     let app = workout_summary_test_app(
         TestIdentityServiceWithSession::default(),


### PR DESCRIPTION
## Summary
- fetch AI Coach workout summaries only for the currently visible week instead of preloading the 12-week history window
- cache loaded weekly workout summaries on the client so revisiting a week does not refetch the same ids
- reject workout summary batch requests above 31 ids to guard the backend from oversized requests

## Testing
- bun run --cwd frontend test src/features/coach/hooks/useWorkoutList.test.tsx src/features/coach/api/workoutSummary.test.ts
- cargo test --test workout_summary_rest list_summaries
- bun run verify:arch
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout errors in the AI Coach by optimizing workout summary fetching to load only the currently visible week instead of pre-loading multiple weeks of data.

* **Performance**
  * Improved responsiveness through efficient data loading and client-side caching of previously loaded summaries.

* **Reliability**
  * Added backend rate limiting to prevent excessive workout summary requests and improve service stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->