### PR TITLE
fix: fall back to REST when coach websocket is offline

### DIFF
--- a/frontend/src/features/coach/hooks/useCoachChat.test.tsx
+++ b/frontend/src/features/coach/hooks/useCoachChat.test.tsx
@@ -7,6 +7,7 @@ import {
   getWorkoutSummary,
   reopenWorkoutSummary,
   saveWorkoutSummary,
+  sendWorkoutSummaryMessage,
   updateWorkoutSummaryRpe,
 } from '../api/workoutSummary';
 import {
@@ -21,11 +22,13 @@ vi.mock('../api/workoutSummary', () => ({
   getWorkoutSummary: vi.fn(),
   reopenWorkoutSummary: vi.fn(),
   saveWorkoutSummary: vi.fn(),
+  sendWorkoutSummaryMessage: vi.fn(),
   updateWorkoutSummaryRpe: vi.fn(),
 }));
 
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
+  static failNextConnection = false;
   static OPEN = 1;
   static CLOSED = 3;
 
@@ -35,6 +38,13 @@ class FakeWebSocket {
   constructor(public readonly url: string) {
     FakeWebSocket.instances.push(this);
     queueMicrotask(() => {
+      if (FakeWebSocket.failNextConnection) {
+        FakeWebSocket.failNextConnection = false;
+        this.emit('error');
+        this.close();
+        return;
+      }
+
       this.emit('open');
     });
   }
@@ -75,6 +85,7 @@ const summaryFixture = {
 afterEach(() => {
   vi.clearAllMocks();
   FakeWebSocket.instances = [];
+  FakeWebSocket.failNextConnection = false;
   global.WebSocket = originalWebSocket;
   Object.defineProperty(window, 'location', {
     configurable: true,
@@ -200,6 +211,70 @@ describe('useCoachChat', () => {
     expect(result.current.progressState).toBe('idle');
     expect(result.current.messages).toHaveLength(1);
     expect(result.current.messages[0]?.content).toBe('Need feedback');
+  });
+
+  it('falls back to REST send when websocket connection fails during send', async () => {
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.mocked(getWorkoutSummary).mockResolvedValue(summaryFixture);
+    vi.mocked(sendWorkoutSummaryMessage).mockResolvedValue({
+      summary: {
+        ...summaryFixture,
+        messages: [
+          {
+            id: 'message-user-1',
+            role: 'user',
+            content: 'Need feedback',
+            createdAtEpochSeconds: 2,
+          },
+          {
+            id: 'message-coach-1',
+            role: 'coach',
+            content: 'Coach reply',
+            createdAtEpochSeconds: 3,
+          },
+        ],
+      },
+      userMessage: {
+        id: 'message-user-1',
+        role: 'user',
+        content: 'Need feedback',
+        createdAtEpochSeconds: 2,
+      },
+      coachMessage: {
+        id: 'message-coach-1',
+        role: 'coach',
+        content: 'Coach reply',
+        createdAtEpochSeconds: 3,
+      },
+    });
+
+    const { result } = renderHook(() => useCoachChat({ apiBaseUrl: '', workoutId: '101' }));
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    FakeWebSocket.failNextConnection = true;
+    act(() => {
+      FakeWebSocket.instances[0]?.emit('error');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    await act(async () => {
+      const sent = await result.current.sendMessage('Need feedback');
+      expect(sent).toBe(true);
+    });
+
+    expect(sendWorkoutSummaryMessage).toHaveBeenCalledWith('', '101', { content: 'Need feedback' });
+    expect(result.current.messages.map((message) => message.content)).toEqual([
+      'Need feedback',
+      'Coach reply',
+    ]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.progressState).toBe('idle');
   });
 
   it('keeps awaiting reply state active after a system message until coach reply arrives', async () => {

--- a/frontend/src/features/coach/hooks/useCoachChat.test.tsx
+++ b/frontend/src/features/coach/hooks/useCoachChat.test.tsx
@@ -216,37 +216,33 @@ describe('useCoachChat', () => {
   it('falls back to REST send when websocket connection fails during send', async () => {
     global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     vi.mocked(getWorkoutSummary).mockResolvedValue(summaryFixture);
-    vi.mocked(sendWorkoutSummaryMessage).mockResolvedValue({
-      summary: {
-        ...summaryFixture,
-        messages: [
-          {
-            id: 'message-user-1',
-            role: 'user',
-            content: 'Need feedback',
-            createdAtEpochSeconds: 2,
-          },
-          {
-            id: 'message-coach-1',
-            role: 'coach',
-            content: 'Coach reply',
-            createdAtEpochSeconds: 3,
-          },
-        ],
-      },
-      userMessage: {
-        id: 'message-user-1',
-        role: 'user',
-        content: 'Need feedback',
-        createdAtEpochSeconds: 2,
-      },
-      coachMessage: {
-        id: 'message-coach-1',
-        role: 'coach',
-        content: 'Coach reply',
-        createdAtEpochSeconds: 3,
-      },
-    });
+    let resolveFallback:
+      | ((value: {
+        summary: typeof summaryFixture & {
+          messages: Array<{
+            id: string;
+            role: 'user' | 'coach';
+            content: string;
+            createdAtEpochSeconds: number;
+          }>;
+        };
+        userMessage: {
+          id: string;
+          role: 'user';
+          content: string;
+          createdAtEpochSeconds: number;
+        };
+        coachMessage: {
+          id: string;
+          role: 'coach';
+          content: string;
+          createdAtEpochSeconds: number;
+        };
+      }) => void)
+      | undefined;
+    vi.mocked(sendWorkoutSummaryMessage).mockImplementation(() => new Promise((resolve) => {
+      resolveFallback = resolve;
+    }));
 
     const { result } = renderHook(() => useCoachChat({ apiBaseUrl: '', workoutId: '101' }));
 
@@ -263,8 +259,49 @@ describe('useCoachChat', () => {
       expect(result.current.isConnected).toBe(false);
     });
 
+    let sendPromise: Promise<boolean> | undefined;
     await act(async () => {
-      const sent = await result.current.sendMessage('Need feedback');
+      sendPromise = result.current.sendMessage('Need feedback');
+    });
+
+    expect(result.current.error).toBeNull();
+
+    act(() => {
+      resolveFallback?.({
+        summary: {
+          ...summaryFixture,
+          messages: [
+            {
+              id: 'message-user-1',
+              role: 'user',
+              content: 'Need feedback',
+              createdAtEpochSeconds: 2,
+            },
+            {
+              id: 'message-coach-1',
+              role: 'coach',
+              content: 'Coach reply',
+              createdAtEpochSeconds: 3,
+            },
+          ],
+        },
+        userMessage: {
+          id: 'message-user-1',
+          role: 'user',
+          content: 'Need feedback',
+          createdAtEpochSeconds: 2,
+        },
+        coachMessage: {
+          id: 'message-coach-1',
+          role: 'coach',
+          content: 'Coach reply',
+          createdAtEpochSeconds: 3,
+        },
+      });
+    });
+
+    await act(async () => {
+      const sent = await sendPromise;
       expect(sent).toBe(true);
     });
 

--- a/frontend/src/features/coach/hooks/useCoachChat.test.tsx
+++ b/frontend/src/features/coach/hooks/useCoachChat.test.tsx
@@ -16,6 +16,7 @@ import {
   isAvailabilityRequiredChatError,
   useCoachChat,
 } from './useCoachChat';
+import type { SendMessageResponse } from '../types';
 
 vi.mock('../api/workoutSummary', () => ({
   createWorkoutSummary: vi.fn(),
@@ -216,30 +217,7 @@ describe('useCoachChat', () => {
   it('falls back to REST send when websocket connection fails during send', async () => {
     global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     vi.mocked(getWorkoutSummary).mockResolvedValue(summaryFixture);
-    let resolveFallback:
-      | ((value: {
-        summary: typeof summaryFixture & {
-          messages: Array<{
-            id: string;
-            role: 'user' | 'coach';
-            content: string;
-            createdAtEpochSeconds: number;
-          }>;
-        };
-        userMessage: {
-          id: string;
-          role: 'user';
-          content: string;
-          createdAtEpochSeconds: number;
-        };
-        coachMessage: {
-          id: string;
-          role: 'coach';
-          content: string;
-          createdAtEpochSeconds: number;
-        };
-      }) => void)
-      | undefined;
+    let resolveFallback: ((value: SendMessageResponse) => void) | undefined;
     vi.mocked(sendWorkoutSummaryMessage).mockImplementation(() => new Promise((resolve) => {
       resolveFallback = resolve;
     }));

--- a/frontend/src/features/coach/hooks/useCoachChat.ts
+++ b/frontend/src/features/coach/hooks/useCoachChat.ts
@@ -6,6 +6,7 @@ import {
   getWorkoutSummary,
   reopenWorkoutSummary,
   saveWorkoutSummary,
+  sendWorkoutSummaryMessage,
   updateWorkoutSummaryRpe,
   type WorkoutSummaryDateRange,
 } from '../api/workoutSummary';
@@ -598,18 +599,34 @@ export function useCoachChat({
         applySummaryState(nextSummary, requestedWorkoutId);
       }
 
-      const socket = await connectSocket(requestedWorkoutId);
-      assertCurrentWorkout(requestedWorkoutId);
-      const payload = clientWsMessageSchema.parse({ type: 'send_message', content: trimmed });
-      setProgressState('awaiting-reply');
-      socket.send(JSON.stringify(payload));
-      setMessages((current) => {
-        if (currentWorkoutIdRef.current !== requestedWorkoutId) {
-          return current;
-        }
+      let socket: WebSocket | null = null;
+      try {
+        socket = await connectSocket(requestedWorkoutId);
+      } catch {
+        socket = null;
+      }
 
-        return [...current, temporaryMessage(trimmed)];
-      });
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        assertCurrentWorkout(requestedWorkoutId);
+        const payload = clientWsMessageSchema.parse({ type: 'send_message', content: trimmed });
+        setProgressState('awaiting-reply');
+        socket.send(JSON.stringify(payload));
+        setMessages((current) => {
+          if (currentWorkoutIdRef.current !== requestedWorkoutId) {
+            return current;
+          }
+
+          return [...current, temporaryMessage(trimmed)];
+        });
+        return true;
+      }
+
+      const response = await sendWorkoutSummaryMessage(apiBaseUrl, requestedWorkoutId, { content: trimmed });
+      assertCurrentWorkout(requestedWorkoutId);
+      setSummary(response.summary);
+      setMessages(response.summary.messages);
+      setDraftRpe(response.summary.rpe);
+      setError(null);
       return true;
     } catch (sendError) {
       if (sendError instanceof StaleWorkoutSelectionError) {

--- a/frontend/src/features/coach/hooks/useCoachChat.ts
+++ b/frontend/src/features/coach/hooks/useCoachChat.ts
@@ -621,12 +621,12 @@ export function useCoachChat({
         return true;
       }
 
+      setError(null);
       const response = await sendWorkoutSummaryMessage(apiBaseUrl, requestedWorkoutId, { content: trimmed });
       assertCurrentWorkout(requestedWorkoutId);
       setSummary(response.summary);
       setMessages(response.summary.messages);
       setDraftRpe(response.summary.rpe);
-      setError(null);
       return true;
     } catch (sendError) {
       if (sendError instanceof StaleWorkoutSelectionError) {

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-29 | CodeRabbit | workout summary chat fallback error flash
+
+- Problem: after the initial websocket-to-REST fallback fix, `useCoachChat.sendMessage(...)` still left the websocket connection error visible while the REST fallback request was in flight. `connectSocket(...)` set `error = "Unable to connect to the coach chat right now."`, the fallback swallowed the rejection, and the code only cleared `error` after the REST response resolved.
+- Fix: moved `setError(null)` to immediately before `sendWorkoutSummaryMessage(...)` and strengthened the fallback regression to hold the REST promise open long enough to assert the stale websocket error is already cleared during the pending request.
+- Prevention: when a fallback path intentionally recovers from an earlier transport error, clear any stale user-facing error state before awaiting the fallback request, not only after success. For async fallback regressions, keep the fallback promise pending long enough to assert interim UI state, not just the final resolved state.
+
 ### 2026-05-29 | user | workout summary chat websocket fallback
 
 - Problem: `frontend/src/features/coach/hooks/useCoachChat.ts` tried to send every workout-summary chat message over websocket only. When the socket failed to reconnect, the UI stayed offline, the green online indicator never returned, and sending a message failed even though the REST `POST /api/workout-summaries/{workout_id}/messages` endpoint still existed for the same behavior.

--- a/reviewers.md
+++ b/reviewers.md
@@ -21,6 +21,12 @@ Read this file before planning and before implementation.
 
 ## Entries
 
+### 2026-05-29 | user | workout summary chat websocket fallback
+
+- Problem: `frontend/src/features/coach/hooks/useCoachChat.ts` tried to send every workout-summary chat message over websocket only. When the socket failed to reconnect, the UI stayed offline, the green online indicator never returned, and sending a message failed even though the REST `POST /api/workout-summaries/{workout_id}/messages` endpoint still existed for the same behavior.
+- Fix: imported `sendWorkoutSummaryMessage(...)` into `useCoachChat` and added a minimal fallback path that uses the existing REST endpoint whenever websocket connection/open fails during `sendMessage(...)`. Added a focused hook regression proving a failed reconnect still sends the message, updates the transcript, and clears the error state.
+- Prevention: when a chat flow offers both websocket streaming and REST request/response paths, keep the REST path wired as the degraded-mode fallback instead of assuming the socket is always available. For online indicators backed by websocket state, add one regression that simulates a reconnect failure during send and verifies the user can still submit a message.
+
 ### 2026-05-28 | user + Copilot + CodeRabbit | PR #257 AI Coach weekly summary review follow-up
 
 - Problem: the first weekly-summary-range fix still had three review gaps: the frontend sent all visible-week ids in one request even though the backend now rejects batches above 31 ids, the visible-week regression test did not assert exclusivity and could still pass with an extra hidden fetch, and the backend error message hardcoded `31` instead of deriving it from the limit constant.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,11 @@
 # Lessons
 
+## 2026-05-29 - Test fixtures with empty arrays must use real response types
+
+- When a frontend test fixture starts with `messages: []`, do not build later async resolver types from `typeof fixture` unless the fixture itself is explicitly annotated. Otherwise TypeScript can infer `never[]` and make later realistic message objects fail only in `tsc -b` or production builds.
+- For mocked API responses in tests, prefer the exported feature type such as `SendMessageResponse` over a hand-written local type stitched together from `typeof summaryFixture` plus overrides.
+- After review-driven test edits in TypeScript-heavy frontend code, run the real `bun run --cwd frontend build`, not only Vitest, because stricter build-time checking can catch `never[]` inference that the test runner path misses.
+
 ## 2026-05-27 - Completed workout alias sets must include provider external ids
 
 - If workout summaries are looked up from completed-workout ids coming from the UI, the alias set cannot stop at `source_activity_id` plus canonical completed-workout id. For imported workouts that exist in both Intervals and Wahoo identity spaces, the persisted summary may still be keyed by the provider external id.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Coach chat now reliably delivers messages even if the WebSocket connection fails, automatically falling back to an alternative delivery method and maintaining conversation history and error state management.

* **Tests**
  * Enhanced test coverage for failure scenarios during chat operations to ensure graceful fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrzejwitkowski/AiWattCoach/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->