### PR TITLE
feat(frontend): markdown viewer for workout summary

### DIFF
--- a/frontend/src/features/calendar/components/WorkoutDetailSummarySection.test.tsx
+++ b/frontend/src/features/calendar/components/WorkoutDetailSummarySection.test.tsx
@@ -1,0 +1,44 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {WorkoutSummarySection} from './WorkoutDetailSummarySection';
+
+describe('WorkoutSummarySection', () => {
+  it('renders plain text summaries without markdown parsing', () => {
+    render(
+      <WorkoutSummarySection
+        isLoading={false}
+        summary={{
+          workoutId: 'w1',
+          text: 'Strong aerobic control with only a small fade near the end.',
+          generatedAtEpochSeconds: 1,
+        }}
+        summaryError={null}
+      />,
+    );
+
+    expect(
+      screen.getByText('Strong aerobic control with only a small fade near the end.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('renders markdown summaries with formatted elements', () => {
+    const {container} = render(
+      <WorkoutSummarySection
+        isLoading={false}
+        summary={{
+          workoutId: 'w1',
+          text: '### Workout Recap\n\n**Execution Quality:** solid effort.',
+          generatedAtEpochSeconds: 1,
+        }}
+        summaryError={null}
+      />,
+    );
+
+    expect(screen.getByRole('heading', {name: 'Workout Recap'})).toBeInTheDocument();
+    expect(screen.getByText('Execution Quality:')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('**Execution Quality:**');
+    expect(container.textContent).not.toContain('### Workout Recap');
+  });
+});

--- a/frontend/src/features/calendar/components/WorkoutDetailSummarySection.tsx
+++ b/frontend/src/features/calendar/components/WorkoutDetailSummarySection.tsx
@@ -1,5 +1,6 @@
 import {useTranslation} from 'react-i18next';
 
+import {SummaryTextContent} from '../../../lib/markdown/SummaryTextContent';
 import type {CompletedWorkoutSummary} from '../../intervals/types';
 
 type WorkoutSummarySectionProps = {
@@ -22,7 +23,10 @@ export function WorkoutSummarySection({
         <p className="mt-4 text-sm text-slate-400">{t('calendar.loadingWorkoutSummary')}</p>
       ) : summary ? (
         <>
-          <div className="mt-4 whitespace-pre-wrap text-sm leading-7 text-slate-100">{summary.text}</div>
+          <SummaryTextContent
+            text={summary.text}
+            className="mt-4 text-sm leading-7 text-slate-100"
+          />
           {summary.provider || summary.model ? (
             <p className="mt-4 text-xs text-slate-500">
               {[summary.provider, summary.model].filter(Boolean).join(' / ')}

--- a/frontend/src/features/coach/components/ChatMessage.tsx
+++ b/frontend/src/features/coach/components/ChatMessage.tsx
@@ -1,7 +1,4 @@
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import type { Components } from 'react-markdown';
-
+import { MarkdownContent } from '../../../lib/markdown/MarkdownContent';
 import { CoachQuestionnaire } from './CoachQuestionnaire';
 import type { ConversationMessage } from '../types';
 
@@ -16,52 +13,6 @@ function formatTimestamp(epochSeconds: number): string {
     minute: '2-digit',
   }).format(new Date(epochSeconds * 1000));
 }
-
-const mdComponents: Components = {
-  table: ({ children }) => (
-    <div className="my-3 overflow-x-auto">
-      <table className="min-w-full border-collapse border border-white/10 text-sm">
-        {children}
-      </table>
-    </div>
-  ),
-  thead: ({ children }) => (
-    <thead className="border-b border-white/10 bg-white/5">{children}</thead>
-  ),
-  th: ({ children }) => (
-    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-slate-300">
-      {children}
-    </th>
-  ),
-  td: ({ children }) => (
-    <td className="border-t border-white/5 px-3 py-2 text-slate-200">{children}</td>
-  ),
-  h1: ({ children }) => (
-    <h3 className="mb-2 mt-4 text-base font-bold text-white">{children}</h3>
-  ),
-  h2: ({ children }) => (
-    <h3 className="mb-1.5 mt-3 text-sm font-bold text-white/90">{children}</h3>
-  ),
-  h3: ({ children }) => (
-    <h4 className="mb-1 mt-2 text-sm font-semibold text-white/80">{children}</h4>
-  ),
-  strong: ({ children }) => (
-    <strong className="font-bold text-white">{children}</strong>
-  ),
-  ul: ({ children }) => <ul className="my-2 list-disc space-y-1 pl-5">{children}</ul>,
-  ol: ({ children }) => <ol className="my-2 list-decimal space-y-1 pl-5">{children}</ol>,
-  li: ({ children }) => <li className="text-slate-200">{children}</li>,
-  hr: () => <hr className="my-4 border-white/10" />,
-  code: ({ children }) => (
-    <code className="rounded bg-white/10 px-1.5 py-0.5 text-xs text-amber-200">{children}</code>
-  ),
-  p: ({ children }) => <p className="mb-2 leading-7">{children}</p>,
-  blockquote: ({ children }) => (
-    <blockquote className="my-2 border-l-2 border-amber-400/30 pl-3 italic text-slate-300">
-      {children}
-    </blockquote>
-  ),
-};
 
 export function ChatMessage({ message, onSendMessage }: ChatMessageProps) {
   const isUser = message.role === 'user';
@@ -95,9 +46,7 @@ export function ChatMessage({ message, onSendMessage }: ChatMessageProps) {
           </div>
         ) : isCoach ? (
           <div className="text-base">
-            <Markdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-              {message.content}
-            </Markdown>
+            <MarkdownContent>{message.content}</MarkdownContent>
             {questions.length > 0 && onSendMessage ? (
               <CoachQuestionnaire questions={questions} onSubmit={onSendMessage} />
             ) : null}

--- a/frontend/src/lib/markdown/MarkdownContent.tsx
+++ b/frontend/src/lib/markdown/MarkdownContent.tsx
@@ -1,0 +1,64 @@
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Components } from 'react-markdown';
+
+const mdComponents: Components = {
+  table: ({ children }) => (
+    <div className="my-3 overflow-x-auto">
+      <table className="min-w-full border-collapse border border-white/10 text-sm">
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children }) => (
+    <thead className="border-b border-white/10 bg-white/5">{children}</thead>
+  ),
+  th: ({ children }) => (
+    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-slate-300">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border-t border-white/5 px-3 py-2 text-slate-200">{children}</td>
+  ),
+  h1: ({ children }) => (
+    <h3 className="mb-2 mt-4 text-base font-bold text-white">{children}</h3>
+  ),
+  h2: ({ children }) => (
+    <h3 className="mb-1.5 mt-3 text-sm font-bold text-white/90">{children}</h3>
+  ),
+  h3: ({ children }) => (
+    <h4 className="mb-1 mt-2 text-sm font-semibold text-white/80">{children}</h4>
+  ),
+  strong: ({ children }) => (
+    <strong className="font-bold text-white">{children}</strong>
+  ),
+  ul: ({ children }) => <ul className="my-2 list-disc space-y-1 pl-5">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 list-decimal space-y-1 pl-5">{children}</ol>,
+  li: ({ children }) => <li className="text-slate-200">{children}</li>,
+  hr: () => <hr className="my-4 border-white/10" />,
+  code: ({ children }) => (
+    <code className="rounded bg-white/10 px-1.5 py-0.5 text-xs text-amber-200">{children}</code>
+  ),
+  p: ({ children }) => <p className="mb-2 leading-7">{children}</p>,
+  blockquote: ({ children }) => (
+    <blockquote className="my-2 border-l-2 border-amber-400/30 pl-3 italic text-slate-300">
+      {children}
+    </blockquote>
+  ),
+};
+
+type MarkdownContentProps = {
+  children: string;
+  className?: string;
+};
+
+export function MarkdownContent({ children, className }: MarkdownContentProps) {
+  return (
+    <div className={className}>
+      <Markdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+        {children}
+      </Markdown>
+    </div>
+  );
+}

--- a/frontend/src/lib/markdown/SummaryTextContent.tsx
+++ b/frontend/src/lib/markdown/SummaryTextContent.tsx
@@ -1,0 +1,15 @@
+import { looksLikeMarkdown } from './looksLikeMarkdown';
+import { MarkdownContent } from './MarkdownContent';
+
+type SummaryTextContentProps = {
+  text: string;
+  className?: string;
+};
+
+export function SummaryTextContent({ text, className }: SummaryTextContentProps) {
+  if (looksLikeMarkdown(text)) {
+    return <MarkdownContent className={className}>{text}</MarkdownContent>;
+  }
+
+  return <div className={['whitespace-pre-wrap', className].filter(Boolean).join(' ')}>{text}</div>;
+}

--- a/frontend/src/lib/markdown/looksLikeMarkdown.test.ts
+++ b/frontend/src/lib/markdown/looksLikeMarkdown.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { looksLikeMarkdown } from './looksLikeMarkdown';
+
+describe('looksLikeMarkdown', () => {
+  it('returns false for plain prose summaries', () => {
+    expect(
+      looksLikeMarkdown('Strong aerobic control with only a small fade near the end.'),
+    ).toBe(false);
+  });
+
+  it('returns false for empty or whitespace-only text', () => {
+    expect(looksLikeMarkdown('')).toBe(false);
+    expect(looksLikeMarkdown('   \n  ')).toBe(false);
+  });
+
+  it('detects headings', () => {
+    expect(looksLikeMarkdown('### Workout Recap\n\nGood effort.')).toBe(true);
+  });
+
+  it('detects bold and list markers', () => {
+    expect(looksLikeMarkdown('**Execution Quality:** solid\n- May 29: recovery')).toBe(true);
+  });
+
+  it('detects inline code', () => {
+    expect(looksLikeMarkdown('Keep `FTP` steady through the block.')).toBe(true);
+  });
+});

--- a/frontend/src/lib/markdown/looksLikeMarkdown.ts
+++ b/frontend/src/lib/markdown/looksLikeMarkdown.ts
@@ -1,0 +1,20 @@
+const MARKDOWN_SIGNAL_PATTERNS: RegExp[] = [
+  /^#{1,6}\s/m,
+  /\*\*[^*\n]+\*\*/,
+  /(?<!\*)\*[^*\n]+\*(?!\*)/,
+  /`[^`\n]+`/,
+  /^\s*[-*+]\s+/m,
+  /^\s*\d+\.\s+/m,
+  /^\s*>\s+/m,
+  /^(\*{3,}|-{3,}|_{3,})\s*$/m,
+  /^\|.+\|.+\|/m,
+];
+
+export function looksLikeMarkdown(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  return MARKDOWN_SIGNAL_PATTERNS.some((pattern) => pattern.test(trimmed));
+}


### PR DESCRIPTION
## Summary

- Add shared markdown rendering in `frontend/src/lib/markdown` (same styling as coach chat).
- Render completed workout AI summary as markdown when lightweight detection matches; otherwise keep plain pre-wrapped text.
- Refactor `ChatMessage` to reuse `MarkdownContent`.

## Test plan

- [x] `bun run --cwd frontend test src/lib/markdown/looksLikeMarkdown.test.ts src/features/calendar/components/WorkoutDetailSummarySection.test.tsx src/features/calendar/components/WorkoutDetailModal.completed.test.tsx`
- [x] `bun run --cwd frontend build`
- [ ] Open a completed workout with an AI summary and confirm headings, bold, and lists render (no raw `###` / `**`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced markdown rendering support for workout summaries and coach messages with improved text formatting and element styling.

* **Refactor**
  * Consolidated markdown rendering logic into reusable components to reduce code duplication and improve consistency across features.

* **Tests**
  * Added test coverage for markdown detection and rendering behavior in summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->