### PR TITLE
perf: speed up AI Coach page load

### DIFF
--- a/frontend/src/features/coach/api/workoutSummary.test.ts
+++ b/frontend/src/features/coach/api/workoutSummary.test.ts
@@ -222,8 +222,12 @@ describe('workoutSummary api', () => {
   it('reopens workout summary', async () => {
     global.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
-        ...summaryFixture,
-        savedAtEpochSeconds: null,
+        summary: { ...summaryFixture, savedAtEpochSeconds: null },
+        workflow: {
+          recapStatus: 'unchanged',
+          planStatus: 'unchanged',
+          messages: [],
+        },
       }), {
         status: 200,
         headers: { 'content-type': 'application/json' },

--- a/frontend/src/features/coach/api/workoutSummary.test.ts
+++ b/frontend/src/features/coach/api/workoutSummary.test.ts
@@ -222,8 +222,8 @@ describe('workoutSummary api', () => {
   it('reopens workout summary', async () => {
     global.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
-        summary: summaryFixture,
-        workflow: { recapStatus: 'unchanged', planStatus: 'unchanged', messages: [] },
+        ...summaryFixture,
+        savedAtEpochSeconds: null,
       }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -232,7 +232,7 @@ describe('workoutSummary api', () => {
 
     const result = await reopenWorkoutSummary('', '101');
 
-    expect(result.summary.savedAtEpochSeconds).toBeNull();
+    expect(result.savedAtEpochSeconds).toBeNull();
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/workout-summaries/101/state',
       expect.objectContaining({

--- a/frontend/src/features/coach/api/workoutSummary.ts
+++ b/frontend/src/features/coach/api/workoutSummary.ts
@@ -9,12 +9,37 @@ import {
 
 const workoutTargetIdSchema = sendMessageRequestSchema.shape.content.transform((value) => value);
 
+export type WorkoutSummaryDateRange = {
+  oldest: string;
+  newest: string;
+};
+
 function normalizeWorkoutTargetId(targetId: string): string {
   return workoutTargetIdSchema.parse(targetId);
 }
 
-export async function getWorkoutSummary(apiBaseUrl: string, targetId: string) {
-  const data = await get(apiBaseUrl, `/api/workout-summaries/${normalizeWorkoutTargetId(targetId)}`);
+function buildSummaryQuery(range?: WorkoutSummaryDateRange, view?: 'metadata'): string {
+  const query = new URLSearchParams();
+  if (range) {
+    query.set('oldest', range.oldest);
+    query.set('newest', range.newest);
+  }
+  if (view === 'metadata') {
+    query.set('view', 'metadata');
+  }
+  const serialized = query.toString();
+  return serialized ? `?${serialized}` : '';
+}
+
+export async function getWorkoutSummary(
+  apiBaseUrl: string,
+  targetId: string,
+  range?: WorkoutSummaryDateRange,
+) {
+  const data = await get(
+    apiBaseUrl,
+    `/api/workout-summaries/${normalizeWorkoutTargetId(targetId)}${buildSummaryQuery(range)}`,
+  );
   return workoutSummarySchema.parse(data);
 }
 
@@ -27,7 +52,14 @@ export async function createWorkoutSummary(apiBaseUrl: string, targetId: string)
   return workoutSummarySchema.parse(data);
 }
 
-export async function listWorkoutSummaries(apiBaseUrl: string, targetIds: string[]) {
+export async function listWorkoutSummaries(
+  apiBaseUrl: string,
+  targetIds: string[],
+  options?: {
+    range?: WorkoutSummaryDateRange;
+    view?: 'metadata';
+  },
+) {
   const normalizedIds = targetIds.map((targetId) => normalizeWorkoutTargetId(targetId));
 
   if (normalizedIds.length === 0) {
@@ -35,6 +67,13 @@ export async function listWorkoutSummaries(apiBaseUrl: string, targetIds: string
   }
 
   const query = new URLSearchParams({ workoutIds: normalizedIds.join(',') });
+  if (options?.range) {
+    query.set('oldest', options.range.oldest);
+    query.set('newest', options.range.newest);
+  }
+  if (options?.view === 'metadata') {
+    query.set('view', 'metadata');
+  }
   const data = await get(apiBaseUrl, `/api/workout-summaries?${query.toString()}`);
   return workoutSummarySchema.array().parse(data);
 }
@@ -64,7 +103,7 @@ export async function reopenWorkoutSummary(apiBaseUrl: string, workoutId: string
     `/api/workout-summaries/${normalizeWorkoutTargetId(workoutId)}/state`,
     { saved: false },
   );
-  return saveWorkoutSummaryResponseSchema.parse(data);
+  return workoutSummarySchema.parse(data);
 }
 
 export async function sendWorkoutSummaryMessage(apiBaseUrl: string, workoutId: string, payload: unknown) {

--- a/frontend/src/features/coach/api/workoutSummary.ts
+++ b/frontend/src/features/coach/api/workoutSummary.ts
@@ -103,7 +103,7 @@ export async function reopenWorkoutSummary(apiBaseUrl: string, workoutId: string
     `/api/workout-summaries/${normalizeWorkoutTargetId(workoutId)}/state`,
     { saved: false },
   );
-  return workoutSummarySchema.parse(data);
+  return saveWorkoutSummaryResponseSchema.parse(data).summary;
 }
 
 export async function sendWorkoutSummaryMessage(apiBaseUrl: string, workoutId: string, payload: unknown) {

--- a/frontend/src/features/coach/components/CoachPageLayout.test.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.test.tsx
@@ -7,6 +7,7 @@ import * as calendarHooks from '../../calendar/hooks/useCalendarData';
 import * as useWorkoutListModule from '../hooks/useWorkoutList';
 import * as useCoachChatModule from '../hooks/useCoachChat';
 import type { CoachWorkoutListItem, WorkoutSummary } from '../types';
+import { CoachSessionCacheProvider } from '../context/CoachSessionCache';
 import { CoachPageLayout } from './CoachPageLayout';
 
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -91,8 +92,10 @@ function setupMocks(opts?: { planStatus?: 'generated' | 'processing' | 'skipped'
   vi.mocked(useWorkoutListModule.useWorkoutList).mockReturnValue({
     items: [defaultWorkoutItem()],
     state: 'ready',
+    summariesState: 'ready',
     error: null,
     weekLabel: 'Mar 10 - Mar 16',
+    visibleWeekRange: { oldest: '2025-03-10', newest: '2025-03-16' },
     canGoToNewerWeek: false,
     goToOlderWeek: vi.fn(),
     goToNewerWeek: vi.fn(),
@@ -140,7 +143,11 @@ describe('CoachPageLayout', () => {
   it('invalidates caches after save with generated plan', async () => {
     const { invalidateCalendarCache, invalidateAll } = setupMocks({ planStatus: 'generated' });
 
-    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    render(
+      <CoachSessionCacheProvider>
+        <CoachPageLayout apiBaseUrl="http://localhost:3000" />
+      </CoachSessionCacheProvider>,
+    );
     fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
     await waitFor(() => expect(invalidateCalendarCache).toHaveBeenCalledTimes(1));
@@ -155,7 +162,11 @@ describe('CoachPageLayout', () => {
   ])('does not invalidate caches when plan status is %s', async (planStatus) => {
     const { invalidateCalendarCache, invalidateAll, refresh } = setupMocks({ planStatus: planStatus as never });
 
-    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    render(
+      <CoachSessionCacheProvider>
+        <CoachPageLayout apiBaseUrl="http://localhost:3000" />
+      </CoachSessionCacheProvider>,
+    );
     fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
     await waitFor(() => expect(refresh).toHaveBeenCalled());
@@ -166,7 +177,11 @@ describe('CoachPageLayout', () => {
   it('does not invalidate caches when save returns null', async () => {
     const { invalidateCalendarCache, invalidateAll } = setupMocks({ saveSummaryResult: null });
 
-    render(<CoachPageLayout apiBaseUrl="http://localhost:3000" />);
+    render(
+      <CoachSessionCacheProvider>
+        <CoachPageLayout apiBaseUrl="http://localhost:3000" />
+      </CoachSessionCacheProvider>,
+    );
     fireEvent.click(screen.getByRole('button', { name: /save as workout summary/i }));
 
     await waitFor(() => expect(invalidateCalendarCache).not.toHaveBeenCalled());

--- a/frontend/src/features/coach/components/CoachPageLayout.tsx
+++ b/frontend/src/features/coach/components/CoachPageLayout.tsx
@@ -6,6 +6,7 @@ import { useCompletedWorkouts } from '../../intervals/context';
 import { useSettings } from '../../settings/context/SettingsContext';
 import { useMediaQuery } from '../../../lib/useMediaQuery';
 import { isAvailabilityConfigured } from '../../settings/types';
+import { useCoachSessionCache } from '../context/CoachSessionCache';
 import { useWorkoutList } from '../hooks/useWorkoutList';
 import { isAvailabilityRequiredChatError, useCoachChat } from '../hooks/useCoachChat';
 import { ChatWindow } from './ChatWindow';
@@ -24,6 +25,7 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 767px)');
   const settingsContext = useSettings();
+  const sessionCache = useCoachSessionCache();
   const workoutList = useWorkoutList({ apiBaseUrl });
   const completedWorkouts = useCompletedWorkouts();
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null);
@@ -40,9 +42,14 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
     () => isAvailabilityConfigured(settingsContext.settings?.availability),
     [settingsContext.settings?.availability],
   );
+  const cachedSummary = selectedItem ? sessionCache.getSummary(selectedItem.id) : null;
+
   const chat = useCoachChat({
     apiBaseUrl,
     workoutId: selectedItem?.id ?? null,
+    aliasRange: workoutList.visibleWeekRange,
+    cachedSummary,
+    onSummaryLoaded: sessionCache.setSummary,
   });
   const hasSettingsLoadError = Boolean(settingsContext.error);
   const chatError = isAvailabilityRequiredChatError(chat.error) ? null : chat.error;
@@ -72,9 +79,10 @@ export function CoachPageLayout({ apiBaseUrl }: CoachPageLayoutProps) {
 
   useEffect(() => {
     if (chat.summary) {
+      sessionCache.setSummary(chat.summary);
       workoutList.replaceSummary(chat.summary);
     }
-  }, [chat.summary, workoutList.replaceSummary]);
+  }, [chat.summary, sessionCache.setSummary, workoutList.replaceSummary]);
 
   const isCurrentSelection = useCallback((workoutId: string) => {
     return selectedWorkoutIdRef.current === workoutId;

--- a/frontend/src/features/coach/context/CoachSessionCache.tsx
+++ b/frontend/src/features/coach/context/CoachSessionCache.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
+
+import type { WorkoutSummary } from '../types';
+
+type CoachSessionCacheValue = {
+  getSummary: (workoutId: string) => WorkoutSummary | undefined;
+  hasSummary: (workoutId: string) => boolean;
+  setSummary: (summary: WorkoutSummary) => void;
+};
+
+const CoachSessionCacheContext = createContext<CoachSessionCacheValue | null>(null);
+
+export function CoachSessionCacheProvider({ children }: { children: React.ReactNode }) {
+  const summariesRef = useRef<Map<string, WorkoutSummary>>(new Map());
+
+  const getSummary = useCallback((workoutId: string) => summariesRef.current.get(workoutId), []);
+
+  const hasSummary = useCallback(
+    (workoutId: string) => summariesRef.current.has(workoutId),
+    [],
+  );
+
+  const setSummary = useCallback((summary: WorkoutSummary) => {
+    summariesRef.current.set(summary.workoutId, summary);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      getSummary,
+      hasSummary,
+      setSummary,
+    }),
+    [getSummary, hasSummary, setSummary],
+  );
+
+  return (
+    <CoachSessionCacheContext.Provider value={value}>{children}</CoachSessionCacheContext.Provider>
+  );
+}
+
+export function useCoachSessionCache(): CoachSessionCacheValue {
+  const context = useContext(CoachSessionCacheContext);
+  if (!context) {
+    throw new Error('useCoachSessionCache must be used within CoachSessionCacheProvider');
+  }
+  return context;
+}

--- a/frontend/src/features/coach/hooks/useCoachChat.test.tsx
+++ b/frontend/src/features/coach/hooks/useCoachChat.test.tsx
@@ -601,8 +601,8 @@ describe('useCoachChat', () => {
     global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     vi.mocked(getWorkoutSummary).mockResolvedValue({ ...summaryFixture, savedAtEpochSeconds: 3 });
     vi.mocked(reopenWorkoutSummary).mockResolvedValue({
-      summary: summaryFixture,
-      workflow: { recapStatus: 'unchanged', planStatus: 'unchanged', messages: [] },
+      ...summaryFixture,
+      savedAtEpochSeconds: null,
     });
 
     const { result } = renderHook(() => useCoachChat({ apiBaseUrl: '', workoutId: '101' }));

--- a/frontend/src/features/coach/hooks/useCoachChat.ts
+++ b/frontend/src/features/coach/hooks/useCoachChat.ts
@@ -7,6 +7,7 @@ import {
   reopenWorkoutSummary,
   saveWorkoutSummary,
   updateWorkoutSummaryRpe,
+  type WorkoutSummaryDateRange,
 } from '../api/workoutSummary';
 import {
   clientWsMessageSchema,
@@ -20,6 +21,9 @@ import {
 type UseCoachChatOptions = {
   apiBaseUrl: string;
   workoutId: string | null;
+  aliasRange?: WorkoutSummaryDateRange | null;
+  cachedSummary?: WorkoutSummary | null;
+  onSummaryLoaded?: (summary: WorkoutSummary) => void;
 };
 
 type UseCoachChatResult = {
@@ -108,7 +112,13 @@ function appendUniqueMessage(messages: ConversationMessage[], message: Conversat
   return [...messages, message];
 }
 
-export function useCoachChat({ apiBaseUrl, workoutId }: UseCoachChatOptions): UseCoachChatResult {
+export function useCoachChat({
+  apiBaseUrl,
+  workoutId,
+  aliasRange = null,
+  cachedSummary = null,
+  onSummaryLoaded,
+}: UseCoachChatOptions): UseCoachChatResult {
   const [summary, setSummary] = useState<WorkoutSummary | null>(null);
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
   const [draftRpe, setDraftRpe] = useState<number | null>(null);
@@ -386,12 +396,31 @@ export function useCoachChat({ apiBaseUrl, workoutId }: UseCoachChatOptions): Us
       setIsLoading(true);
 
       try {
-        const loadedSummary = await getWorkoutSummary(apiBaseUrl, workoutId);
+        if (
+          cachedSummary
+          && cachedSummary.workoutId === workoutId
+          && cachedSummary.messages.length > 0
+        ) {
+          if (cancelled) {
+            return;
+          }
+
+          applySummaryState(cachedSummary, workoutId);
+          await connectSocket(workoutId);
+          return;
+        }
+
+        const loadedSummary = await getWorkoutSummary(
+          apiBaseUrl,
+          workoutId,
+          aliasRange ?? undefined,
+        );
 
         if (cancelled) {
           return;
         }
 
+        onSummaryLoaded?.(loadedSummary);
         setSummary(loadedSummary);
         setMessages(loadedSummary.messages);
         setDraftRpe(loadedSummary.rpe);
@@ -425,7 +454,17 @@ export function useCoachChat({ apiBaseUrl, workoutId }: UseCoachChatOptions): Us
       cancelled = true;
       closeSocket();
     };
-  }, [apiBaseUrl, clearSummaryState, closeSocket, connectSocket, workoutId]);
+  }, [
+    aliasRange,
+    apiBaseUrl,
+    applySummaryState,
+    cachedSummary,
+    clearSummaryState,
+    closeSocket,
+    connectSocket,
+    onSummaryLoaded,
+    workoutId,
+  ]);
 
   const saveSummary = useCallback(async () => {
     if (!workoutId) {
@@ -507,9 +546,9 @@ export function useCoachChat({ apiBaseUrl, workoutId }: UseCoachChatOptions): Us
     setError(null);
 
     try {
-      const reopenResult = await reopenWorkoutSummary(apiBaseUrl, requestedWorkoutId);
-      applySummaryState(reopenResult.summary, requestedWorkoutId);
-      return reopenResult.summary;
+      const reopenedSummary = await reopenWorkoutSummary(apiBaseUrl, requestedWorkoutId);
+      applySummaryState(reopenedSummary, requestedWorkoutId);
+      return reopenedSummary;
     } catch (saveError) {
       if (saveError instanceof StaleWorkoutSelectionError) {
         return null;

--- a/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
+++ b/frontend/src/features/coach/hooks/useWorkoutList.test.tsx
@@ -40,6 +40,14 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+const metadataListOptions = expect.objectContaining({
+  view: 'metadata',
+  range: expect.objectContaining({
+    oldest: expect.any(String),
+    newest: expect.any(String),
+  }),
+});
+
 const eventFixture: IntervalEvent = {
   id: 101,
   startDateLocal: '2026-03-24T09:00:00',
@@ -172,7 +180,7 @@ describe('useWorkoutList', () => {
     expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
     expect(result.current.items).toHaveLength(2);
     expect(result.current.items[0]?.hasConversation).toBe(true);
-    expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-101', 'activity-102']);
+    expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-101', 'activity-102'], metadataListOptions);
   });
 
   it('keeps activities whose matched event has an unknown category', async () => {
@@ -239,6 +247,7 @@ describe('useWorkoutList', () => {
       1,
       '',
       ['activity-200', 'activity-201', 'activity-202', 'activity-203', 'activity-204', 'activity-205'],
+      metadataListOptions,
     );
 
     act(() => {
@@ -256,6 +265,7 @@ describe('useWorkoutList', () => {
       2,
       '',
       ['activity-206', 'activity-207', 'activity-208', 'activity-209'],
+      metadataListOptions,
     );
 
     act(() => {
@@ -354,7 +364,7 @@ describe('useWorkoutList', () => {
     expect(result.current.items[0]?.event?.actualWorkout?.activityId).toBe('activity-linked');
   });
 
-  it('reuses cached activities on refresh without re-fetching', async () => {
+  it('re-fetches activities on refresh', async () => {
     vi.mocked(listWorkoutSummaries).mockResolvedValue([]);
     vi.mocked(listActivities).mockResolvedValue([
       {
@@ -381,7 +391,7 @@ describe('useWorkoutList', () => {
     });
 
     expect(result.current.items[0]?.activity?.name).toBe('Cached result');
-    expect(listActivities).toHaveBeenCalledTimes(1);
+    expect(listActivities).toHaveBeenCalledTimes(2);
   });
 
   it('refresh clears stale visible-week summaries omitted by the next batch response', async () => {
@@ -473,8 +483,14 @@ describe('useWorkoutList', () => {
         1,
         '',
         activities.slice(0, 31).map((activity) => activity.id),
+        metadataListOptions,
       );
-      expect(listWorkoutSummaries).toHaveBeenNthCalledWith(2, '', [activities[31]!.id]);
+      expect(listWorkoutSummaries).toHaveBeenNthCalledWith(
+        2,
+        '',
+        [activities[31]!.id],
+        metadataListOptions,
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -635,7 +651,7 @@ describe('useWorkoutList', () => {
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0]?.id).toBe('activity-990');
     expect(result.current.items[0]?.summary?.workoutId).toBe('activity-990');
-    expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-990']);
+    expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-990'], metadataListOptions);
   });
 
   it('loads summaries only for the currently visible week', async () => {
@@ -686,7 +702,7 @@ describe('useWorkoutList', () => {
       });
 
       expect(result.current.weekLabel).toBe(formatWeekLabel(new Date(2026, 2, 23), new Date(2026, 2, 29)));
-      expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-current-week']);
+      expect(listWorkoutSummaries).toHaveBeenCalledWith('', ['activity-current-week'], metadataListOptions);
       expect(listWorkoutSummaries).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();

--- a/frontend/src/features/coach/hooks/useWorkoutList.ts
+++ b/frontend/src/features/coach/hooks/useWorkoutList.ts
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { listEvents } from '../../intervals/api/intervals';
-import { useCompletedWorkouts } from '../../intervals/context';
+import { listActivities, listEvents } from '../../intervals/api/intervals';
 import { AuthenticationError, HttpError } from '../../../lib/httpClient';
 import { addDays, addWeeks, extractDateKey, formatDateRange, getMondayOfWeek, toDateKey } from '../../calendar/utils/dateUtils';
-import { listWorkoutSummaries } from '../api/workoutSummary';
+import { listWorkoutSummaries, type WorkoutSummaryDateRange } from '../api/workoutSummary';
 import type { CoachWorkoutListItem, WorkoutSummary } from '../types';
 import type { IntervalActivity, IntervalEvent } from '../../intervals/types';
 
 export type WorkoutListState = 'loading' | 'ready' | 'error' | 'credentials-required';
+export type WorkoutSummariesState = 'idle' | 'loading' | 'ready' | 'error';
 
 const WORKOUT_PAGE_SIZE = 7;
 const WORKOUT_LOOKBACK_WEEKS = 12;
@@ -21,8 +21,10 @@ type UseWorkoutListOptions = {
 type UseWorkoutListResult = {
   items: CoachWorkoutListItem[];
   state: WorkoutListState;
+  summariesState: WorkoutSummariesState;
   error: string | null;
   weekLabel: string;
+  visibleWeekRange: WorkoutSummaryDateRange;
   canGoToNewerWeek: boolean;
   goToOlderWeek: () => void;
   goToNewerWeek: () => void;
@@ -225,7 +227,17 @@ function withSummaryState(item: CoachWorkoutListItem, summary: WorkoutSummary | 
     ...item,
     summary,
     hasSummary: summary !== null,
-    hasConversation: summary?.messages.some((message) => message.role === 'coach') ?? false,
+    hasConversation:
+      summary?.hasCoachMessage
+      ?? summary?.messages.some((message) => message.role === 'coach')
+      ?? false,
+  };
+}
+
+function weekDateRange(weekStart: Date): WorkoutSummaryDateRange {
+  return {
+    oldest: toDateKey(weekStart),
+    newest: toDateKey(addDays(weekStart, 6)),
   };
 }
 
@@ -297,7 +309,6 @@ function defaultVisibleWeekStart(items: CoachWorkoutListItem[], currentWeekStart
 }
 
 export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkoutListResult {
-  const { getActivitiesForRange, error: contextError } = useCompletedWorkouts();
   const [currentWeekStart, setCurrentWeekStart] = useState(() => getMondayOfWeek(new Date()));
   const [visibleWeekStart, setVisibleWeekStart] = useState(() => getMondayOfWeek(new Date()));
   const [allItems, setAllItems] = useState<CoachWorkoutListItem[]>([]);
@@ -305,21 +316,19 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   const [loadedSummaryIds, setLoadedSummaryIds] = useState<Set<string>>(() => new Set());
   const [hasLoadedWorkouts, setHasLoadedWorkouts] = useState(false);
   const [state, setState] = useState<WorkoutListState>('loading');
+  const [summariesState, setSummariesState] = useState<WorkoutSummariesState>('idle');
   const [error, setError] = useState<string | null>(null);
   const currentWeekStartRef = useRef(currentWeekStart);
   const requestIdRef = useRef(0);
   const summaryRequestIdRef = useRef(0);
-  const contextErrorRef = useRef(contextError);
+
+  const visibleWeekRange = useMemo(() => weekDateRange(visibleWeekStart), [visibleWeekStart]);
 
   const items = useMemo(() => buildVisibleItems(allItems, visibleWeekStart, summaryCache), [
     allItems,
     visibleWeekStart,
     summaryCache,
   ]);
-
-  useEffect(() => {
-    contextErrorRef.current = contextError;
-  }, [contextError]);
 
   const loadRecentWorkouts = useCallback(async () => {
     const requestId = requestIdRef.current + 1;
@@ -335,19 +344,8 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
       const range = formatDateRange(lookbackStart, WORKOUT_LOOKBACK_WEEKS);
       const [events, activities] = await Promise.all([
         listEvents(apiBaseUrl, range),
-        getActivitiesForRange(range.oldest, range.newest),
+        listActivities(apiBaseUrl, { ...range, detail: 'list' }),
       ]);
-
-      if (contextErrorRef.current?.kind === 'credentials-required') {
-        setState('credentials-required');
-        return;
-      }
-
-      if (contextErrorRef.current?.kind === 'network-error') {
-        setState('error');
-        setError(contextErrorRef.current.message);
-        return;
-      }
 
       const workoutEvents = [...events]
         .sort((left, right) => right.startDateLocal.localeCompare(left.startDateLocal))
@@ -375,6 +373,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
         return current;
       });
       setHasLoadedWorkouts(true);
+      setState('ready');
     } catch (loadError) {
       if (requestId !== requestIdRef.current) {
         return;
@@ -393,7 +392,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
       setState('error');
       setError(loadError instanceof Error ? loadError.message : 'Unknown error');
     }
-  }, [apiBaseUrl, getActivitiesForRange]);
+  }, [apiBaseUrl]);
 
   useEffect(() => {
     void loadRecentWorkouts();
@@ -407,29 +406,31 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
     const summaryTargetIds = items.map((item) => item.id);
 
     if (summaryTargetIds.length === 0) {
-      setState('ready');
-      setError(null);
+      setSummariesState('ready');
       return;
     }
 
     const missingSummaryIds = summaryTargetIds.filter((workoutId) => !loadedSummaryIds.has(workoutId));
 
     if (missingSummaryIds.length === 0) {
-      setState('ready');
-      setError(null);
+      setSummariesState('ready');
       return;
     }
 
     const requestId = summaryRequestIdRef.current + 1;
     summaryRequestIdRef.current = requestId;
-    setState('loading');
-    setError(null);
+    setSummariesState('loading');
 
     void (async () => {
       try {
         const summaries = (
           await Promise.all(
-            chunkWorkoutIds(missingSummaryIds).map((workoutIds) => listWorkoutSummaries(apiBaseUrl, workoutIds)),
+            chunkWorkoutIds(missingSummaryIds).map((workoutIds) =>
+              listWorkoutSummaries(apiBaseUrl, workoutIds, {
+                range: visibleWeekRange,
+                view: 'metadata',
+              }),
+            ),
           )
         ).flat();
 
@@ -447,7 +448,7 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
 
           return next;
         });
-        setState('ready');
+        setSummariesState('ready');
       } catch (loadError) {
         if (requestId !== summaryRequestIdRef.current) {
           return;
@@ -463,11 +464,11 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
           return;
         }
 
-        setState('error');
+        setSummariesState('error');
         setError(loadError instanceof Error ? loadError.message : 'Unknown error');
       }
     })();
-  }, [apiBaseUrl, hasLoadedWorkouts, items, loadedSummaryIds]);
+  }, [apiBaseUrl, hasLoadedWorkouts, items, loadedSummaryIds, visibleWeekRange]);
 
   const weekLabel = useMemo(() => {
     return formatRangeLabel(visibleWeekStart, addDays(visibleWeekStart, 6));
@@ -486,8 +487,10 @@ export function useWorkoutList({ apiBaseUrl }: UseWorkoutListOptions): UseWorkou
   return {
     items,
     state,
+    summariesState,
     error,
     weekLabel,
+    visibleWeekRange,
     canGoToNewerWeek,
     goToOlderWeek: () => {
       setVisibleWeekStart((current) => addWeeks(current, -1));

--- a/frontend/src/features/coach/types.ts
+++ b/frontend/src/features/coach/types.ts
@@ -35,6 +35,7 @@ export const workoutSummarySchema = z.object({
   id: z.string(),
   workoutId: z.string(),
   rpe: z.number().int().min(1).max(10).nullable(),
+  hasCoachMessage: z.boolean().optional(),
   messages: z.array(conversationMessageSchema),
   savedAtEpochSeconds: z.number().int().nullable(),
   createdAtEpochSeconds: z.number().int(),

--- a/frontend/src/features/intervals/api/intervals.ts
+++ b/frontend/src/features/intervals/api/intervals.ts
@@ -14,6 +14,7 @@ import {
   intervalActivitySchema,
   intervalEventSchema,
   intervalEventsResponseSchema,
+  listCompletedWorkoutsQuerySchema,
   listEventsQuerySchema,
   updateActivityRequestSchema,
   updateIntervalEventRequestSchema,
@@ -89,7 +90,7 @@ export async function deleteEvent(apiBaseUrl: string, eventId: number) {
 }
 
 export async function listActivities(apiBaseUrl: string, query: unknown) {
-  const validated = listEventsQuerySchema.parse(query);
+  const validated = listCompletedWorkoutsQuerySchema.parse(query);
   const path = `/api/completed-workouts?${toQueryString(validated)}`;
   const data = await get(apiBaseUrl, path);
   return intervalActivitiesResponseSchema.parse(data);

--- a/frontend/src/features/intervals/types.ts
+++ b/frontend/src/features/intervals/types.ts
@@ -122,6 +122,10 @@ export const listEventsQuerySchema = z.object({
   newest: dateSchema,
 });
 
+export const listCompletedWorkoutsQuerySchema = listEventsQuerySchema.extend({
+  detail: z.literal('list').optional(),
+});
+
 export const createIntervalEventRequestSchema = z.object({
   category: intervalCategorySchema,
   startDateLocal: dateSchema,

--- a/frontend/src/pages/AICoachPage.tsx
+++ b/frontend/src/pages/AICoachPage.tsx
@@ -1,9 +1,14 @@
 import { CoachPageLayout } from '../features/coach/components/CoachPageLayout';
+import { CoachSessionCacheProvider } from '../features/coach/context/CoachSessionCache';
 
 type AICoachPageProps = {
   apiBaseUrl: string;
 };
 
 export function AICoachPage({ apiBaseUrl }: AICoachPageProps) {
-  return <CoachPageLayout apiBaseUrl={apiBaseUrl} />;
+  return (
+    <CoachSessionCacheProvider>
+      <CoachPageLayout apiBaseUrl={apiBaseUrl} />
+    </CoachSessionCacheProvider>
+  );
 }

--- a/src/adapters/rest/completed_workouts/handlers.rs
+++ b/src/adapters/rest/completed_workouts/handlers.rs
@@ -14,6 +14,7 @@ use super::mapping::{map_completed_workout_summary_to_dto, map_completed_workout
 pub(crate) struct ListCompletedWorkoutsQuery {
     pub oldest: String,
     pub newest: String,
+    pub detail: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -56,13 +57,21 @@ pub(crate) async fn list_completed_workouts(
         .list_completed_workouts(&user_id, &query.oldest, &query.newest)
         .await
     {
-        Ok(workouts) => Json(
-            workouts
-                .into_iter()
-                .map(map_completed_workout_to_dto)
-                .collect::<Vec<_>>(),
-        )
-        .into_response(),
+        Ok(workouts) => {
+            let list_view = query.detail.as_deref() == Some("list");
+            let payload = if list_view {
+                workouts
+                    .into_iter()
+                    .map(super::mapping::map_completed_workout_list_to_dto)
+                    .collect::<Vec<_>>()
+            } else {
+                workouts
+                    .into_iter()
+                    .map(map_completed_workout_to_dto)
+                    .collect::<Vec<_>>()
+            };
+            Json(payload).into_response()
+        }
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }

--- a/src/adapters/rest/completed_workouts/mapping.rs
+++ b/src/adapters/rest/completed_workouts/mapping.rs
@@ -31,6 +31,15 @@ pub(super) fn map_completed_workout_to_dto(workout: CompletedWorkout) -> Activit
     map_activity_to_dto(map_completed_workout_to_activity(workout))
 }
 
+pub(super) fn map_completed_workout_list_to_dto(workout: CompletedWorkout) -> ActivityDto {
+    let mut activity = map_completed_workout_to_activity(workout);
+    activity.stream_types.clear();
+    activity.details.streams.clear();
+    activity.details.interval_summary.clear();
+    activity.details.skyline_chart.clear();
+    map_activity_to_dto(activity)
+}
+
 pub(super) fn map_completed_workout_summary_to_dto(
     summary: WorkoutSummary,
 ) -> Option<CompletedWorkoutSummaryDto> {

--- a/src/adapters/rest/workout_summary/dto.rs
+++ b/src/adapters/rest/workout_summary/dto.rs
@@ -20,6 +20,15 @@ pub(in crate::adapters::rest) struct ListWorkoutSummariesQuery {
     // Keep alias for backward compatibility during transition.
     #[serde(rename = "workoutIds", alias = "eventIds")]
     pub workout_ids: String,
+    pub oldest: Option<String>,
+    pub newest: Option<String>,
+    pub view: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(in crate::adapters::rest) struct GetWorkoutSummaryQuery {
+    pub oldest: Option<String>,
+    pub newest: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -58,6 +67,9 @@ pub(super) struct WorkoutSummaryDto {
     #[serde(rename = "workoutId")]
     pub workout_id: String,
     pub rpe: Option<u8>,
+    #[serde(rename = "hasCoachMessage", skip_serializing_if = "Option::is_none")]
+    pub has_coach_message: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub messages: Vec<ConversationMessageDto>,
     #[serde(rename = "savedAtEpochSeconds")]
     pub saved_at_epoch_seconds: Option<i64>,

--- a/src/adapters/rest/workout_summary/handlers.rs
+++ b/src/adapters/rest/workout_summary/handlers.rs
@@ -6,17 +6,23 @@ use axum::{
 };
 use serde::Serialize;
 
-use crate::{config::AppState, domain::workout_summary::WorkoutSummaryUseCases};
+use crate::{
+    config::AppState,
+    domain::workout_summary::{
+        CompletedWorkoutAliasScope, WorkoutSummaryGetOptions, WorkoutSummaryListOptions,
+        WorkoutSummaryUseCases,
+    },
+};
 
 use super::{
     dto::{
-        ListWorkoutSummariesQuery, SendMessageRequest, SetSavedStateRequest, UpdateRpeRequest,
-        WorkoutSummaryPath, WorkoutSummaryStateResponse,
+        GetWorkoutSummaryQuery, ListWorkoutSummariesQuery, SendMessageRequest,
+        SetSavedStateRequest, UpdateRpeRequest, WorkoutSummaryPath, WorkoutSummaryStateResponse,
     },
     error::map_workout_summary_error,
     mapping::{
-        map_save_summary_result_to_dto, map_send_message_result_to_dto, map_summary_to_dto,
-        unchanged_save_summary_result,
+        map_save_summary_result_to_dto, map_send_message_result_to_dto,
+        map_summary_metadata_to_dto, map_summary_to_dto, unchanged_save_summary_result,
     },
 };
 
@@ -46,10 +52,27 @@ fn workout_summary_service(
     state.workout_summary_service.as_ref()
 }
 
+fn parse_alias_scope(
+    oldest: Option<String>,
+    newest: Option<String>,
+) -> Option<CompletedWorkoutAliasScope> {
+    let oldest = oldest?;
+    let newest = newest?;
+    if !super::super::intervals::is_valid_date(&oldest)
+        || !super::super::intervals::is_valid_date(&newest)
+        || oldest > newest
+    {
+        return None;
+    }
+
+    Some(CompletedWorkoutAliasScope { oldest, newest })
+}
+
 pub async fn get_summary(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(path): Path<WorkoutSummaryPath>,
+    Query(query): Query<GetWorkoutSummaryQuery>,
 ) -> Response {
     let user_id = match resolve_user_id(&state, &headers).await {
         Ok(user_id) => user_id,
@@ -60,7 +83,14 @@ pub async fn get_summary(
         None => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
     };
 
-    match service.get_summary(&user_id, &path.workout_id).await {
+    let options = WorkoutSummaryGetOptions {
+        alias_scope: parse_alias_scope(query.oldest, query.newest),
+    };
+
+    match service
+        .get_summary_with_options(&user_id, &path.workout_id, options)
+        .await
+    {
         Ok(summary) => Json(map_summary_to_dto(summary)).into_response(),
         Err(error) => map_workout_summary_error(&error),
     }
@@ -127,14 +157,29 @@ pub async fn list_summaries(
             .into_response();
     }
 
-    match service.list_summaries(&user_id, workout_ids).await {
-        Ok(summaries) => Json(
-            summaries
-                .into_iter()
-                .map(map_summary_to_dto)
-                .collect::<Vec<_>>(),
-        )
-        .into_response(),
+    let metadata_only = query.view.as_deref() == Some("metadata");
+    let options = WorkoutSummaryListOptions {
+        alias_scope: parse_alias_scope(query.oldest, query.newest),
+    };
+
+    match service
+        .list_summaries_with_options(&user_id, workout_ids, options)
+        .await
+    {
+        Ok(summaries) => {
+            let payload = if metadata_only {
+                summaries
+                    .into_iter()
+                    .map(map_summary_metadata_to_dto)
+                    .collect::<Vec<_>>()
+            } else {
+                summaries
+                    .into_iter()
+                    .map(map_summary_to_dto)
+                    .collect::<Vec<_>>()
+            };
+            Json(payload).into_response()
+        }
         Err(error) => map_workout_summary_error(&error),
     }
 }

--- a/src/adapters/rest/workout_summary/mapping.rs
+++ b/src/adapters/rest/workout_summary/mapping.rs
@@ -13,11 +13,29 @@ pub(super) fn map_summary_to_dto(summary: WorkoutSummary) -> WorkoutSummaryDto {
         id: summary.id,
         workout_id: summary.workout_id,
         rpe: summary.rpe,
+        has_coach_message: None,
         messages: summary
             .messages
             .into_iter()
             .map(map_message_to_dto)
             .collect(),
+        saved_at_epoch_seconds: summary.saved_at_epoch_seconds,
+        created_at_epoch_seconds: summary.created_at_epoch_seconds,
+        updated_at_epoch_seconds: summary.updated_at_epoch_seconds,
+    }
+}
+
+pub(super) fn map_summary_metadata_to_dto(summary: WorkoutSummary) -> WorkoutSummaryDto {
+    let has_coach_message = summary
+        .messages
+        .iter()
+        .any(|message| message.role == MessageRole::Coach);
+    WorkoutSummaryDto {
+        id: summary.id,
+        workout_id: summary.workout_id,
+        rpe: summary.rpe,
+        has_coach_message: Some(has_coach_message),
+        messages: Vec::new(),
         saved_at_epoch_seconds: summary.saved_at_epoch_seconds,
         created_at_epoch_seconds: summary.created_at_epoch_seconds,
         updated_at_epoch_seconds: summary.updated_at_epoch_seconds,

--- a/src/adapters/workout_summary_completed_target.rs
+++ b/src/adapters/workout_summary_completed_target.rs
@@ -372,12 +372,27 @@ mod tests {
 
         fn list_by_user_id_and_date_range(
             &self,
-            _user_id: &str,
-            _oldest: &str,
-            _newest: &str,
+            user_id: &str,
+            oldest: &str,
+            newest: &str,
         ) -> CompletedWorkoutBoxFuture<Result<Vec<CompletedWorkout>, CompletedWorkoutError>>
         {
-            Box::pin(async { Ok(Vec::new()) })
+            let workout = self.workout.clone();
+            let user_id = user_id.to_string();
+            let oldest = oldest.to_string();
+            let newest = newest.to_string();
+            Box::pin(async move {
+                if workout.user_id != user_id {
+                    return Ok(Vec::new());
+                }
+
+                let workout_date = workout.start_date_local.get(..10).unwrap_or("");
+                if workout_date >= oldest.as_str() && workout_date <= newest.as_str() {
+                    Ok(vec![workout])
+                } else {
+                    Ok(Vec::new())
+                }
+            })
         }
 
         fn upsert(

--- a/src/adapters/workout_summary_completed_target.rs
+++ b/src/adapters/workout_summary_completed_target.rs
@@ -1,13 +1,17 @@
+use std::collections::HashMap;
+
 use crate::domain::{
     completed_workouts::{
         canonical_completed_workout_id, completed_workout_activity_id, CompletedWorkout,
         CompletedWorkoutRepository,
     },
     workout_summary::{
-        BoxFuture, CompletedWorkoutTargetUseCases, ResolvedCompletedWorkoutTarget,
-        WorkoutSummaryError,
+        BoxFuture, CompletedWorkoutAliasScope, CompletedWorkoutTargetUseCases,
+        ResolvedCompletedWorkoutTarget, WorkoutSummaryError,
     },
 };
+
+const ALIAS_SCOPE_MARGIN_DAYS: i64 = 7;
 
 #[derive(Clone)]
 pub struct CompletedWorkoutTargetAdapter<Repo> {
@@ -54,7 +58,7 @@ where
             };
 
             let mut equivalent_workout_ids =
-                equivalent_workout_ids_for_workout(&repository, &user_id, &workout).await?;
+                equivalent_workout_ids_for_workout(&repository, &user_id, &workout, None).await?;
             let preferred_workout_id = workout
                 .source_activity_id
                 .clone()
@@ -67,16 +71,144 @@ where
             }))
         })
     }
+
+    fn resolve_completed_workout_target_in_scope(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        alias_scope: &CompletedWorkoutAliasScope,
+    ) -> BoxFuture<Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>> {
+        let repository = self.repository.clone();
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        let alias_scope = alias_scope.clone();
+        Box::pin(async move {
+            let siblings = load_alias_scope_siblings(&repository, &user_id, &alias_scope).await?;
+            let Some(workout) =
+                resolve_completed_workout_from_siblings(&siblings, &user_id, &workout_id)
+            else {
+                return Ok(None);
+            };
+
+            let mut equivalent_workout_ids =
+                equivalent_workout_ids_for_workout_with_siblings(&workout, &siblings);
+            let preferred_workout_id = workout
+                .source_activity_id
+                .clone()
+                .unwrap_or_else(|| workout.completed_workout_id.clone());
+            push_unique_workout_id(&mut equivalent_workout_ids, preferred_workout_id.clone());
+
+            Ok(Some(ResolvedCompletedWorkoutTarget {
+                preferred_workout_id,
+                equivalent_workout_ids,
+            }))
+        })
+    }
+
+    fn resolve_completed_workout_targets_in_scope(
+        &self,
+        user_id: &str,
+        workout_ids: &[String],
+        alias_scope: &CompletedWorkoutAliasScope,
+    ) -> BoxFuture<Result<HashMap<String, ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>>
+    {
+        let repository = self.repository.clone();
+        let user_id = user_id.to_string();
+        let workout_ids = workout_ids.to_vec();
+        let alias_scope = alias_scope.clone();
+        Box::pin(async move {
+            let siblings = load_alias_scope_siblings(&repository, &user_id, &alias_scope).await?;
+            let mut resolved = HashMap::new();
+
+            for workout_id in workout_ids {
+                let Some(workout) =
+                    resolve_completed_workout_from_siblings(&siblings, &user_id, &workout_id)
+                else {
+                    continue;
+                };
+
+                let mut equivalent_workout_ids =
+                    equivalent_workout_ids_for_workout_with_siblings(&workout, &siblings);
+                let preferred_workout_id = workout
+                    .source_activity_id
+                    .clone()
+                    .unwrap_or_else(|| workout.completed_workout_id.clone());
+                push_unique_workout_id(&mut equivalent_workout_ids, preferred_workout_id.clone());
+
+                resolved.insert(
+                    workout_id,
+                    ResolvedCompletedWorkoutTarget {
+                        preferred_workout_id,
+                        equivalent_workout_ids,
+                    },
+                );
+            }
+
+            Ok(resolved)
+        })
+    }
+}
+
+async fn load_alias_scope_siblings<Repo>(
+    repository: &Repo,
+    user_id: &str,
+    alias_scope: &CompletedWorkoutAliasScope,
+) -> Result<Vec<CompletedWorkout>, WorkoutSummaryError>
+where
+    Repo: CompletedWorkoutRepository + Clone + Send + Sync + 'static,
+{
+    let expanded_scope = alias_scope.with_alias_margin_days(ALIAS_SCOPE_MARGIN_DAYS);
+    repository
+        .list_by_user_id_and_date_range(user_id, &expanded_scope.oldest, &expanded_scope.newest)
+        .await
+        .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))
+}
+
+fn resolve_completed_workout_from_siblings(
+    siblings: &[CompletedWorkout],
+    user_id: &str,
+    workout_id: &str,
+) -> Option<CompletedWorkout> {
+    if let Some(workout) = siblings.iter().find(|workout| {
+        workout.user_id == user_id && workout.source_activity_id.as_deref() == Some(workout_id)
+    }) {
+        return Some(workout.clone());
+    }
+
+    let canonical_id = canonical_completed_workout_id(workout_id);
+    siblings
+        .iter()
+        .find(|workout| workout.user_id == user_id && workout.completed_workout_id == canonical_id)
+        .cloned()
 }
 
 async fn equivalent_workout_ids_for_workout<Repo>(
     repository: &Repo,
     user_id: &str,
     workout: &CompletedWorkout,
+    alias_scope: Option<&CompletedWorkoutAliasScope>,
 ) -> Result<Vec<String>, WorkoutSummaryError>
 where
     Repo: CompletedWorkoutRepository + Clone + Send + Sync + 'static,
 {
+    let siblings = if let Some(scope) = alias_scope {
+        load_alias_scope_siblings(repository, user_id, scope).await?
+    } else {
+        repository
+            .list_by_user_id(user_id)
+            .await
+            .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))?
+    };
+
+    Ok(equivalent_workout_ids_for_workout_with_siblings(
+        workout, &siblings,
+    ))
+}
+
+fn equivalent_workout_ids_for_workout_with_siblings(
+    workout: &CompletedWorkout,
+    siblings: &[CompletedWorkout],
+) -> Vec<String> {
     let mut equivalent_workout_ids = Vec::new();
     push_unique_workout_id(
         &mut equivalent_workout_ids,
@@ -93,12 +225,8 @@ where
         push_unique_workout_id(&mut equivalent_workout_ids, external_id);
     }
 
-    let siblings = repository
-        .list_by_user_id(user_id)
-        .await
-        .map_err(|error| WorkoutSummaryError::Repository(error.to_string()))?;
     for sibling in siblings {
-        if same_completed_workout_family(workout, &sibling) {
+        if same_completed_workout_family(workout, sibling) {
             push_unique_workout_id(
                 &mut equivalent_workout_ids,
                 sibling
@@ -106,14 +234,17 @@ where
                     .clone()
                     .unwrap_or_else(|| sibling.completed_workout_id.clone()),
             );
-            push_unique_workout_id(&mut equivalent_workout_ids, sibling.completed_workout_id);
-            if let Some(external_id) = sibling.external_id {
+            push_unique_workout_id(
+                &mut equivalent_workout_ids,
+                sibling.completed_workout_id.clone(),
+            );
+            if let Some(external_id) = sibling.external_id.clone() {
                 push_unique_workout_id(&mut equivalent_workout_ids, external_id);
             }
         }
     }
 
-    Ok(equivalent_workout_ids)
+    equivalent_workout_ids
 }
 
 fn same_completed_workout_family(left: &CompletedWorkout, right: &CompletedWorkout) -> bool {
@@ -182,7 +313,7 @@ mod tests {
             BoxFuture as CompletedWorkoutBoxFuture, CompletedWorkout, CompletedWorkoutDetails,
             CompletedWorkoutError, CompletedWorkoutMetrics, CompletedWorkoutRepository,
         },
-        workout_summary::CompletedWorkoutTargetUseCases,
+        workout_summary::{CompletedWorkoutAliasScope, CompletedWorkoutTargetUseCases},
     };
 
     #[derive(Clone)]
@@ -306,5 +437,52 @@ mod tests {
                 "459893292".to_string(),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_completed_workout_target_in_scope_uses_date_range_lookup() {
+        let repository = StubCompletedWorkoutRepository {
+            workout: CompletedWorkout {
+                completed_workout_id: "wahoo-workout:459893292".to_string(),
+                user_id: "user-1".to_string(),
+                start_date_local: "2026-05-27T13:10:35.000Z".to_string(),
+                source_activity_id: Some("i151959404".to_string()),
+                planned_workout_id: None,
+                name: Some("Aerobic Endurance".to_string()),
+                description: None,
+                activity_type: Some("Ride".to_string()),
+                external_id: Some("459893292".to_string()),
+                trainer: false,
+                duration_seconds: Some(5283),
+                distance_meters: Some(44_718.45),
+                metrics: CompletedWorkoutMetrics::default(),
+                details: CompletedWorkoutDetails {
+                    intervals: Vec::new(),
+                    interval_groups: Vec::new(),
+                    streams: Vec::new(),
+                    interval_summary: Vec::new(),
+                    skyline_chart: Vec::new(),
+                    power_zone_times: Vec::new(),
+                    heart_rate_zone_times: Vec::new(),
+                    pace_zone_times: Vec::new(),
+                    gap_zone_times: Vec::new(),
+                },
+                details_unavailable_reason: None,
+                power_curve_5s: None,
+            },
+        };
+        let adapter = CompletedWorkoutTargetAdapter::new(repository);
+        let scope = CompletedWorkoutAliasScope {
+            oldest: "2026-05-20".to_string(),
+            newest: "2026-05-28".to_string(),
+        };
+
+        let resolved = adapter
+            .resolve_completed_workout_target_in_scope("user-1", "i151959404", &scope)
+            .await
+            .expect("resolver should succeed")
+            .expect("target should resolve");
+
+        assert_eq!(resolved.preferred_workout_id, "i151959404");
     }
 }

--- a/src/domain/workout_summary/mod.rs
+++ b/src/domain/workout_summary/mod.rs
@@ -20,9 +20,10 @@ pub use model::{
 pub use ports::{BoxFuture, CoachReplyOperationRepository, WorkoutSummaryRepository};
 pub use save_completion_port::{NoopSaveWorkflowCompletionPort, SaveWorkflowCompletionPort};
 pub use service::{
-    workout_summary_coach_reply_task_handler, CompletedWorkoutTargetUseCases,
-    LatestCompletedActivityUseCases, ResolvedCompletedWorkoutTarget, SaveSummaryResult,
-    SaveWorkflowResult, SaveWorkflowStatus, SchedulerBackedWorkoutSummaryService,
+    workout_summary_coach_reply_task_handler, CompletedWorkoutAliasScope,
+    CompletedWorkoutTargetUseCases, LatestCompletedActivityUseCases,
+    ResolvedCompletedWorkoutTarget, SaveSummaryResult, SaveWorkflowResult, SaveWorkflowStatus,
+    SchedulerBackedWorkoutSummaryService, WorkoutSummaryGetOptions, WorkoutSummaryListOptions,
     WorkoutSummaryService, WorkoutSummaryUseCases,
 };
 pub(crate) use service::{

--- a/src/domain/workout_summary/service/internals/target_resolution.rs
+++ b/src/domain/workout_summary/service/internals/target_resolution.rs
@@ -23,6 +23,7 @@ where
         &self,
         user_id: &str,
         workout_id: &str,
+        alias_scope: Option<CompletedWorkoutAliasScope>,
     ) -> Result<ResolvedWorkoutSummaryTarget, WorkoutSummaryError> {
         let Some(service) = &self.completed_workout_target_service else {
             return self
@@ -30,10 +31,20 @@ where
                 .await;
         };
 
-        let Some(resolved_target) = service
-            .resolve_completed_workout_target(user_id, workout_id)
-            .await?
-        else {
+        let resolved_target = match alias_scope.as_ref() {
+            Some(scope) => {
+                service
+                    .resolve_completed_workout_target_in_scope(user_id, workout_id, scope)
+                    .await?
+            }
+            None => {
+                service
+                    .resolve_completed_workout_target(user_id, workout_id)
+                    .await?
+            }
+        };
+
+        let Some(resolved_target) = resolved_target else {
             return Err(not_completed_workout_target_error());
         };
 
@@ -46,7 +57,7 @@ where
         user_id: &str,
         workout_id: &str,
     ) -> Result<(), WorkoutSummaryError> {
-        self.resolve_workout_summary_target(user_id, workout_id)
+        self.resolve_workout_summary_target(user_id, workout_id, None)
             .await
             .map(|_| ())
     }

--- a/src/domain/workout_summary/service/mod.rs
+++ b/src/domain/workout_summary/service/mod.rs
@@ -38,7 +38,9 @@ pub trait WorkoutSummaryUseCases: Send + Sync {
         &self,
         user_id: &str,
         workout_id: &str,
-    ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>>;
+    ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
+        self.get_summary_with_options(user_id, workout_id, WorkoutSummaryGetOptions::default())
+    }
 
     fn create_summary(
         &self,
@@ -46,11 +48,27 @@ pub trait WorkoutSummaryUseCases: Send + Sync {
         workout_id: &str,
     ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>>;
 
+    fn list_summaries_with_options(
+        &self,
+        user_id: &str,
+        workout_ids: Vec<String>,
+        options: WorkoutSummaryListOptions,
+    ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>>;
+
     fn list_summaries(
         &self,
         user_id: &str,
         workout_ids: Vec<String>,
-    ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>>;
+    ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
+        self.list_summaries_with_options(user_id, workout_ids, WorkoutSummaryListOptions::default())
+    }
+
+    fn get_summary_with_options(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        options: WorkoutSummaryGetOptions,
+    ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>>;
 
     fn update_rpe(
         &self,
@@ -113,6 +131,45 @@ pub struct ResolvedCompletedWorkoutTarget {
     pub equivalent_workout_ids: Vec<String>,
 }
 
+/// Date window for resolving completed-workout alias families without scanning full user history.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletedWorkoutAliasScope {
+    pub oldest: String,
+    pub newest: String,
+}
+
+impl CompletedWorkoutAliasScope {
+    pub fn with_alias_margin_days(&self, margin_days: i64) -> Self {
+        use chrono::{Duration, NaiveDate};
+
+        let expanded_oldest = NaiveDate::parse_from_str(&self.oldest, "%Y-%m-%d")
+            .ok()
+            .and_then(|date| date.checked_sub_signed(Duration::days(margin_days)))
+            .map(|date| date.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| self.oldest.clone());
+        let expanded_newest = NaiveDate::parse_from_str(&self.newest, "%Y-%m-%d")
+            .ok()
+            .and_then(|date| date.checked_add_signed(Duration::days(margin_days)))
+            .map(|date| date.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| self.newest.clone());
+
+        Self {
+            oldest: expanded_oldest,
+            newest: expanded_newest,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkoutSummaryListOptions {
+    pub alias_scope: Option<CompletedWorkoutAliasScope>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkoutSummaryGetOptions {
+    pub alias_scope: Option<CompletedWorkoutAliasScope>,
+}
+
 pub trait CompletedWorkoutTargetUseCases: Send + Sync {
     fn is_completed_workout_target(
         &self,
@@ -137,6 +194,27 @@ pub trait CompletedWorkoutTargetUseCases: Send + Sync {
                 }))
         })
     }
+
+    fn resolve_completed_workout_target_in_scope(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _alias_scope: &CompletedWorkoutAliasScope,
+    ) -> BoxFuture<Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>> {
+        self.resolve_completed_workout_target(user_id, workout_id)
+    }
+
+    fn resolve_completed_workout_targets_in_scope(
+        &self,
+        user_id: &str,
+        workout_ids: &[String],
+        alias_scope: &CompletedWorkoutAliasScope,
+    ) -> BoxFuture<
+        Result<
+            std::collections::HashMap<String, ResolvedCompletedWorkoutTarget>,
+            WorkoutSummaryError,
+        >,
+    >;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/domain/workout_summary/service/scheduler/wrapper.rs
+++ b/src/domain/workout_summary/service/scheduler/wrapper.rs
@@ -1,7 +1,9 @@
 use super::checkpoint::{parse_terminal_coach_reply_checkpoint, parse_terminal_task_error};
 use super::*;
 use crate::domain::task_scheduler::{parse_failed_or_error_message, ResultTaskHandler};
-use crate::domain::workout_summary::SaveSummaryResult;
+use crate::domain::workout_summary::{
+    SaveSummaryResult, WorkoutSummaryGetOptions, WorkoutSummaryListOptions,
+};
 
 #[derive(Clone)]
 struct CoachReplyTaskResultHandler<Base> {
@@ -175,12 +177,14 @@ where
     Time: Clock,
     Ids: IdGenerator,
 {
-    fn get_summary(
+    fn get_summary_with_options(
         &self,
         user_id: &str,
         workout_id: &str,
+        options: WorkoutSummaryGetOptions,
     ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
-        self.base.get_summary(user_id, workout_id)
+        self.base
+            .get_summary_with_options(user_id, workout_id, options)
     }
 
     fn create_summary(
@@ -191,12 +195,14 @@ where
         self.base.create_summary(user_id, workout_id)
     }
 
-    fn list_summaries(
+    fn list_summaries_with_options(
         &self,
         user_id: &str,
         workout_ids: Vec<String>,
+        options: WorkoutSummaryListOptions,
     ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
-        self.base.list_summaries(user_id, workout_ids)
+        self.base
+            .list_summaries_with_options(user_id, workout_ids, options)
     }
 
     fn update_rpe(

--- a/src/domain/workout_summary/service/use_cases/chat.rs
+++ b/src/domain/workout_summary/service/use_cases/chat.rs
@@ -45,7 +45,7 @@ where
         content: String,
     ) -> Result<PersistedUserMessage, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
 
         let user_message = self
@@ -95,7 +95,7 @@ where
         user_message_id: String,
     ) -> Result<CoachReply, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
 
         let user_message = self

--- a/src/domain/workout_summary/service/use_cases/mod.rs
+++ b/src/domain/workout_summary/service/use_cases/mod.rs
@@ -11,15 +11,20 @@ where
     Time: Clock + Clone,
     Ids: IdGenerator + Clone,
 {
-    fn get_summary(
+    fn get_summary_with_options(
         &self,
         user_id: &str,
         workout_id: &str,
+        options: WorkoutSummaryGetOptions,
     ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
         let service = self.clone();
         let user_id = user_id.to_string();
         let workout_id = workout_id.to_string();
-        Box::pin(async move { service.get_summary_impl(&user_id, &workout_id).await })
+        Box::pin(async move {
+            service
+                .get_summary_impl(&user_id, &workout_id, options)
+                .await
+        })
     }
 
     fn create_summary(
@@ -33,14 +38,19 @@ where
         Box::pin(async move { service.create_summary_impl(&user_id, &workout_id).await })
     }
 
-    fn list_summaries(
+    fn list_summaries_with_options(
         &self,
         user_id: &str,
         workout_ids: Vec<String>,
+        options: WorkoutSummaryListOptions,
     ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
         let service = self.clone();
         let user_id = user_id.to_string();
-        Box::pin(async move { service.list_summaries_impl(&user_id, workout_ids).await })
+        Box::pin(async move {
+            service
+                .list_summaries_impl(&user_id, workout_ids, options)
+                .await
+        })
     }
 
     fn update_rpe(

--- a/src/domain/workout_summary/service/use_cases/read.rs
+++ b/src/domain/workout_summary/service/use_cases/read.rs
@@ -1,10 +1,6 @@
-use futures::{stream, StreamExt, TryStreamExt};
-
 use std::collections::HashSet;
 
 use super::*;
-
-const LIST_SUMMARIES_TARGET_CHECK_CONCURRENCY: usize = 8;
 
 struct ListSummaryLookup {
     requested_workout_id: String,
@@ -22,9 +18,10 @@ where
         &self,
         user_id: &str,
         workout_id: &str,
+        options: WorkoutSummaryGetOptions,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, options.alias_scope)
             .await?;
         let summary = target
             .existing_summary
@@ -38,7 +35,7 @@ where
         workout_id: &str,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
 
         if let Some(existing) = target.existing_summary {
@@ -69,22 +66,23 @@ where
         &self,
         user_id: &str,
         workout_ids: Vec<String>,
+        options: WorkoutSummaryListOptions,
     ) -> Result<Vec<WorkoutSummary>, WorkoutSummaryError> {
-        let lookup_requests = stream::iter(workout_ids.into_iter().map(|workout_id| {
-            let service = self.clone();
-            let user_id = user_id.to_string();
-            async move {
-                service
-                    .resolve_list_summary_lookup(&user_id, workout_id)
-                    .await
+        let lookup_requests = if let Some(alias_scope) = options.alias_scope.clone() {
+            self.resolve_list_summary_lookups_in_scope(user_id, &workout_ids, &alias_scope)
+                .await?
+        } else {
+            let mut lookup_requests = Vec::new();
+            for workout_id in workout_ids {
+                if let Some(lookup) = self
+                    .resolve_list_summary_lookup(user_id, workout_id)
+                    .await?
+                {
+                    lookup_requests.push(lookup);
+                }
             }
-        }))
-        .buffered(LIST_SUMMARIES_TARGET_CHECK_CONCURRENCY)
-        .try_collect::<Vec<_>>()
-        .await?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+            lookup_requests
+        };
 
         let mut lookup_workout_ids = Vec::new();
         let mut seen_lookup_workout_ids = HashSet::new();
@@ -131,7 +129,60 @@ where
                         .cmp(&left.created_at_epoch_seconds)
                 })
         });
+
         Ok(summaries)
+    }
+
+    async fn resolve_list_summary_lookups_in_scope(
+        &self,
+        user_id: &str,
+        workout_ids: &[String],
+        alias_scope: &CompletedWorkoutAliasScope,
+    ) -> Result<Vec<ListSummaryLookup>, WorkoutSummaryError> {
+        let Some(service) = &self.completed_workout_target_service else {
+            return Ok(workout_ids
+                .iter()
+                .map(|workout_id| ListSummaryLookup {
+                    requested_workout_id: workout_id.clone(),
+                    lookup_workout_ids: vec![workout_id.clone()],
+                })
+                .collect());
+        };
+
+        let resolved_targets = service
+            .resolve_completed_workout_targets_in_scope(user_id, workout_ids, alias_scope)
+            .await?;
+
+        Ok(workout_ids
+            .iter()
+            .filter_map(|workout_id| {
+                let resolved_target = resolved_targets.get(workout_id)?;
+                let mut lookup_workout_ids = Vec::new();
+                let mut seen_lookup_workout_ids = HashSet::new();
+                push_unique_list_summary_lookup_workout_id(
+                    &mut lookup_workout_ids,
+                    &mut seen_lookup_workout_ids,
+                    resolved_target.preferred_workout_id.clone(),
+                );
+                push_unique_list_summary_lookup_workout_id(
+                    &mut lookup_workout_ids,
+                    &mut seen_lookup_workout_ids,
+                    workout_id.clone(),
+                );
+                for equivalent_workout_id in &resolved_target.equivalent_workout_ids {
+                    push_unique_list_summary_lookup_workout_id(
+                        &mut lookup_workout_ids,
+                        &mut seen_lookup_workout_ids,
+                        equivalent_workout_id.clone(),
+                    );
+                }
+
+                Some(ListSummaryLookup {
+                    requested_workout_id: workout_id.clone(),
+                    lookup_workout_ids,
+                })
+            })
+            .collect())
     }
 
     async fn resolve_list_summary_lookup(
@@ -186,7 +237,7 @@ where
         rpe: u8,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
         let rpe = validate_rpe(rpe)?;
         let existing = target
@@ -212,7 +263,7 @@ where
         workout_id: &str,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
         let existing = target
             .existing_summary
@@ -237,7 +288,7 @@ where
         recap: WorkoutRecap,
     ) -> Result<WorkoutSummary, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
         let existing = target
             .existing_summary

--- a/src/domain/workout_summary/service/use_cases/save.rs
+++ b/src/domain/workout_summary/service/use_cases/save.rs
@@ -259,7 +259,7 @@ where
         workout_id: &str,
     ) -> Result<SaveSummaryResult, WorkoutSummaryError> {
         let target = self
-            .resolve_workout_summary_target(user_id, workout_id)
+            .resolve_workout_summary_target(user_id, workout_id, None)
             .await?;
         let existing = target
             .existing_summary

--- a/src/main_runtime.rs
+++ b/src/main_runtime.rs
@@ -430,6 +430,24 @@ mod tests {
             unreachable!()
         }
 
+        fn list_summaries_with_options(
+            &self,
+            user_id: &str,
+            workout_ids: Vec<String>,
+            _options: crate::domain::workout_summary::WorkoutSummaryListOptions,
+        ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
+            self.list_summaries(user_id, workout_ids)
+        }
+
+        fn get_summary_with_options(
+            &self,
+            user_id: &str,
+            workout_id: &str,
+            _options: crate::domain::workout_summary::WorkoutSummaryGetOptions,
+        ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
+            self.get_summary(user_id, workout_id)
+        }
+
         fn update_rpe(
             &self,
             _user_id: &str,
@@ -540,6 +558,24 @@ mod tests {
             _workout_ids: Vec<String>,
         ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
             unreachable!()
+        }
+
+        fn list_summaries_with_options(
+            &self,
+            user_id: &str,
+            workout_ids: Vec<String>,
+            _options: crate::domain::workout_summary::WorkoutSummaryListOptions,
+        ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
+            self.list_summaries(user_id, workout_ids)
+        }
+
+        fn get_summary_with_options(
+            &self,
+            user_id: &str,
+            workout_id: &str,
+            _options: crate::domain::workout_summary::WorkoutSummaryGetOptions,
+        ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
+            self.get_summary(user_id, workout_id)
         }
 
         fn update_rpe(

--- a/tests/intervals_rest/app.rs
+++ b/tests/intervals_rest/app.rs
@@ -451,6 +451,24 @@ impl WorkoutSummaryUseCases for TestWorkoutSummaryService {
         })
     }
 
+    fn list_summaries_with_options(
+        &self,
+        user_id: &str,
+        workout_ids: Vec<String>,
+        _options: aiwattcoach::domain::workout_summary::WorkoutSummaryListOptions,
+    ) -> WorkoutSummaryBoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
+        self.list_summaries(user_id, workout_ids)
+    }
+
+    fn get_summary_with_options(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _options: aiwattcoach::domain::workout_summary::WorkoutSummaryGetOptions,
+    ) -> WorkoutSummaryBoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
+        self.get_summary(user_id, workout_id)
+    }
+
     fn update_rpe(
         &self,
         _user_id: &str,

--- a/tests/intervals_rest/completed_workouts.rs
+++ b/tests/intervals_rest/completed_workouts.rs
@@ -67,6 +67,63 @@ async fn list_completed_workouts_returns_canonical_workouts_for_authenticated_us
 }
 
 #[tokio::test]
+async fn list_completed_workouts_detail_list_omits_streams() {
+    let app = intervals_test_app_with_calendar_entries_and_completed_workouts(
+        TestIdentityServiceWithSession::default(),
+        TestIntervalsService::default(),
+        InMemoryCalendarEntryViewRepository::default(),
+        InMemoryCompletedWorkoutRepository::with_workouts(vec![sample_completed_workout(
+            "activity-11",
+            None,
+        )]),
+    )
+    .await;
+
+    let full_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/completed-workouts?oldest=2026-03-01&newest=2026-03-31")
+                .header(header::COOKIE, session_cookie("session-1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(full_response.status(), StatusCode::OK);
+    let full_body: Value = get_json(full_response).await;
+    let full_streams = full_body.as_array().unwrap()[0]
+        .get("details")
+        .unwrap()
+        .get("streams")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert!(!full_streams.is_empty());
+
+    let list_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/completed-workouts?oldest=2026-03-01&newest=2026-03-31&detail=list")
+                .header(header::COOKIE, session_cookie("session-1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_body: Value = get_json(list_response).await;
+    let list_streams = list_body.as_array().unwrap()[0]
+        .get("details")
+        .unwrap()
+        .get("streams")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert!(list_streams.is_empty());
+}
+
+#[tokio::test]
 async fn list_completed_workouts_excludes_other_users_workouts() {
     let mut other_user_workout = sample_completed_workout("activity-99", None);
     other_user_workout.user_id = "user-2".to_string();

--- a/tests/workout_summary_rest/shared/workout_summary.rs
+++ b/tests/workout_summary_rest/shared/workout_summary.rs
@@ -139,6 +139,24 @@ impl WorkoutSummaryUseCases for TestWorkoutSummaryService {
         })
     }
 
+    fn get_summary_with_options(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _options: aiwattcoach::domain::workout_summary::WorkoutSummaryGetOptions,
+    ) -> BoxFuture<Result<WorkoutSummary, WorkoutSummaryError>> {
+        self.get_summary(user_id, workout_id)
+    }
+
+    fn list_summaries_with_options(
+        &self,
+        user_id: &str,
+        workout_ids: Vec<String>,
+        _options: aiwattcoach::domain::workout_summary::WorkoutSummaryListOptions,
+    ) -> BoxFuture<Result<Vec<WorkoutSummary>, WorkoutSummaryError>> {
+        self.list_summaries(user_id, workout_ids)
+    }
+
     fn list_summaries(
         &self,
         user_id: &str,

--- a/tests/workout_summary_rest/summary_endpoints.rs
+++ b/tests/workout_summary_rest/summary_endpoints.rs
@@ -90,7 +90,12 @@ async fn create_summary_returns_created_summary() {
         body.get("workoutId").unwrap().as_str().unwrap(),
         "workout-1"
     );
-    assert!(body.get("messages").unwrap().as_array().unwrap().is_empty());
+    assert_eq!(
+        body.get("messages")
+            .and_then(|value| value.as_array())
+            .map_or(0, Vec::len),
+        0,
+    );
 }
 
 #[tokio::test]

--- a/tests/workout_summary_rest/summary_endpoints.rs
+++ b/tests/workout_summary_rest/summary_endpoints.rs
@@ -16,7 +16,9 @@ use crate::shared::{
     TestWorkoutSummaryService,
 };
 use aiwattcoach::adapters::rest::WorkoutSummarySaveNotifier;
-use aiwattcoach::domain::workout_summary::{WorkoutSummaryRepository, WorkoutSummaryService};
+use aiwattcoach::domain::workout_summary::{
+    ConversationMessage, MessageRole, WorkoutSummaryRepository, WorkoutSummaryService,
+};
 
 #[tokio::test]
 async fn get_summary_requires_authentication() {
@@ -183,6 +185,56 @@ async fn list_summaries_returns_batch_results() {
     assert_eq!(
         summaries[1].get("workoutId").unwrap().as_str().unwrap(),
         "workout-1"
+    );
+}
+
+#[tokio::test]
+async fn list_summaries_metadata_view_omits_messages() {
+    let mut summary = sample_summary("workout-1");
+    summary.messages.push(ConversationMessage {
+        id: "coach-1".to_string(),
+        role: MessageRole::Coach,
+        content: "How did it feel?".to_string(),
+        questions: Vec::new(),
+        tool_call: None,
+        created_at_epoch_seconds: 1_700_000_010,
+    });
+
+    let app = workout_summary_test_app(
+        TestIdentityServiceWithSession::default(),
+        TestWorkoutSummaryService::with_summaries(vec![summary]),
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/workout-summaries?workoutIds=workout-1&view=metadata")
+                .header(header::COOKIE, session_cookie("session-1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = get_json(response).await;
+    let summaries = body
+        .as_array()
+        .expect("metadata list response should be an array");
+    assert_eq!(summaries.len(), 1);
+    let summary = &summaries[0];
+    assert_eq!(
+        summary
+            .get("messages")
+            .and_then(|value| value.as_array())
+            .map_or(0, Vec::len),
+        0
+    );
+    assert_eq!(
+        summary.get("hasCoachMessage").and_then(Value::as_bool),
+        Some(true)
     );
 }
 

--- a/tests/workout_summary_service/shared/services.rs
+++ b/tests/workout_summary_service/shared/services.rs
@@ -519,6 +519,46 @@ impl CompletedWorkoutTargetUseCases for RecordingCompletedWorkoutTargetService {
             Ok(resolved_targets.get(&workout_id).cloned())
         })
     }
+
+    fn resolve_completed_workout_target_in_scope(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _alias_scope: &aiwattcoach::domain::workout_summary::CompletedWorkoutAliasScope,
+    ) -> aiwattcoach::domain::workout_summary::BoxFuture<
+        Result<Option<ResolvedCompletedWorkoutTarget>, WorkoutSummaryError>,
+    > {
+        self.resolve_completed_workout_target(user_id, workout_id)
+    }
+
+    fn resolve_completed_workout_targets_in_scope(
+        &self,
+        user_id: &str,
+        workout_ids: &[String],
+        _alias_scope: &aiwattcoach::domain::workout_summary::CompletedWorkoutAliasScope,
+    ) -> aiwattcoach::domain::workout_summary::BoxFuture<
+        Result<
+            std::collections::HashMap<String, ResolvedCompletedWorkoutTarget>,
+            WorkoutSummaryError,
+        >,
+    > {
+        let resolved_targets = self.resolved_targets.lock().unwrap().clone();
+        let calls = self.calls.clone();
+        let user_id = user_id.to_string();
+        let workout_ids = workout_ids.to_vec();
+        Box::pin(async move {
+            let mut resolved = std::collections::HashMap::new();
+            for workout_id in workout_ids {
+                calls.lock().unwrap().push(format!(
+                    "resolve_completed_workout_target:{user_id}:{workout_id}"
+                ));
+                if let Some(target) = resolved_targets.get(&workout_id).cloned() {
+                    resolved.insert(workout_id, target);
+                }
+            }
+            Ok(resolved)
+        })
+    }
 }
 
 impl RecordingTrainingPlanService {


### PR DESCRIPTION
## Summary
- Resolve workout-summary aliases with a single date-scoped completed-workout read (plus margin) instead of per-request full-user scans.
- Add \detail=list\ for completed workouts and \iew=metadata\ for workout-summary batch responses to cut payload size on coach sidebar loads.
- Add \CoachSessionCache\, pass \oldest\/\
ewest\ from the coach UI, and skip duplicate summary GETs when switching back to a workout in the same session.

## Test plan
- [x] \cargo test list_summaries\
- [x] \cargo test --test workout_summary_rest\
- [x] \cargo test --test intervals_rest completed_workouts\
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [x] \un run --cwd frontend test\ (coach hooks/components/api)
- [x] \un run --cwd frontend build\
- [ ] Manual: AI Coach Network tab — one full GET for selected workout + metadata batch; no repeat GET when switching A→B→A in the same week

Made with [Cursor](https://cursor.com)