### PR TITLE
feat: admin LLM prompt preview (post-workout + calendar coach)

### DIFF
--- a/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+ - Do not stop at "this could be a bit cleaner."
+ - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+ - Prefer the solution that makes the code feel inevitable in hindsight.
+ - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+ - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+ - Treat this as a strong code-quality smell by default.
+ - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+ - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+ - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+ - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+ - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+ - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+ - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+ - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+ - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+ - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+ - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+ - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+ - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+ - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+ - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+ - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+ - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+ - Prefer existing canonical utilities/helpers over bespoke one-offs.
+ - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+ - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+ - If related updates can leave state half-applied, push for a more atomic structure.
+ - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ This file is for coding agents working in `AiWattCoach`.
 - Deploy shape: one Rust server also serves the built SPA from `frontend/dist`.
 - Architecture: hexagonal / ports-and-adapters style.
 
+## Local Machine Constraints (Andrzej Linux dev box)
+
+**Memory / IDE stability:** On this machine, do not run parallel Rust compilation or multiple heavy `cargo` invocations at once. Parallel `rustc` processes can exhaust RAM and crash the IDE.
+
+Agents must:
+
+- Set **`CARGO_BUILD_JOBS=1`** (or `cargo … -j 1`) for every `cargo build`, `cargo test`, `cargo clippy`, and `cargo fmt` check that compiles.
+- Run **at most one** `cargo` command at a time; wait for it to finish before starting another.
+- Prefer **one narrow test filter per invocation** (e.g. `cargo test workout_pick -- --test-threads=1`) instead of `cargo test` for the whole workspace.
+- Never launch several `cargo test` binaries or `verify:rust` steps in parallel in the same turn.
+- Frontend checks (`bun test`, `bun run build`) are lighter; still avoid running them in parallel with an active `cargo` compile on this host.
+
 ## Instruction Sources
 
 - Before starting meaningful work, read the Obsidian handbook entry at `/Users/andrzej.witkowski/obsidian/andrzej.witkowski/opencode/OpenCode Start Here.md`.

--- a/docs/plans/2026-05-31-admin-prompt-preview.md
+++ b/docs/plans/2026-05-31-admin-prompt-preview.md
@@ -1,0 +1,270 @@
+# Admin Prompt Preview (dual surface)
+
+**Goal:** Admin page with date (today or earlier), `userId`, and **two preview actions** that show the full assembled LLM request (pretty-printed JSON) without calling a provider.
+
+| Button | Product surface | Code path |
+| --- | --- | --- |
+| **Preview post-workout request** | AI Coach (completed workout chat) | `LlmWorkoutCoach` / `workout_summary_coach.rs` — `ToolScope::WorkoutSummaryChat` |
+| **Preview calendar view coach** | Calendar → AI coach (general coaching) | `prepare_calendar_llm_request` — `ToolScope::CalendarCoachChat` |
+
+**Non-goals:** Live LLM calls, editing prompts, training-plan / athlete-summary previews, persisting admin previews.
+
+---
+
+## Shared rules
+
+| Topic | Decision |
+| --- | --- |
+| Date | `YYYY-MM-DD`, `is_valid_date`, `date <= today` (UTC, same as admin backfill) |
+| As-of time | Clock frozen to **end of selected UTC day** (`23:59:59`) for `conversation_timing`, `today` in tool context, and calendar overview `focus_date` |
+| User | Required `userId` field (pattern: `/api/admin/settings/{user_id}`) |
+| JSON UI | `JSON.stringify(payload, null, 2)` in large scrollable `<pre>` |
+| Auth | Session + `require_admin` |
+| Conversation in preview | **Synthetic placeholder** unless a stored summary/conversation exists (post-workout only) |
+
+Placeholder user line (both surfaces, when no stored messages):
+
+`"Preview: [admin] sample athlete message"`
+
+---
+
+## 1. Preview post-workout request (AI Coach)
+
+### Behaviour
+
+Shows the request that would be sent when the athlete chats about **one completed workout** on the selected day — same assembly as `LlmWorkoutCoach::reply`, but without `run_tool_loop` / `chat`.
+
+### Workout selection (“best match” for the day)
+
+Domain helper: `pick_representative_completed_workout_for_date(user_id, date)`.
+
+| Step | Action |
+| --- | --- |
+| 1 | `list_by_user_id_and_date_range(user_id, date, date)` |
+| 2 | `select_visible_workouts_by_day(..., wahoo_entity_ids)` — same dedupe as calendar visibility (`src/domain/completed_workouts/selection.rs`) |
+| 3 | 0 workouts → **404** `no_completed_workout_for_date` |
+| 4 | 1 workout → use it |
+| 5 | Multiple | Score planned↔completed pairs using existing **`find_best_activity_match`** (`src/domain/intervals/workout/matching.rs`) + **`build_event_activity_matches`** pattern (`src/domain/training_context/service/context.rs`): load workout-category events + map completed rows to `Activity` for that day, take **max `compliance_score`** across pairs |
+| 6 | No pair ≥ 0.45 | Fallback: highest `training_stress_score`, then latest `start_date_local` |
+| 7 | Resolve canonical id via `CompletedWorkoutTargetService` → `preferred_workout_id` for `workout_id` in summary |
+
+Response `meta` includes selection diagnostics:
+
+```json
+{
+  "selectedWorkoutId": "...",
+  "selectionMethod": "compliance_match | single_workout | tss_fallback | latest_start_fallback",
+  "complianceScore": 0.92
+}
+```
+
+### Training context & summary payload
+
+- `training_context_builder.build(user_id, &workout_id)` with **`as_of_date = selected date`** so `focus_date` is that day (not real today).
+- **Summary source:**
+  - If `WorkoutSummaryRepository` has a document → use real `rpe`, `messages`, `provider_transcript` (preview matches ongoing thread).
+  - Else → minimal stub: `{ workout_id, rpe: null, messages: [], provider_transcript: [] }` + placeholder user message (simulates first post-workout coach turn).
+- **Athlete summary text:** read current stored summary text if available (`get` / ensure path **without** regeneration); omit field when missing (do not trigger LLM regen in preview).
+
+### Refactor
+
+Extract from `workout_summary_coach.rs` (move builders to `src/domain/workout_summary/prompt.rs` or `src/domain/llm/prompt_assembly/workout_summary.rs`):
+
+- `assemble_workout_summary_coach_request(WorkoutSummaryCoachPromptInput) -> LlmChatRequest`
+- `LlmWorkoutCoach::reply` calls the helper.
+
+Populate `tools` / `tool_choice` for `ToolScope::WorkoutSummaryChat` like `run_tool_loop` does.
+
+---
+
+## 2. Preview calendar view coach
+
+### Behaviour
+
+Shows the request for **calendar AI coach** — general coaching from calendar view (`build_calendar_overview_context`, calendar system prompt, calendar stable/volatile builders).
+
+Unchanged from original plan except naming:
+
+- `build_calendar_overview_context_as_of(user_id, focus_date)`
+- `assemble_calendar_coach_request` extracted from `src/domain/coach_conversation/service/request.rs`
+- Synthetic `CoachConversation` (overview focus, empty messages) + placeholder user line
+- `ToolScope::CalendarCoachChat` tools included
+
+---
+
+## API
+
+Two explicit routes (maps 1:1 to UI buttons):
+
+```
+GET /api/admin/users/{user_id}/prompt-preview/post-workout?date=YYYY-MM-DD
+GET /api/admin/users/{user_id}/prompt-preview/calendar-coach?date=YYYY-MM-DD
+```
+
+### Response shape (both)
+
+```json
+{
+  "meta": {
+    "userId": "...",
+    "date": "2026-05-30",
+    "surface": "post_workout | calendar_coach",
+    "provider": "...",
+    "model": "...",
+    "focusDate": "2026-05-30"
+  },
+  "request": {
+    "systemPrompt": "...",
+    "stableContext": "...",
+    "volatileContext": "...",
+    "conversation": [],
+    "tools": [],
+    "toolChoice": "auto"
+  },
+  "providerMessages": []
+}
+```
+
+Post-workout `meta` adds `selectedWorkoutId`, `selectionMethod`, optional `complianceScore`.
+
+### Errors
+
+| Condition | Status |
+| --- | --- |
+| Not admin | 403 |
+| Bad / future date | 400 |
+| No completed workout on date (post-workout only) | 404 |
+| Service not wired | 503 |
+| Build failure | 500 |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+  UI[AdminPromptPreviewPage]
+  REST[admin_prompt_preview handlers]
+  Svc[AdminPromptPreviewService]
+  Pick[pick_representative_completed_workout]
+  W[assemble_workout_summary_coach_request]
+  C[assemble_calendar_coach_request]
+  Ctx[TrainingContextBuilder as_of]
+
+  UI -->|post-workout button| REST
+  UI -->|calendar button| REST
+  REST --> Svc
+  Svc --> Pick
+  Pick --> W
+  Svc --> C
+  W --> Ctx
+  C --> Ctx
+```
+
+### Domain module
+
+`src/domain/admin_prompt_preview/` (or `src/domain/llm/prompt_preview/`):
+
+- `ports.rs` — trait `AdminPromptPreviewUseCases`
+- `service.rs` — orchestration
+- `workout_selection.rs` — day picker (unit-tested)
+- Reuses extracted assemblers in `workout_summary` + `coach_conversation`
+
+### Training context change
+
+```rust
+fn build_as_of(
+    &self,
+    user_id: &str,
+    workout_id: &str,
+    focus_date: NaiveDate,
+) -> BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
+
+fn build_calendar_overview_context_as_of(
+    &self,
+    user_id: &str,
+    focus_date: NaiveDate,
+) -> BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
+```
+
+`build` / `build_calendar_overview_context` keep calling with `as_of: None` (production behaviour).
+
+---
+
+## Frontend
+
+### Route
+
+`/admin/prompt-preview` — admin nav entry (i18n `nav.promptPreview`).
+
+### Controls
+
+1. `userId` text input  
+2. `type="date"` with `max={todayUtc}`  
+3. **Preview post-workout request** (primary / amber)  
+4. **Preview calendar view coach** (secondary / slate)  
+5. Shared preview panel — shows last successful response; label which button produced it (`meta.surface`)
+
+### Feature module
+
+- `loadAdminPostWorkoutPromptPreview(apiBaseUrl, userId, date)`
+- `loadAdminCalendarCoachPromptPreview(apiBaseUrl, userId, date)`
+- Zod schemas + API tests for both paths
+- Page test: both buttons call correct URLs; 404 surfaced for empty day on post-workout
+
+---
+
+## Tests
+
+### Backend unit
+
+| Case | Module |
+| --- | --- |
+| Multiple workouts → highest compliance wins | `workout_selection.rs` |
+| No compliance → TSS / latest fallback | same |
+| `select_visible_workouts_by_day` respected before scoring | same |
+| `build_as_of` sets `focus_date` on overview + workout id | `training_context` |
+
+### Backend integration
+
+| Case | File |
+| --- | --- |
+| 403 non-admin | `tests/admin_prompt_preview_rest.rs` |
+| 400 future date | both routes |
+| 404 no workout (post-workout) | post-workout route |
+| 200 calendar coach with empty day allowed | calendar route |
+| 200 post-workout includes `selectedWorkoutId` | fakes with 2 workouts + scored match |
+
+### Frontend
+
+- API tests (2 endpoints)
+- Page: date max, button → pretty JSON, error states
+
+---
+
+## Implementation order
+
+1. `as_of` on `TrainingContextBuilder` + tests  
+2. `workout_selection.rs` + tests  
+3. Extract `assemble_workout_summary_coach_request` + `assemble_calendar_coach_request`  
+4. `AdminPromptPreviewService` + AppState wiring  
+5. REST: two handlers + routes  
+6. Integration tests  
+7. Frontend page + i18n  
+8. `verify:arch`, fmt, clippy, targeted tests  
+
+---
+
+## Security
+
+- Admin-only; responses contain PII and full packed context.  
+- Do not log response bodies on these routes.  
+- No external API cost.
+
+---
+
+## Out of scope
+
+- Training plan / athlete summary preview buttons  
+- Pretty-printing JSON *inside* `stableContext` strings  
+- Deep-link from task scheduler

--- a/docs/plans/2026-05-31-admin-prompt-preview.md
+++ b/docs/plans/2026-05-31-admin-prompt-preview.md
@@ -44,8 +44,8 @@ Domain helper: `pick_representative_completed_workout_for_date(user_id, date)`.
 | 2 | `select_visible_workouts_by_day(..., wahoo_entity_ids)` — same dedupe as calendar visibility (`src/domain/completed_workouts/selection.rs`) |
 | 3 | 0 workouts → **404** `no_completed_workout_for_date` |
 | 4 | 1 workout → use it |
-| 5 | Multiple | Score planned↔completed pairs using existing **`find_best_activity_match`** (`src/domain/intervals/workout/matching.rs`) + **`build_event_activity_matches`** pattern (`src/domain/training_context/service/context.rs`): load workout-category events + map completed rows to `Activity` for that day, take **max `compliance_score`** across pairs |
-| 6 | No pair ≥ 0.45 | Fallback: highest `training_stress_score`, then latest `start_date_local` |
+| 5 | Multiple workouts → score planned↔completed pairs using existing **`find_best_activity_match`** (`src/domain/intervals/workout/matching.rs`) + **`build_event_activity_matches`** pattern (`src/domain/training_context/service/context.rs`): load workout-category events + map completed rows to `Activity` for that day, take **max `compliance_score`** across pairs |
+| 6 | No pair ≥ 0.45 → fallback: highest `training_stress_score`, then latest `start_date_local` |
 | 7 | Resolve canonical id via `CompletedWorkoutTargetService` → `preferred_workout_id` for `workout_id` in summary |
 
 Response `meta` includes selection diagnostics:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { SettingsProvider } from './features/settings/context/SettingsContext';
 import { CompletedWorkoutsProvider } from './features/intervals/context';
 import { AppHomePage } from './pages/AppHomePage';
 import { AdminSystemInfoPage } from './pages/AdminSystemInfoPage';
+import { AdminPromptPreviewPage } from './pages/AdminPromptPreviewPage';
 import { AdminTaskSchedulerPage } from './pages/AdminTaskSchedulerPage';
 import { CalendarPage } from './pages/CalendarPage';
 import { AICoachPage } from './pages/AICoachPage';
@@ -133,6 +134,14 @@ export function App() {
                     </ApiBaseUrlProvider>
                   }
                   path="/admin/task-scheduler"
+                />
+                <Route
+                  element={
+                    <ApiBaseUrlProvider value={API_BASE_URL}>
+                      <AdminPromptPreviewPage />
+                    </ApiBaseUrlProvider>
+                  }
+                  path="/admin/prompt-preview"
                 />
                 <Route
                   element={

--- a/frontend/src/app/AuthenticatedLayout.tsx
+++ b/frontend/src/app/AuthenticatedLayout.tsx
@@ -7,6 +7,7 @@ import {
   Flag,
   LayoutDashboard,
   ListChecks,
+  ScrollText,
   Settings,
   ShieldCheck,
 } from 'lucide-react';
@@ -29,6 +30,7 @@ const PAGE_TITLE_KEYS: Record<string, string> = {
   '/races': 'appShell.pageTitles.races',
   '/ai-coach': 'appShell.pageTitles.aiCoach',
   '/admin/task-scheduler': 'appShell.pageTitles.taskScheduler',
+  '/admin/prompt-preview': 'appShell.pageTitles.promptPreview',
   '/admin/system-info': 'appShell.pageTitles.systemInfo',
 };
 
@@ -68,6 +70,7 @@ export function AuthenticatedLayout({ apiBaseUrl }: AuthenticatedLayoutProps) {
           {currentUser && currentUser.roles.includes('admin') && (
             <>
               <NavItem to="/admin/task-scheduler" icon={ListChecks} label={t('nav.taskScheduler')} />
+              <NavItem to="/admin/prompt-preview" icon={ScrollText} label={t('nav.promptPreview')} />
               <NavItem to="/admin/system-info" icon={ShieldCheck} label={t('nav.systemInfo')} />
             </>
           )}

--- a/frontend/src/features/admin-prompt-preview/api.test.ts
+++ b/frontend/src/features/admin-prompt-preview/api.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  loadAdminCalendarCoachPromptPreview,
+  loadAdminPostWorkoutPromptPreview,
+} from './api';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('admin prompt preview api', () => {
+  it('loads post-workout preview', async () => {
+    mockFetch({
+      meta: {
+        userId: 'user-1',
+        date: '2026-05-01',
+        surface: 'post_workout',
+        provider: 'openrouter',
+        model: 'test-model',
+        focusDate: '2026-05-01',
+        selectedWorkoutId: 'ride-1',
+        selectionMethod: 'single_workout',
+      },
+      request: {
+        systemPrompt: 'system',
+        stableContext: 'stable',
+        volatileContext: 'volatile',
+        conversation: [],
+        tools: [],
+        toolChoice: 'auto',
+      },
+      providerMessages: [{ role: 'system', content: 'system' }],
+    });
+
+    const result = await loadAdminPostWorkoutPromptPreview('', 'user-1', '2026-05-01');
+    expect(result.meta.surface).toBe('post_workout');
+    expect(result.meta.selectedWorkoutId).toBe('ride-1');
+  });
+
+  it('loads calendar coach preview', async () => {
+    mockFetch({
+      meta: {
+        userId: 'user-1',
+        date: '2026-05-01',
+        surface: 'calendar_coach',
+        provider: 'openrouter',
+        model: 'test-model',
+        focusDate: '2026-05-01',
+      },
+      request: {
+        systemPrompt: 'system',
+        stableContext: 'stable',
+        volatileContext: 'volatile',
+        conversation: [{ role: 'user', content: 'hello' }],
+        tools: [],
+        toolChoice: 'none',
+      },
+      providerMessages: [],
+    });
+
+    const result = await loadAdminCalendarCoachPromptPreview('', 'user-1', '2026-05-01');
+    expect(result.meta.surface).toBe('calendar_coach');
+  });
+});
+
+function mockFetch(payload: unknown) {
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+    .mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  global.fetch = fetchMock as typeof fetch;
+  return fetchMock;
+}

--- a/frontend/src/features/admin-prompt-preview/api.ts
+++ b/frontend/src/features/admin-prompt-preview/api.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from 'react';
+
+import { useApiBaseUrl } from '../../lib/apiBaseUrl';
+import { get } from '../../lib/httpClient';
+import { adminPromptPreviewResponseSchema, type AdminPromptPreviewResponse } from './types';
+
+function buildPath(userId: string, surface: 'post-workout' | 'calendar-coach', date: string) {
+  const encodedUserId = encodeURIComponent(userId);
+  const query = new URLSearchParams({ date });
+  return `/api/admin/users/${encodedUserId}/prompt-preview/${surface}?${query.toString()}`;
+}
+
+export async function loadAdminPostWorkoutPromptPreview(
+  apiBaseUrl: string,
+  userId: string,
+  date: string,
+): Promise<AdminPromptPreviewResponse> {
+  const data = await get(apiBaseUrl, buildPath(userId, 'post-workout', date));
+  return adminPromptPreviewResponseSchema.parse(data);
+}
+
+export async function loadAdminCalendarCoachPromptPreview(
+  apiBaseUrl: string,
+  userId: string,
+  date: string,
+): Promise<AdminPromptPreviewResponse> {
+  const data = await get(apiBaseUrl, buildPath(userId, 'calendar-coach', date));
+  return adminPromptPreviewResponseSchema.parse(data);
+}
+
+export function useAdminPromptPreviewApi() {
+  const apiBaseUrl = useApiBaseUrl();
+
+  const loadPostWorkout = useCallback(
+    async (userId: string, date: string) =>
+      loadAdminPostWorkoutPromptPreview(apiBaseUrl, userId, date),
+    [apiBaseUrl],
+  );
+
+  const loadCalendarCoach = useCallback(
+    async (userId: string, date: string) =>
+      loadAdminCalendarCoachPromptPreview(apiBaseUrl, userId, date),
+    [apiBaseUrl],
+  );
+
+  return useMemo(
+    () => ({
+      loadAdminPostWorkoutPromptPreview: loadPostWorkout,
+      loadAdminCalendarCoachPromptPreview: loadCalendarCoach,
+    }),
+    [loadCalendarCoach, loadPostWorkout],
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/ConversationSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ConversationSection.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+import type { AdminPromptPreviewResponse } from '../types';
+import { SectionCard } from './SystemPromptSection';
+
+type ConversationSectionProps = {
+  conversation: AdminPromptPreviewResponse['request']['conversation'];
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  user: 'border-sky-500/30 bg-sky-500/5',
+  assistant: 'border-emerald-500/30 bg-emerald-500/5',
+  tool: 'border-amber-500/20 bg-amber-500/5',
+  system: 'border-slate-500/30 bg-slate-500/5',
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  user: 'User',
+  assistant: 'Coach',
+  tool: 'Tool',
+  system: 'System',
+};
+
+export function ConversationSection({ conversation }: ConversationSectionProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  if (conversation.length === 0) return null;
+
+  return (
+    <SectionCard title={`Conversation (${conversation.length} messages)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-3">
+          {conversation.map((msg, i) => {
+            const role = String((msg as Record<string, unknown>).role ?? '');
+            const content = String((msg as Record<string, unknown>).content ?? '');
+            const toolCalls = (msg as Record<string, unknown>).tool_calls;
+            return (
+              <div key={i} className={`rounded-xl border px-4 py-3 ${ROLE_COLORS[role] ?? 'border-white/10 bg-white/[0.02]'}`}>
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    {ROLE_LABELS[role] ?? role}
+                  </span>
+                  <span className="text-[10px] text-slate-600">#{i}</span>
+                </div>
+                <div className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">{content}</div>
+                {Array.isArray(toolCalls) && toolCalls.length > 0 && (
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-xs text-slate-500">Tool calls ({toolCalls.length})</summary>
+                    <pre className="mt-1 overflow-auto rounded-lg bg-[#070b12] p-2 font-mono text-xs text-slate-400">
+                      {JSON.stringify(toolCalls, null, 2)}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/ConversationSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ConversationSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import type { AdminPromptPreviewResponse } from '../types';
-import { SectionCard } from './SystemPromptSection';
+import { SectionCard } from './SectionCard';
 
 type ConversationSectionProps = {
   conversation: AdminPromptPreviewResponse['request']['conversation'];

--- a/frontend/src/features/admin-prompt-preview/components/DecodedPackedContext.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/DecodedPackedContext.tsx
@@ -1,0 +1,300 @@
+import { useMemo } from 'react';
+import { decodeShortKey, formatSeconds } from '../utils/decodePackedContext';
+
+type DecodedPackedContextProps = {
+  label: string;
+  data: Record<string, unknown>;
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export function DecodedPackedContext({ label, data }: DecodedPackedContextProps) {
+  const sections = useMemo(() => buildSections(data), [data]);
+
+  return (
+    <div className="space-y-4">
+      <div className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">{label}</div>
+      {sections.map((section, i) => (
+        <div key={i} className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3">
+          {section}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function buildSections(data: Record<string, unknown>): React.ReactNode[] {
+  const sections: React.ReactNode[] = [];
+
+  if (data.p && isObject(data.p)) {
+    sections.push(buildProfileTable(data.p));
+  }
+  if (data.rc && Array.isArray(data.rc)) {
+    sections.push(buildRaceTable(data.rc));
+  }
+  if (data.h && isObject(data.h)) {
+    sections.push(buildHistorySummary(data.h));
+  }
+  if (data.rd && Array.isArray(data.rd)) {
+    sections.push(buildRecentDays(data.rd));
+  }
+
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(data)) {
+    if (!['p', 'rc', 'h', 'rd', 'ud', 'pd', 'fe', 'v', 'g', 'fx', 'i'].includes(key)) {
+      rest[key] = data[key];
+    }
+  }
+
+  const rawSection = buildRawTable(rest);
+  if (rawSection) sections.push(rawSection);
+
+  return sections;
+}
+
+function buildProfileTable(p: Record<string, unknown>) {
+  const rows: { label: string; value: string }[] = [];
+  if (p.fnm) rows.push({ label: 'Name', value: String(p.fnm) });
+  if (p.age) rows.push({ label: 'Age', value: String(p.age) });
+  if (p.hcm) rows.push({ label: 'Height', value: `${p.hcm} cm` });
+  if (p.wkg) rows.push({ label: 'Weight', value: `${p.wkg} kg` });
+  if (p.ftp) rows.push({ label: 'FTP', value: `${p.ftp} W` });
+  if (p.hrm) rows.push({ label: 'Max HR', value: String(p.hrm) });
+  if (p.vo2) rows.push({ label: 'VO₂max', value: String(p.vo2) });
+  if (p.meds) rows.push({ label: 'Medications', value: String(p.meds) });
+  if (p.notes) rows.push({ label: 'Notes', value: String(p.notes) });
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Athlete Profile</div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm md:grid-cols-3">
+        {rows.map((r) => (
+          <div key={r.label} className="flex justify-between gap-2">
+            <span className="text-slate-400">{r.label}</span>
+            <span className="text-slate-200">{r.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function buildRaceTable(races: unknown[]) {
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Race Calendar</div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-white/10 text-left text-xs uppercase text-slate-500">
+            <th className="pb-1 pr-3">Date</th>
+            <th className="pb-1 pr-3">Name</th>
+            <th className="pb-1 pr-3">Dist</th>
+            <th className="pb-1 pr-3">Priority</th>
+          </tr>
+        </thead>
+        <tbody>
+          {races.map((item, i) => {
+            const r = item as Record<string, unknown>;
+            return (
+              <tr key={i} className="border-b border-white/5 text-slate-200">
+                <td className="py-1 pr-3 text-slate-400">{String(r.d ?? '')}</td>
+                <td className="py-1 pr-3">{String(r.n ?? '')}</td>
+                <td className="py-1 pr-3">{r.km ? `${r.km} km` : ''}</td>
+                <td className="py-1 pr-3">
+                  <PriorityBadge priority={String(r.pri ?? '')} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PriorityBadge({ priority }: { priority: string }) {
+  const colors: Record<string, string> = {
+    A: 'bg-red-500/20 text-red-300',
+    B: 'bg-amber-500/20 text-amber-300',
+    C: 'bg-slate-500/20 text-slate-300',
+  };
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-xs font-semibold ${colors[priority] ?? 'bg-white/10 text-slate-300'}`}>
+      {priority}
+    </span>
+  );
+}
+
+function buildHistorySummary(h: Record<string, unknown>) {
+  const metrics: { label: string; value: string }[] = [];
+  if (h.ac) metrics.push({ label: 'Activities', value: String(h.ac) });
+  if (h.ttss) metrics.push({ label: 'Total TSS', value: String(h.ttss) });
+  if (h.ctl != null) metrics.push({ label: 'CTL', value: numStr(h.ctl) });
+  if (h.atl != null) metrics.push({ label: 'ATL', value: numStr(h.atl) });
+  if (h.tsb != null) metrics.push({ label: 'TSB', value: numStr(h.tsb) });
+  if (h.ftp) metrics.push({ label: 'FTP', value: `${h.ftp} W` });
+  if (h.ftpd) metrics.push({ label: 'FTP Δ', value: numStr(h.ftpd) });
+  if (h.t7) metrics.push({ label: 'Avg TSS 7d', value: numStr(h.t7) });
+  if (h.t28) metrics.push({ label: 'Avg TSS 28d', value: numStr(h.t28) });
+
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Training Load Summary</div>
+      <div className="mb-3 grid grid-cols-2 gap-x-6 gap-y-1 text-sm md:grid-cols-4">
+        {metrics.map((m) => (
+          <div key={m.label} className="flex justify-between gap-2">
+            <span className="text-slate-400">{m.label}</span>
+            <span className="text-slate-200">{m.value}</span>
+          </div>
+        ))}
+      </div>
+      {Array.isArray(h.lt) && h.lt.length > 0 && (
+        <details>
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Load Trend ({h.lt.length} days)
+          </summary>
+          <div className="mt-2 max-h-48 overflow-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-slate-500">
+                  <th className="pb-1 pr-2">Date</th>
+                  <th className="pb-1 pr-2">TSS</th>
+                  <th className="pb-1 pr-2">CTL</th>
+                  <th className="pb-1 pr-2">ATL</th>
+                  <th className="pb-1 pr-2">TSB</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(h.lt as unknown[]).slice(-21).map((pt, i) => {
+                  const p = pt as Record<string, unknown>;
+                  const tsbVal = Number(p.tsb);
+                  return (
+                    <tr key={i} className="border-b border-white/5 text-slate-300">
+                      <td className="py-0.5 pr-2 text-slate-500">{String(p.d ?? '')}</td>
+                      <td className="py-0.5 pr-2">{String(p.tss ?? '')}</td>
+                      <td className="py-0.5 pr-2">{numStr(p.ctl)}</td>
+                      <td className="py-0.5 pr-2">{numStr(p.atl)}</td>
+                      <td className={`py-0.5 pr-2 ${!Number.isNaN(tsbVal) && tsbVal < -5 ? 'text-red-300' : !Number.isNaN(tsbVal) && tsbVal > 5 ? 'text-green-300' : ''}`}>
+                        {numStr(p.tsb)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function buildRecentDays(rd: unknown[]) {
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Recent Days</div>
+      <div className="space-y-2">
+        {(rd as unknown[]).slice(-7).map((item, i) => {
+          const d = item as Record<string, unknown>;
+          return (
+            <details key={i}>
+              <summary className="cursor-pointer rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-sm">
+                <span className="text-slate-300">{String(d.d ?? '')}</span>
+                {d.fr ? <span className="ml-2 text-xs text-cyan-400">Free day</span> : null}
+                {d.sick ? <span className="ml-2 text-xs text-red-400">Sick</span> : null}
+                {Array.isArray(d.w) && d.w.length > 0 ? (
+                  <span className="ml-2 text-xs text-slate-500">
+                    {d.w.length} workout{d.w.length > 1 ? 's' : ''}
+                  </span>
+                ) : (
+                  <span className="ml-2 text-xs text-slate-500">Rest</span>
+                )}
+              </summary>
+              {Array.isArray(d.w) && d.w.length > 0 && (
+                <div className="mt-2 space-y-2 pl-2">
+                  {(d.w as unknown[]).map((w, j) => {
+                    const workout = w as Record<string, unknown>;
+                    return (
+                      <div key={j} className="rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-sm">
+                          <span className="font-medium text-slate-200">{String(workout.n ?? '')}</span>
+                          <span className="text-xs text-slate-500">{String(workout.ty ?? '')}</span>
+                          {workout.dur ? <span className="text-xs text-slate-400">{formatSeconds(Number(workout.dur))}</span> : null}
+                          {workout.tss != null ? <span className="text-xs text-slate-400">{String(workout.tss)} TSS</span> : null}
+                          {workout.ifv != null ? <span className="text-xs text-slate-400">IF {numStr(workout.ifv)}</span> : null}
+                          {workout.rpe != null ? <RPEDisplay rpe={Number(workout.rpe)} /> : null}
+                        </div>
+                        {typeof workout.recap === 'string' && workout.recap.length > 80 && (
+                          <details className="mt-1">
+                            <summary className="cursor-pointer text-xs text-slate-500">Recap snippet</summary>
+                            <div className="mt-1 whitespace-pre-wrap break-words text-xs leading-5 text-slate-400">
+                              {(workout.recap as string).slice(0, 300)}
+                              {(workout.recap as string).length > 300 ? '…' : ''}
+                            </div>
+                          </details>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </details>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RPEDisplay({ rpe }: { rpe: number }) {
+  const colors: Record<number, string> = {
+    1: 'text-green-400',
+    2: 'text-green-300',
+    3: 'text-sky-300',
+    4: 'text-sky-200',
+    5: 'text-amber-300',
+    6: 'text-amber-200',
+    7: 'text-orange-300',
+    8: 'text-red-300',
+    9: 'text-red-400',
+    10: 'text-red-500',
+  };
+  return <span className={`text-xs font-semibold ${colors[rpe] ?? 'text-slate-400'}`}>RPE {rpe}</span>;
+}
+
+function buildRawTable(data: Record<string, unknown>) {
+  const entries = Object.entries(data).filter(([, v]) => {
+    if (v == null) return false;
+    if (Array.isArray(v) && v.length === 0) return false;
+    if (isObject(v) && Object.keys(v).length === 0) return false;
+    return true;
+  });
+  if (entries.length === 0) return null;
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Other Fields</div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm md:grid-cols-3">
+        {entries.map(([key, val]) => (
+          <div key={key} className="flex justify-between gap-2">
+            <span className="text-slate-400">{decodeShortKey(key)}</span>
+            <span className="text-slate-200">{fmtVal(val)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function fmtVal(v: unknown): string {
+  if (typeof v === 'number') return String(v);
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return `[${v.length} items]`;
+  if (isObject(v)) return `{${Object.keys(v).length} fields}`;
+  return String(v);
+}
+
+function numStr(v: unknown): string {
+  if (typeof v === 'number') return v.toFixed(1);
+  return String(v ?? '');
+}

--- a/frontend/src/features/admin-prompt-preview/components/MetaBar.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/MetaBar.tsx
@@ -1,0 +1,33 @@
+import type { AdminPromptPreviewResponse } from '../types';
+
+type MetaBarProps = {
+  meta: AdminPromptPreviewResponse['meta'];
+};
+
+export function MetaBar({ meta }: MetaBarProps) {
+  return (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-white/10 bg-[#0f1620]/95 px-5 py-3 text-xs uppercase tracking-wider text-slate-400 backdrop-blur">
+      <span className="font-semibold text-[#f2c98e]">{meta.surface}</span>
+      {meta.selectedWorkoutId ? <span>· {meta.selectedWorkoutId}</span> : null}
+      <span className="text-slate-500">·</span>
+      <span>{meta.date}</span>
+      <span className="text-slate-500">·</span>
+      <span className="text-cyan-300">{meta.provider}</span>
+      <span className="text-cyan-300/60">{meta.model}</span>
+      {meta.focusDate ? (
+        <>
+          <span className="text-slate-500">·</span>
+          <span>focus {meta.focusDate}</span>
+        </>
+      ) : null}
+      {meta.complianceScore != null ? (
+        <>
+          <span className="text-slate-500">·</span>
+          <span className={meta.complianceScore < 0.7 ? 'text-amber-400' : 'text-slate-400'}>
+            compliance {Math.round(meta.complianceScore * 100)}%
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/ProviderMessagesSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ProviderMessagesSection.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+import type { AdminPromptPreviewResponse } from '../types';
+import { SectionCard } from './SystemPromptSection';
+
+type ProviderMessagesSectionProps = {
+  messages: AdminPromptPreviewResponse['providerMessages'];
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  system: 'System',
+  user: 'User',
+  assistant: 'Assistant',
+  tool: 'Tool',
+};
+
+export function ProviderMessagesSection({ messages }: ProviderMessagesSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (messages.length === 0) return null;
+
+  return (
+    <SectionCard title={`Provider Messages (${messages.length})`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-3">
+          {messages.map((msg, i) => (
+            <div
+              key={i}
+              className={`rounded-xl border px-4 py-3 ${
+                msg.role === 'system'
+                  ? 'border-slate-500/20 bg-slate-500/5'
+                  : msg.role === 'assistant'
+                    ? 'border-emerald-500/20 bg-emerald-500/5'
+                    : 'border-white/10 bg-white/[0.02]'
+              }`}
+            >
+              <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                {ROLE_LABELS[msg.role] ?? msg.role}
+              </div>
+              <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-slate-300">
+                {msg.content.length > 5000 ? msg.content.slice(0, 5000) + '\n… (truncated)' : msg.content}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/ProviderMessagesSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ProviderMessagesSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import type { AdminPromptPreviewResponse } from '../types';
-import { SectionCard } from './SystemPromptSection';
+import { SectionCard } from './SectionCard';
 
 type ProviderMessagesSectionProps = {
   messages: AdminPromptPreviewResponse['providerMessages'];

--- a/frontend/src/features/admin-prompt-preview/components/SectionCard.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/SectionCard.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+type SectionCardProps = {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+};
+
+export function SectionCard({ title, expanded, onToggle, children }: SectionCardProps) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03]">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between px-5 py-3 text-left text-xs font-semibold uppercase tracking-[0.15em] text-slate-400"
+      >
+        <span>{title}</span>
+        <span className="text-slate-500">{expanded ? '▾' : '▸'}</span>
+      </button>
+      {expanded && <div className="border-t border-white/5 px-5 py-4">{children}</div>}
+    </div>
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
 
 import { MarkdownContent } from '../../../lib/markdown/MarkdownContent';
-import { tryParseJson } from '../utils/parseContextLines';
-import { SectionCard } from './SystemPromptSection';
+import { parseKeyValueLines, tryParseJson } from '../utils/parseContextLines';
 import { DecodedPackedContext } from './DecodedPackedContext';
+import { SectionCard } from './SectionCard';
 
 type StableContextSectionProps = {
   rawText: string;
@@ -13,7 +13,20 @@ export function StableContextSection({ rawText }: StableContextSectionProps) {
   const [showRaw, setShowRaw] = useState(false);
   const [expanded, setExpanded] = useState(true);
 
-  const parsed = useMemo(() => parseStableContext(rawText), [rawText]);
+  const parsed = useMemo(() => {
+    const lines = parseKeyValueLines(rawText);
+    const workoutSummary = tryParseJson<Record<string, unknown>>(lines.workout_summary ?? '');
+    const selectedWorkout = tryParseJson<Record<string, unknown>>(lines.selected_workout ?? '');
+    const packedJson = tryParseJson<Record<string, unknown>>(lines.training_context_stable ?? '');
+    return {
+      workoutId: workoutSummary ? String(workoutSummary.workoutId ?? '') : null,
+      rpe: workoutSummary ? (workoutSummary.rpe != null ? Number(workoutSummary.rpe) : null) : null,
+      workoutDate: selectedWorkout ? String(selectedWorkout.date ?? '') : null,
+      workoutContext: lines.current_workout_context?.trim() ?? null,
+      athleteSummary: lines.athlete_summary_text?.trim() ?? null,
+      packedJson,
+    };
+  }, [rawText]);
 
   return (
     <SectionCard title={`Stable Context (${rawText.length} chars)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
@@ -74,71 +87,4 @@ export function StableContextSection({ rawText }: StableContextSectionProps) {
       )}
     </SectionCard>
   );
-}
-
-function parseStableContext(text: string) {
-  const result: {
-    workoutId: string | null;
-    rpe: number | null;
-    workoutDate: string | null;
-    workoutContext: string | null;
-    athleteSummary: string | null;
-    packedJson: Record<string, unknown> | null;
-  } = {
-    workoutId: null,
-    rpe: null,
-    workoutDate: null,
-    workoutContext: null,
-    athleteSummary: null,
-    packedJson: null,
-  };
-
-  const lines = text.split('\n');
-  let currentKey: string | null = null;
-  let currentValue = '';
-
-  for (const line of lines) {
-    if (currentKey === null) {
-      const eqIdx = line.indexOf('=');
-      if (eqIdx < 0) continue;
-      currentKey = line.slice(0, eqIdx);
-      currentValue = line.slice(eqIdx + 1);
-    } else {
-      currentValue += '\n' + line;
-    }
-
-    if (currentKey === 'workout_summary') {
-      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
-      if (parsed) {
-        result.workoutId = String(parsed.workoutId ?? '');
-        result.rpe = parsed.rpe != null ? Number(parsed.rpe) : null;
-      }
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'selected_workout') {
-      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
-      if (parsed) result.workoutDate = String(parsed.date ?? '');
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'current_workout_context') {
-      result.workoutContext = currentValue.trim();
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'athlete_summary_text') {
-      result.athleteSummary = (result.athleteSummary ?? '') + currentValue;
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'training_context_stable') {
-      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
-      if (parsed) result.packedJson = parsed;
-      currentKey = null;
-      currentValue = '';
-    }
-  }
-
-  if (currentKey === 'athlete_summary_text') {
-    result.athleteSummary = (result.athleteSummary ?? '') + currentValue;
-  }
-
-  return result;
 }

--- a/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react';
+
+import { MarkdownContent } from '../../../lib/markdown/MarkdownContent';
+import { tryParseJson } from '../utils/parseContextLines';
+import { SectionCard } from './SystemPromptSection';
+import { DecodedPackedContext } from './DecodedPackedContext';
+
+type StableContextSectionProps = {
+  rawText: string;
+};
+
+export function StableContextSection({ rawText }: StableContextSectionProps) {
+  const [showRaw, setShowRaw] = useState(false);
+  const [expanded, setExpanded] = useState(true);
+
+  const parsed = useMemo(() => parseStableContext(rawText), [rawText]);
+
+  return (
+    <SectionCard title={`Stable Context (${rawText.length} chars)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-4">
+          {parsed.workoutId && parsed.rpe != null && (
+            <div className="flex flex-wrap gap-4 text-sm">
+              <span className="text-slate-400">
+                Workout: <span className="text-slate-200">{parsed.workoutId}</span>
+              </span>
+              <span className="text-slate-400">
+                RPE: <span className="text-slate-200">{parsed.rpe}</span>
+              </span>
+              {parsed.workoutDate && (
+                <span className="text-slate-400">
+                  Date: <span className="text-slate-200">{parsed.workoutDate}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {parsed.workoutContext && (
+            <div className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-slate-300">
+              {parsed.workoutContext}
+            </div>
+          )}
+
+          {parsed.athleteSummary && (
+            <details className="rounded-xl border border-white/10 bg-white/[0.02]">
+              <summary className="cursor-pointer px-4 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                Athlete Summary
+              </summary>
+              <div className="border-t border-white/5 px-4 py-3 text-sm">
+                <MarkdownContent>{parsed.athleteSummary}</MarkdownContent>
+              </div>
+            </details>
+          )}
+
+          {parsed.packedJson && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowRaw(!showRaw)}
+                className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500 hover:text-slate-300"
+              >
+                {showRaw ? 'Decoded view' : 'Show raw JSON'}
+              </button>
+              {showRaw ? (
+                <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-xl border border-white/10 bg-[#070b12] p-4 font-mono text-xs leading-5 text-slate-400">
+                  {JSON.stringify(parsed.packedJson, null, 2)}
+                </pre>
+              ) : (
+                <DecodedPackedContext label="Training Context" data={parsed.packedJson} />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function parseStableContext(text: string) {
+  const result: {
+    workoutId: string | null;
+    rpe: number | null;
+    workoutDate: string | null;
+    workoutContext: string | null;
+    athleteSummary: string | null;
+    packedJson: Record<string, unknown> | null;
+  } = {
+    workoutId: null,
+    rpe: null,
+    workoutDate: null,
+    workoutContext: null,
+    athleteSummary: null,
+    packedJson: null,
+  };
+
+  const lines = text.split('\n');
+  let currentKey: string | null = null;
+  let currentValue = '';
+
+  for (const line of lines) {
+    if (currentKey === null) {
+      const eqIdx = line.indexOf('=');
+      if (eqIdx < 0) continue;
+      currentKey = line.slice(0, eqIdx);
+      currentValue = line.slice(eqIdx + 1);
+    } else {
+      currentValue += '\n' + line;
+    }
+
+    if (currentKey === 'workout_summary') {
+      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
+      if (parsed) {
+        result.workoutId = String(parsed.workoutId ?? '');
+        result.rpe = parsed.rpe != null ? Number(parsed.rpe) : null;
+      }
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'selected_workout') {
+      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
+      if (parsed) result.workoutDate = String(parsed.date ?? '');
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'current_workout_context') {
+      result.workoutContext = currentValue.trim();
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'athlete_summary_text') {
+      result.athleteSummary = (result.athleteSummary ?? '') + currentValue;
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'training_context_stable') {
+      const parsed = tryParseJson<Record<string, unknown>>(currentValue);
+      if (parsed) result.packedJson = parsed;
+      currentKey = null;
+      currentValue = '';
+    }
+  }
+
+  if (currentKey === 'athlete_summary_text') {
+    result.athleteSummary = (result.athleteSummary ?? '') + currentValue;
+  }
+
+  return result;
+}

--- a/frontend/src/features/admin-prompt-preview/components/SystemPromptSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/SystemPromptSection.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+type SystemPromptSectionProps = {
+  systemPrompt: string;
+};
+
+export function SystemPromptSection({ systemPrompt }: SystemPromptSectionProps) {
+  const [expanded, setExpanded] = useState(true);
+  const lines = systemPrompt.split('\n');
+  const toolIdx = lines.findIndex((l) => l.startsWith('Tool usage guidance:'));
+  const introLines = toolIdx >= 0 ? lines.slice(0, toolIdx) : lines;
+  const toolLines = toolIdx >= 0 ? lines.slice(toolIdx) : [];
+
+  return (
+    <SectionCard title={`System Prompt (${systemPrompt.length} chars)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-4 text-sm leading-6 text-slate-200">
+          <div className="whitespace-pre-wrap break-words font-sans">{introLines.join('\n')}</div>
+          {toolLines.length > 0 && (
+            <details className="mt-3 rounded-xl border border-white/10 bg-white/5">
+              <summary className="cursor-pointer px-3 py-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                Tool guidance ({toolLines.length} lines)
+              </summary>
+              <div className="whitespace-pre-wrap break-words px-3 pb-3 pt-1 font-sans text-slate-300">
+                {toolLines.join('\n')}
+              </div>
+            </details>
+          )}
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+type SectionCardProps = {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+};
+
+function SectionCard({ title, expanded, onToggle, children }: SectionCardProps) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03]">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between px-5 py-3 text-left text-xs font-semibold uppercase tracking-[0.15em] text-slate-400"
+      >
+        <span>{title}</span>
+        <span className="text-slate-500">{expanded ? '▾' : '▸'}</span>
+      </button>
+      {expanded && <div className="border-t border-white/5 px-5 py-4">{children}</div>}
+    </div>
+  );
+}
+
+export { SectionCard };

--- a/frontend/src/features/admin-prompt-preview/components/SystemPromptSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/SystemPromptSection.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { SectionCard } from './SectionCard';
+
 type SystemPromptSectionProps = {
   systemPrompt: string;
 };
@@ -31,28 +33,3 @@ export function SystemPromptSection({ systemPrompt }: SystemPromptSectionProps) 
     </SectionCard>
   );
 }
-
-type SectionCardProps = {
-  title: string;
-  expanded: boolean;
-  onToggle: () => void;
-  children: React.ReactNode;
-};
-
-function SectionCard({ title, expanded, onToggle, children }: SectionCardProps) {
-  return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.03]">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center justify-between px-5 py-3 text-left text-xs font-semibold uppercase tracking-[0.15em] text-slate-400"
-      >
-        <span>{title}</span>
-        <span className="text-slate-500">{expanded ? '▾' : '▸'}</span>
-      </button>
-      {expanded && <div className="border-t border-white/5 px-5 py-4">{children}</div>}
-    </div>
-  );
-}
-
-export { SectionCard };

--- a/frontend/src/features/admin-prompt-preview/components/ToolsSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ToolsSection.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import type { AdminPromptPreviewResponse } from '../types';
+import { SectionCard } from './SystemPromptSection';
+
+type ToolsSectionProps = {
+  tools: AdminPromptPreviewResponse['request']['tools'];
+  toolChoice: unknown;
+};
+
+export function ToolsSection({ tools, toolChoice }: ToolsSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (tools.length === 0) return null;
+
+  return (
+    <SectionCard title={`Tools (${tools.length})`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-3">
+          <div className="text-xs text-slate-500">
+            Tool choice: <span className="font-mono text-slate-300">{JSON.stringify(toolChoice)}</span>
+          </div>
+          {tools.map((tool, i) => (
+            <div key={i} className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3">
+              <div className="mb-1 font-mono text-sm font-semibold text-cyan-300">{tool.name}</div>
+              {tool.description && (
+                <div className="whitespace-pre-wrap break-words text-xs leading-5 text-slate-400">{tool.description}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/frontend/src/features/admin-prompt-preview/components/ToolsSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/ToolsSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import type { AdminPromptPreviewResponse } from '../types';
-import { SectionCard } from './SystemPromptSection';
+import { SectionCard } from './SectionCard';
 
 type ToolsSectionProps = {
   tools: AdminPromptPreviewResponse['request']['tools'];

--- a/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
 
-import { tryParseJson } from '../utils/parseContextLines';
+import { parseKeyValueLines, tryParseJson } from '../utils/parseContextLines';
 import { DecodedPackedContext } from './DecodedPackedContext';
-import { SectionCard } from './SystemPromptSection';
+import { SectionCard } from './SectionCard';
 
 type VolatileContextSectionProps = {
   rawText: string;
@@ -12,7 +12,16 @@ export function VolatileContextSection({ rawText }: VolatileContextSectionProps)
   const [showRaw, setShowRaw] = useState(false);
   const [expanded, setExpanded] = useState(true);
 
-  const parsed = useMemo(() => parseVolatileContext(rawText), [rawText]);
+  const parsed = useMemo(() => {
+    const lines = parseKeyValueLines(rawText);
+    const timing = tryParseJson<Record<string, unknown>>(lines.conversation_timing ?? '');
+    const packedJson = tryParseJson<Record<string, unknown>>(lines.training_context_volatile ?? '');
+    return {
+      timing,
+      latestUserMessageDatetime: lines.latest_user_message_datetime?.trim() ?? null,
+      packedJson,
+    };
+  }, [rawText]);
 
   return (
     <SectionCard title={`Volatile Context (${rawText.length} chars)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
@@ -57,41 +66,4 @@ export function VolatileContextSection({ rawText }: VolatileContextSectionProps)
       )}
     </SectionCard>
   );
-}
-
-function parseVolatileContext(text: string) {
-  let timing: Record<string, unknown> | null = null;
-  let latestUserMessageDatetime: string | null = null;
-  let packedJson: Record<string, unknown> | null = null;
-
-  const lines = text.split('\n');
-  let currentKey: string | null = null;
-  let currentValue = '';
-
-  for (const line of lines) {
-    if (currentKey === null) {
-      const eqIdx = line.indexOf('=');
-      if (eqIdx < 0) continue;
-      currentKey = line.slice(0, eqIdx);
-      currentValue = line.slice(eqIdx + 1);
-    } else {
-      currentValue += '\n' + line;
-    }
-
-    if (currentKey === 'conversation_timing') {
-      timing = tryParseJson<Record<string, unknown>>(currentValue);
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'latest_user_message_datetime') {
-      latestUserMessageDatetime = currentValue.trim();
-      currentKey = null;
-      currentValue = '';
-    } else if (currentKey === 'training_context_volatile') {
-      packedJson = tryParseJson<Record<string, unknown>>(currentValue);
-      currentKey = null;
-      currentValue = '';
-    }
-  }
-
-  return { timing, latestUserMessageDatetime, packedJson };
 }

--- a/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+
+import { tryParseJson } from '../utils/parseContextLines';
+import { DecodedPackedContext } from './DecodedPackedContext';
+import { SectionCard } from './SystemPromptSection';
+
+type VolatileContextSectionProps = {
+  rawText: string;
+};
+
+export function VolatileContextSection({ rawText }: VolatileContextSectionProps) {
+  const [showRaw, setShowRaw] = useState(false);
+  const [expanded, setExpanded] = useState(true);
+
+  const parsed = useMemo(() => parseVolatileContext(rawText), [rawText]);
+
+  return (
+    <SectionCard title={`Volatile Context (${rawText.length} chars)`} expanded={expanded} onToggle={() => setExpanded(!expanded)}>
+      {expanded && (
+        <div className="space-y-4">
+          {parsed.timing && (
+            <div className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm">
+              <div className="mb-1.5 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Conversation Timing</div>
+              <p className="text-slate-200">
+                Current:{' '}
+                <span className="font-mono text-cyan-300">{String(parsed.timing.currentConversationDatetime ?? '')}</span>
+              </p>
+              {parsed.latestUserMessageDatetime && (
+                <p className="mt-1 text-slate-200">
+                  Latest user msg:{' '}
+                  <span className="font-mono text-amber-300">{parsed.latestUserMessageDatetime}</span>
+                </p>
+              )}
+              <p className="mt-1 text-xs italic text-slate-500">{String(parsed.timing.instruction ?? '')}</p>
+            </div>
+          )}
+
+          {parsed.packedJson && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowRaw(!showRaw)}
+                className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500 hover:text-slate-300"
+              >
+                {showRaw ? 'Decoded view' : 'Show raw JSON'}
+              </button>
+              {showRaw ? (
+                <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-xl border border-white/10 bg-[#070b12] p-4 font-mono text-xs leading-5 text-slate-400">
+                  {JSON.stringify(parsed.packedJson, null, 2)}
+                </pre>
+              ) : (
+                <DecodedPackedContext label="Volatile Training Context" data={parsed.packedJson} />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function parseVolatileContext(text: string) {
+  let timing: Record<string, unknown> | null = null;
+  let latestUserMessageDatetime: string | null = null;
+  let packedJson: Record<string, unknown> | null = null;
+
+  const lines = text.split('\n');
+  let currentKey: string | null = null;
+  let currentValue = '';
+
+  for (const line of lines) {
+    if (currentKey === null) {
+      const eqIdx = line.indexOf('=');
+      if (eqIdx < 0) continue;
+      currentKey = line.slice(0, eqIdx);
+      currentValue = line.slice(eqIdx + 1);
+    } else {
+      currentValue += '\n' + line;
+    }
+
+    if (currentKey === 'conversation_timing') {
+      timing = tryParseJson<Record<string, unknown>>(currentValue);
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'latest_user_message_datetime') {
+      latestUserMessageDatetime = currentValue.trim();
+      currentKey = null;
+      currentValue = '';
+    } else if (currentKey === 'training_context_volatile') {
+      packedJson = tryParseJson<Record<string, unknown>>(currentValue);
+      currentKey = null;
+      currentValue = '';
+    }
+  }
+
+  return { timing, latestUserMessageDatetime, packedJson };
+}

--- a/frontend/src/features/admin-prompt-preview/types.ts
+++ b/frontend/src/features/admin-prompt-preview/types.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+const llmChatMessageSchema = z
+  .object({
+    role: z.string(),
+    content: z.string(),
+  })
+  .passthrough();
+
+const llmToolDefinitionSchema = z
+  .object({
+    name: z.string(),
+    description: z.string(),
+  })
+  .passthrough();
+
+export const adminPromptPreviewResponseSchema = z.object({
+  meta: z.object({
+    userId: z.string(),
+    date: z.string(),
+    surface: z.string(),
+    provider: z.string(),
+    model: z.string(),
+    focusDate: z.string(),
+    selectedWorkoutId: z.string().optional(),
+    selectionMethod: z.string().optional(),
+    complianceScore: z.number().optional(),
+  }),
+  request: z.object({
+    systemPrompt: z.string(),
+    stableContext: z.string(),
+    volatileContext: z.string(),
+    conversation: z.array(llmChatMessageSchema),
+    tools: z.array(llmToolDefinitionSchema),
+    toolChoice: z.unknown(),
+  }),
+  providerMessages: z.array(
+    z.object({
+      role: z.string(),
+      content: z.string(),
+    }),
+  ),
+});
+
+export type AdminPromptPreviewResponse = z.infer<typeof adminPromptPreviewResponseSchema>;

--- a/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.test.ts
+++ b/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeShortKey, formatSeconds } from './decodePackedContext';
+
+describe('decodeShortKey', () => {
+  it('maps known short keys to human labels', () => {
+    expect(decodeShortKey('ctl')).toBe('CTL');
+    expect(decodeShortKey('fnm')).toBe('Full Name');
+    expect(decodeShortKey('tss')).toBe('TSS');
+  });
+
+  it('returns the key as-is when unknown', () => {
+    expect(decodeShortKey('zzz')).toBe('zzz');
+    expect(decodeShortKey('')).toBe('');
+  });
+});
+
+describe('formatSeconds', () => {
+  it('formats hours and minutes', () => {
+    expect(formatSeconds(7722)).toBe('2h 8m');
+    expect(formatSeconds(3600)).toBe('1h 0m');
+  });
+
+  it('formats minutes only', () => {
+    expect(formatSeconds(1842)).toBe('30m');
+    expect(formatSeconds(60)).toBe('1m');
+  });
+});

--- a/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.ts
+++ b/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.ts
@@ -1,0 +1,100 @@
+const KEY_LABEL: Record<string, string> = {
+  v: 'Schema Version',
+  i: 'Intervals Status',
+  g: 'Generated At (epoch)',
+  fx: 'Focus',
+  k: 'Kind',
+  p: 'Athlete Profile',
+  rc: 'Race Calendar',
+  fe: 'Future Events',
+  h: 'Historical Training',
+  rd: 'Recent Days',
+  ud: 'Upcoming Days',
+  pd: 'Projected Days',
+  a: 'Activities Status',
+  e: 'Events Status',
+  fnm: 'Full Name',
+  age: 'Age',
+  hcm: 'Height (cm)',
+  wkg: 'Weight (kg)',
+  ftp: 'FTP (W)',
+  hrm: 'Max HR',
+  vo2: 'VO₂max',
+  ap: 'Athlete Prompt',
+  meds: 'Medications',
+  notes: 'Athlete Notes',
+  acfg: 'Availability Configured',
+  av: 'Weekly Availability',
+  wd: 'Weekday',
+  available: 'Available',
+  mdm: 'Max Duration (min)',
+  ws: 'Window Start',
+  we: 'Window End',
+  ac: 'Activity Count',
+  ttss: 'Total TSS',
+  ctl: 'CTL',
+  atl: 'ATL',
+  tsb: 'TSB',
+  ftpd: 'FTP Change',
+  t7: 'Avg TSS 7d',
+  t28: 'Avg TSS 28d',
+  if28: 'Avg IF 28d',
+  lt: 'Load Trend',
+  w: 'Workouts',
+  pw: 'Planned Workouts',
+  days: 'Days',
+  tss: 'TSS',
+  dur: 'Duration (s)',
+  ifv: 'IF',
+  ef: 'EF',
+  np: 'NP',
+  vi: 'VI',
+  rpe: 'RPE',
+  recap: 'Recap',
+  bl: 'Interval Blocks',
+  pc: 'Power Curve',
+  c5: 'Cadence 5s',
+  minp: 'Min %FTP',
+  maxp: 'Max %FTP',
+  minw: 'Min Watts',
+  maxw: 'Max Watts',
+  sd: 'Start Date',
+  n: 'Name',
+  ty: 'Activity Type',
+  c: 'Category',
+  desc: 'Description',
+  id: 'ID',
+  d: 'Date',
+  fr: 'Free Day',
+  sick: 'Sick',
+  sickn: 'Sick Note',
+  doc: 'Raw Doc',
+  done: 'Completed',
+  km: 'Distance (km)',
+  disc: 'Discipline',
+  pri: 'Priority',
+  n7d: 'Avg NP 7d',
+  n28d: 'Avg NP 28d',
+};
+
+export function decodeShortKey(key: string): string {
+  return KEY_LABEL[key] ?? key;
+}
+
+const SKIP_KEYS = new Set(['pc', 'c5', 'bl', 'doc']);
+
+export function isSkippableBulkKey(key: string): boolean {
+  return SKIP_KEYS.has(key);
+}
+
+export function formatSeconds(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export function formatEpochSeconds(epoch: number): string {
+  const d = new Date(epoch * 1000);
+  return d.toISOString().replace('T', ' ').slice(0, 19) + 'Z';
+}

--- a/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.ts
+++ b/frontend/src/features/admin-prompt-preview/utils/decodePackedContext.ts
@@ -81,20 +81,9 @@ export function decodeShortKey(key: string): string {
   return KEY_LABEL[key] ?? key;
 }
 
-const SKIP_KEYS = new Set(['pc', 'c5', 'bl', 'doc']);
-
-export function isSkippableBulkKey(key: string): boolean {
-  return SKIP_KEYS.has(key);
-}
-
 export function formatSeconds(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
-}
-
-export function formatEpochSeconds(epoch: number): string {
-  const d = new Date(epoch * 1000);
-  return d.toISOString().replace('T', ' ').slice(0, 19) + 'Z';
 }

--- a/frontend/src/features/admin-prompt-preview/utils/parseContextLines.test.ts
+++ b/frontend/src/features/admin-prompt-preview/utils/parseContextLines.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseKeyValueLines, tryParseJson } from './parseContextLines';
+
+describe('parseKeyValueLines', () => {
+  it('parses simple key=value pairs', () => {
+    const result = parseKeyValueLines('a=1\nb=2');
+    expect(result).toEqual({ a: '1', b: '2' });
+  });
+
+  it('parses JSON values spanning newlines', () => {
+    const text = 'x={"a":1}\ny=2';
+    const result = parseKeyValueLines(text);
+    expect(result).toEqual({ x: '{"a":1}', y: '2' });
+  });
+
+  it('parses the athlete_summary_text multi-line value', () => {
+    const text = 'athlete_summary_text=**bold**\nmore text';
+    const result = parseKeyValueLines(text);
+    expect(result).toEqual({ athlete_summary_text: '**bold**\nmore text' });
+  });
+
+  it('parses deeply nested JSON multi-line', () => {
+    const text = 'ctx={"a":{"b":1}}\nnext=2';
+    const result = parseKeyValueLines(text);
+    expect(result).toEqual({ ctx: '{"a":{"b":1}}', next: '2' });
+  });
+});
+
+describe('tryParseJson', () => {
+  it('parses valid JSON', () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(tryParseJson('not json')).toBeNull();
+  });
+});

--- a/frontend/src/features/admin-prompt-preview/utils/parseContextLines.ts
+++ b/frontend/src/features/admin-prompt-preview/utils/parseContextLines.ts
@@ -1,0 +1,60 @@
+export function parseKeyValueLines(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  let currentKey = '';
+  let currentValue = '';
+
+  for (const line of text.split('\n')) {
+    const eqIdx = line.indexOf('=');
+
+    if (eqIdx >= 0 && currentKey === '') {
+      currentKey = line.slice(0, eqIdx);
+      currentValue = line.slice(eqIdx + 1);
+    } else if (eqIdx >= 0 && currentKey !== '') {
+      if (currentValue.startsWith('{') && !isBalancedBrace(currentValue)) {
+        currentValue += '\n' + line;
+      } else {
+        result[currentKey] = currentValue;
+        currentKey = line.slice(0, eqIdx);
+        currentValue = line.slice(eqIdx + 1);
+      }
+    } else {
+      currentValue += '\n' + line;
+      if (currentValue.startsWith('{') && isBalancedBrace(currentValue)) {
+        result[currentKey] = currentValue;
+        currentKey = '';
+        currentValue = '';
+      }
+    }
+  }
+
+  if (currentKey !== '') {
+    result[currentKey] = currentValue;
+  }
+
+  return result;
+}
+
+function isBalancedBrace(s: string): boolean {
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+  }
+  return depth === 0;
+}
+
+export function tryParseJson<T = unknown>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -16,7 +16,8 @@
     "aiCoach": "AI Coach",
     "workspace": "Workspace",
     "systemInfo": "System Info",
-    "taskScheduler": "Task Scheduler"
+    "taskScheduler": "Task Scheduler",
+    "promptPreview": "Prompt Preview"
   },
   "appShell": {
     "brand": {
@@ -32,8 +33,23 @@
       "aiCoach": "AI Coach",
       "workspace": "Workspace",
       "systemInfo": "System Info",
-      "taskScheduler": "Task Scheduler"
+      "taskScheduler": "Task Scheduler",
+      "promptPreview": "Prompt Preview"
     }
+  },
+  "adminPromptPreview": {
+    "title": "LLM prompt preview",
+    "subtitle": "Inspect the assembled LLM request for a user and date without calling a provider.",
+    "userIdLabel": "User ID",
+    "userIdPlaceholder": "user-uuid",
+    "dateLabel": "Date",
+    "postWorkoutButton": "Preview post-workout request",
+    "calendarCoachButton": "Preview calendar view coach",
+    "loading": "Loading preview...",
+    "empty": "Choose a user, date, and preview action to render the request JSON here.",
+    "validation": "Enter a user ID and date.",
+    "futureDate": "Date cannot be in the future.",
+    "loadError": "Could not load prompt preview."
   },
   "adminTaskScheduler": {
     "kicker": "Admin operations",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -16,7 +16,8 @@
     "aiCoach": "AI Trener",
     "workspace": "Obszar roboczy",
     "systemInfo": "Info systemowe",
-    "taskScheduler": "Harmonogram zadań"
+    "taskScheduler": "Harmonogram zadań",
+    "promptPreview": "Podgląd promptu"
   },
   "appShell": {
     "brand": {
@@ -32,8 +33,23 @@
       "aiCoach": "AI Trener",
       "workspace": "Obszar roboczy",
       "systemInfo": "Info systemowe",
-      "taskScheduler": "Harmonogram zadań"
+      "taskScheduler": "Harmonogram zadań",
+      "promptPreview": "Podgląd promptu"
     }
+  },
+  "adminPromptPreview": {
+    "title": "Podgląd promptu LLM",
+    "subtitle": "Podejrzyj złożone żądanie LLM dla użytkownika i daty bez wywoływania providera.",
+    "userIdLabel": "ID użytkownika",
+    "userIdPlaceholder": "uuid-użytkownika",
+    "dateLabel": "Data",
+    "postWorkoutButton": "Podgląd post-workout",
+    "calendarCoachButton": "Podgląd coacha kalendarza",
+    "loading": "Ładowanie podglądu...",
+    "empty": "Wybierz użytkownika, datę i akcję podglądu, aby wyświetlić JSON żądania.",
+    "validation": "Podaj ID użytkownika i datę.",
+    "futureDate": "Data nie może być w przyszłości.",
+    "loadError": "Nie udało się załadować podglądu promptu."
   },
   "adminTaskScheduler": {
     "kicker": "Operacje administratora",

--- a/frontend/src/pages/AdminPromptPreviewPage.tsx
+++ b/frontend/src/pages/AdminPromptPreviewPage.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useAdminPromptPreviewApi } from '../features/admin-prompt-preview/api';
+import type { AdminPromptPreviewResponse } from '../features/admin-prompt-preview/types';
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function AdminPromptPreviewPage() {
+  const { t } = useTranslation();
+  const { loadAdminPostWorkoutPromptPreview, loadAdminCalendarCoachPromptPreview } =
+    useAdminPromptPreviewApi();
+  const [userId, setUserId] = useState('');
+  const [date, setDate] = useState(todayIsoDate());
+  const [preview, setPreview] = useState<AdminPromptPreviewResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingSurface, setLoadingSurface] = useState<'post-workout' | 'calendar-coach' | null>(
+    null,
+  );
+
+  const maxDate = useMemo(() => todayIsoDate(), []);
+  const formattedPreview = useMemo(
+    () => (preview ? JSON.stringify(preview, null, 2) : ''),
+    [preview],
+  );
+
+  const runPreview = async (surface: 'post-workout' | 'calendar-coach') => {
+    if (!userId.trim() || !date) {
+      setError(t('adminPromptPreview.validation'));
+      return;
+    }
+    if (date > maxDate) {
+      setError(t('adminPromptPreview.futureDate'));
+      return;
+    }
+
+    setLoadingSurface(surface);
+    setError(null);
+    try {
+      const response =
+        surface === 'post-workout'
+          ? await loadAdminPostWorkoutPromptPreview(userId.trim(), date)
+          : await loadAdminCalendarCoachPromptPreview(userId.trim(), date);
+      setPreview(response);
+    } catch {
+      setPreview(null);
+      setError(t('adminPromptPreview.loadError'));
+    } finally {
+      setLoadingSurface(null);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">{t('adminPromptPreview.title')}</h1>
+        <p className="mt-2 max-w-3xl text-sm text-slate-400">{t('adminPromptPreview.subtitle')}</p>
+      </div>
+
+      <div className="grid gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 md:grid-cols-[minmax(0,1fr)_12rem_auto] md:items-end">
+        <label className="grid gap-2 text-sm text-slate-300">
+          <span>{t('adminPromptPreview.userIdLabel')}</span>
+          <input
+            value={userId}
+            onChange={(event) => setUserId(event.target.value)}
+            className="rounded-xl border border-white/10 bg-[#0a0f1a] px-4 py-3 text-sm text-white outline-none transition focus:border-[#f2c98e]/45"
+            placeholder={t('adminPromptPreview.userIdPlaceholder')}
+          />
+        </label>
+
+        <label className="grid gap-2 text-sm text-slate-300">
+          <span>{t('adminPromptPreview.dateLabel')}</span>
+          <input
+            type="date"
+            max={maxDate}
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+            className="rounded-xl border border-white/10 bg-[#0a0f1a] px-4 py-3 text-sm text-white outline-none transition focus:border-[#f2c98e]/45"
+          />
+        </label>
+
+        <div className="flex flex-col gap-2 sm:flex-row md:flex-col">
+          <button
+            type="button"
+            disabled={loadingSurface !== null}
+            onClick={() => void runPreview('post-workout')}
+            className="rounded-xl bg-[#f2c98e] px-4 py-3 text-sm font-semibold text-[#0a0f1a] transition hover:bg-[#f7d9ad] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loadingSurface === 'post-workout'
+              ? t('adminPromptPreview.loading')
+              : t('adminPromptPreview.postWorkoutButton')}
+          </button>
+          <button
+            type="button"
+            disabled={loadingSurface !== null}
+            onClick={() => void runPreview('calendar-coach')}
+            className="rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-[#f2c98e]/45 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loadingSurface === 'calendar-coach'
+              ? t('adminPromptPreview.loading')
+              : t('adminPromptPreview.calendarCoachButton')}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="min-h-[60vh] rounded-2xl border border-white/10 bg-[#070b12] p-4">
+        {preview ? (
+          <div className="mb-3 text-xs uppercase tracking-[0.2em] text-slate-500">
+            {preview.meta.surface}
+            {preview.meta.selectedWorkoutId
+              ? ` · ${preview.meta.selectedWorkoutId}`
+              : ''}
+          </div>
+        ) : null}
+        <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-slate-200">
+          {formattedPreview || t('adminPromptPreview.empty')}
+        </pre>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/AdminPromptPreviewPage.tsx
+++ b/frontend/src/pages/AdminPromptPreviewPage.tsx
@@ -3,6 +3,13 @@ import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../features/auth/context/AuthProvider';
 import { useAdminPromptPreviewApi } from '../features/admin-prompt-preview/api';
+import { MetaBar } from '../features/admin-prompt-preview/components/MetaBar';
+import { SystemPromptSection } from '../features/admin-prompt-preview/components/SystemPromptSection';
+import { StableContextSection } from '../features/admin-prompt-preview/components/StableContextSection';
+import { VolatileContextSection } from '../features/admin-prompt-preview/components/VolatileContextSection';
+import { ConversationSection } from '../features/admin-prompt-preview/components/ConversationSection';
+import { ToolsSection } from '../features/admin-prompt-preview/components/ToolsSection';
+import { ProviderMessagesSection } from '../features/admin-prompt-preview/components/ProviderMessagesSection';
 import type { AdminPromptPreviewResponse } from '../features/admin-prompt-preview/types';
 
 function todayIsoDate() {
@@ -27,6 +34,7 @@ export function AdminPromptPreviewPage() {
     () => (preview ? JSON.stringify(preview, null, 2) : ''),
     [preview],
   );
+  const [showRawJson, setShowRawJson] = useState(false);
 
   const runPreview = async (surface: 'post-workout' | 'calendar-coach') => {
     if (!userId.trim() || !date) {
@@ -113,19 +121,41 @@ export function AdminPromptPreviewPage() {
         </p>
       ) : null}
 
-      <div className="min-h-[60vh] rounded-2xl border border-white/10 bg-[#070b12] p-4">
-        {preview ? (
-          <div className="mb-3 text-xs uppercase tracking-[0.2em] text-slate-500">
-            {preview.meta.surface}
-            {preview.meta.selectedWorkoutId
-              ? ` · ${preview.meta.selectedWorkoutId}`
-              : ''}
+      {preview && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <MetaBar meta={preview.meta} />
+            <button
+              type="button"
+              onClick={() => setShowRawJson(!showRawJson)}
+              className="ml-auto rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400 hover:text-slate-200"
+            >
+              {showRawJson ? 'Structured view' : 'Raw JSON'}
+            </button>
           </div>
-        ) : null}
-        <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-slate-200">
-          {formattedPreview || t('adminPromptPreview.empty')}
-        </pre>
-      </div>
+
+          {showRawJson ? (
+            <pre className="max-h-[80vh] overflow-auto whitespace-pre-wrap break-words rounded-2xl border border-white/10 bg-[#070b12] p-5 font-mono text-xs leading-5 text-slate-300">
+              {formattedPreview}
+            </pre>
+          ) : (
+            <div className="space-y-4">
+              <SystemPromptSection systemPrompt={preview.request.systemPrompt} />
+              <StableContextSection rawText={preview.request.stableContext} />
+              <VolatileContextSection rawText={preview.request.volatileContext} />
+              <ConversationSection conversation={preview.request.conversation} />
+              <ToolsSection tools={preview.request.tools} toolChoice={preview.request.toolChoice} />
+              <ProviderMessagesSection messages={preview.providerMessages} />
+            </div>
+          )}
+        </div>
+      )}
+
+      {!preview && !error && (
+        <div className="flex min-h-[40vh] items-center justify-center rounded-2xl border border-dashed border-white/10">
+          <p className="text-sm text-slate-500">{t('adminPromptPreview.empty')}</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/pages/AdminPromptPreviewPage.tsx
+++ b/frontend/src/pages/AdminPromptPreviewPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAuth } from '../features/auth/context/AuthProvider';
 import { useAdminPromptPreviewApi } from '../features/admin-prompt-preview/api';
 import type { AdminPromptPreviewResponse } from '../features/admin-prompt-preview/types';
 
@@ -10,9 +11,10 @@ function todayIsoDate() {
 
 export function AdminPromptPreviewPage() {
   const { t } = useTranslation();
+  const { user } = useAuth();
   const { loadAdminPostWorkoutPromptPreview, loadAdminCalendarCoachPromptPreview } =
     useAdminPromptPreviewApi();
-  const [userId, setUserId] = useState('');
+  const [userId, setUserId] = useState(user?.id ?? '');
   const [date, setDate] = useState(todayIsoDate());
   const [preview, setPreview] = useState<AdminPromptPreviewResponse | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/adapters/llm/workout_summary_coach.rs
+++ b/src/adapters/llm/workout_summary_coach.rs
@@ -1,23 +1,18 @@
 use std::sync::Arc;
 
-use super::context_prelude::PACKED_TRAINING_CONTEXT_LEGEND;
-
 use crate::domain::{
     identity::Clock,
     llm::{
-        build_chat_request, conversation_timing_volatile_context, current_date_string,
-        find_reusable_context_cache, persist_reusable_context_cache,
-        rebuild_conversation_with_provider_transcript, reusable_context_cache_key,
-        timestamped_message_content, BoxFuture, LlmChatMessage, LlmChatPort, LlmChatRequestInput,
-        LlmContextCacheRepository, LlmError, LlmMessageRole, LlmProvider,
-        ReusableContextCacheLookup, ReusableContextCacheUpsert, UserLlmConfigProvider,
+        current_date_string, find_reusable_context_cache, persist_reusable_context_cache,
+        reusable_context_cache_key, BoxFuture, LlmChatPort, LlmContextCacheRepository, LlmError,
+        LlmProvider, ReusableContextCacheLookup, ReusableContextCacheUpsert, UserLlmConfigProvider,
     },
-    llm_tools::{
-        run_tool_loop, with_tool_prompt_guidance, GetSelectedWorkoutDataPort, LlmToolLoopOutput,
-        ToolExecutionContext, ToolScope,
-    },
+    llm_tools::{run_tool_loop, GetSelectedWorkoutDataPort, LlmToolLoopOutput, ToolScope},
     training_context::TrainingContextBuilder,
-    workout_summary::{workout_summary_coach_reply_json_schema, WorkoutCoach, WorkoutSummary},
+    workout_summary::{
+        assemble_workout_summary_coach_request, WorkoutCoach, WorkoutSummary,
+        WorkoutSummaryCoachPromptInput,
+    },
 };
 
 #[derive(Clone)]
@@ -100,38 +95,16 @@ where
             let training_context = training_context_builder
                 .build(&user_id, &summary.workout_id)
                 .await?;
-            let stable_context = build_stable_context(
-                &summary,
-                &training_context.focus_date,
-                &training_context.rendered.stable_context,
-                athlete_summary_text.as_deref(),
-            );
-            let volatile_context = build_volatile_context(
-                &training_context.rendered.volatile_context,
-                clock.now_epoch_seconds(),
-                latest_user_message_epoch_seconds(&summary, clock.now_epoch_seconds()),
-            );
-            let tool_context = ToolExecutionContext {
-                user_id: user_id.clone(),
-                training_context: training_context.context.clone(),
-                today: current_date_string(&clock),
-                data_port,
-                planned_workout_update_port: None,
-            };
-            let system_prompt = with_tool_prompt_guidance(
-                &workout_coach_system_prompt(),
-                ToolScope::WorkoutSummaryChat,
-                &config.provider,
-                &tool_context,
-            );
-            let conversation = build_conversation(
-                summary.messages.as_slice(),
-                &summary.provider_transcript,
-                &user_message,
-                clock.now_epoch_seconds(),
-            );
             let cache_scope_key = Some(format!("workout-summary:{user_id}:{}", summary.workout_id));
-            let context_hash = reusable_context_cache_key(&system_prompt, &stable_context);
+            let context_hash = reusable_context_cache_key(
+                &crate::domain::workout_summary::workout_coach_system_prompt(),
+                &crate::domain::workout_summary::build_stable_context(
+                    &summary,
+                    &training_context.focus_date,
+                    &training_context.rendered.stable_context,
+                    athlete_summary_text.as_deref(),
+                ),
+            );
             let reusable_cache_id = if config.provider == LlmProvider::Gemini {
                 match (
                     context_cache_repository.as_deref(),
@@ -187,16 +160,29 @@ where
             } else {
                 None
             };
-            let request = build_chat_request(LlmChatRequestInput {
+            let today = current_date_string(&clock);
+            let tool_context = crate::domain::llm_tools::ToolExecutionContext {
                 user_id: user_id.clone(),
-                system_prompt,
-                stable_context,
-                volatile_context,
-                conversation,
-                cache_scope_key: cache_scope_key.clone(),
-                cache_key: Some(context_hash.clone()),
-                reusable_cache_id,
-            });
+                training_context: training_context.context.clone(),
+                today: today.clone(),
+                data_port: data_port.clone(),
+                planned_workout_update_port: None,
+            };
+            let mut request =
+                assemble_workout_summary_coach_request(WorkoutSummaryCoachPromptInput {
+                    user_id: user_id.clone(),
+                    config: config.clone(),
+                    summary: summary.clone(),
+                    training_context,
+                    user_message,
+                    athlete_summary_text,
+                    conversation_epoch_seconds: clock.now_epoch_seconds(),
+                    today,
+                    data_port,
+                    reusable_cache_id,
+                });
+            request.cache_key = Some(context_hash.clone());
+            request.cache_scope_key = cache_scope_key.clone();
             tracing::info!(
                 user_id = %user_id,
                 workout_id = %summary.workout_id,
@@ -251,141 +237,9 @@ where
     }
 }
 
-const WORKOUT_COACH_SYSTEM_PROMPT_BASE: &str = "You are an AI cycling coach helping an athlete reflect on one completed workout. Use the packed training context as factual background. Be direct, adult, and concise. Do not flatter, hedge, or act like a yes-man. Challenge weak reasoning when the context does not support it. Keep the conversation focused and practical rather than digressive. In your first reply after a workout, ask all follow-up questions you genuinely need at once instead of stretching them across many turns. The athlete should still feel coached, not interrogated. Ask concrete questions about the workout limiter, legs, breathing, fueling, sleep, stress, pain, readiness for the next days, and any plan constraints when relevant. Add other questions only when the workout characteristics clearly justify them. You may also ask about nutrition, race strategy, or the desired direction of the next 14 days when that would materially improve the next plan. For completed interval workouts, judge execution quality primarily from packed workout evidence: bl as intended block structure/targets, pc as executed power pattern, and c5 as supporting cadence evidence. Aggregate metrics like NP, average power, IF, VI, and TSS are secondary context only and are not sufficient proof that interval blocks were or were not executed correctly. Do not conclude poor interval execution just because whole-workout averages were lowered by recovery valleys, coasting, zeros, terrain, or wind. If the packed evidence is insufficient for a confident execution judgment, inspect higher-fidelity data before making a strong claim. When workout tools are available, use them for that fallback. If you already have enough information to generate the plan, say that clearly and tell the athlete to save the summary. Return your final answer as JSON only matching the workout summary coach reply schema. The summary may use markdown. Questions may be an empty array when you are ready. Do not output any text outside the JSON object. Do not invent details beyond the provided context.";
-
-fn build_stable_context(
-    summary: &WorkoutSummary,
-    selected_workout_date: &str,
-    packed_training_context: &str,
-    athlete_summary_text: Option<&str>,
-) -> String {
-    let mut context = format!(
-        "workout_summary={{\"workoutId\":\"{}\",\"rpe\":{}}}\nselected_workout={{\"workoutId\":\"{}\",\"date\":\"{}\"}}\ncurrent_workout_context=You are discussing the completed workout from {}.",
-        summary.workout_id,
-        summary
-            .rpe
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "null".to_string()),
-        summary.workout_id,
-        selected_workout_date,
-        selected_workout_date,
-    );
-
-    if let Some(summary_text) = athlete_summary_text.filter(|value| !value.trim().is_empty()) {
-        context.push_str(&format!("\nathlete_summary_text={summary_text}"));
-    }
-
-    context.push_str(&format!(
-        "\ntraining_context_stable={packed_training_context}"
-    ));
-    context
-}
-
-fn build_volatile_context(
-    packed_training_context: &str,
-    current_conversation_epoch_seconds: i64,
-    latest_user_message_epoch_seconds: Option<i64>,
-) -> String {
-    format!(
-        "{}\ntraining_context_volatile={packed_training_context}",
-        conversation_timing_volatile_context(
-            current_conversation_epoch_seconds,
-            latest_user_message_epoch_seconds,
-        )
-    )
-}
-
-fn workout_coach_system_prompt() -> String {
-    format!(
-        "{WORKOUT_COACH_SYSTEM_PROMPT_BASE}\n{WORKOUT_COACH_SELECTED_WORKOUT_PROMPT}\nworkout_summary_coach_reply_schema={}\n{PACKED_TRAINING_CONTEXT_LEGEND}",
-        workout_summary_coach_reply_json_schema()
-    )
-}
-
-const WORKOUT_COACH_SELECTED_WORKOUT_PROMPT: &str = "Use the provided selected workout date as the active workout context for this conversation. When inspecting the current workout, prefer that exact selected workout date or id instead of inferring from nearby history.";
-
-fn build_conversation(
-    messages: &[crate::domain::workout_summary::ConversationMessage],
-    provider_transcript: &[LlmChatMessage],
-    user_message: &str,
-    fallback_user_message_epoch_seconds: i64,
-) -> Vec<LlmChatMessage> {
-    let conversation = messages
-        .iter()
-        .filter_map(|message| match message.role {
-            crate::domain::workout_summary::MessageRole::User => Some(LlmChatMessage {
-                role: LlmMessageRole::User,
-                content: timestamped_message_content(
-                    &message.content,
-                    message.created_at_epoch_seconds,
-                ),
-                tool_calls: Vec::new(),
-                tool_call_id: None,
-                reasoning_content: None,
-            }),
-            crate::domain::workout_summary::MessageRole::Coach => Some(LlmChatMessage {
-                role: LlmMessageRole::Assistant,
-                content: timestamped_message_content(
-                    &message.content,
-                    message.created_at_epoch_seconds,
-                ),
-                tool_calls: Vec::new(),
-                tool_call_id: None,
-                reasoning_content: None,
-            }),
-            crate::domain::workout_summary::MessageRole::Tool => None,
-        })
-        .collect::<Vec<_>>();
-
-    let mut rebuilt =
-        rebuild_conversation_with_provider_transcript(conversation, provider_transcript);
-
-    if let Some(last) = rebuilt.last_mut() {
-        if last.role == LlmMessageRole::User {
-            last.content = timestamped_message_content(
-                user_message,
-                latest_user_message_epoch_seconds_in_messages(messages)
-                    .unwrap_or(fallback_user_message_epoch_seconds),
-            );
-            return rebuilt;
-        }
-    }
-
-    rebuilt.push(LlmChatMessage::user(timestamped_message_content(
-        user_message,
-        latest_user_message_epoch_seconds_in_messages(messages)
-            .unwrap_or(fallback_user_message_epoch_seconds),
-    )));
-
-    rebuilt
-}
-
-fn latest_user_message_epoch_seconds(
-    summary: &WorkoutSummary,
-    fallback_epoch_seconds: i64,
-) -> Option<i64> {
-    latest_user_message_epoch_seconds_in_messages(&summary.messages)
-        .or(Some(fallback_epoch_seconds))
-}
-
-fn latest_user_message_epoch_seconds_in_messages(
-    messages: &[crate::domain::workout_summary::ConversationMessage],
-) -> Option<i64> {
-    messages
-        .iter()
-        .rev()
-        .find(|message| {
-            matches!(
-                message.role,
-                crate::domain::workout_summary::MessageRole::User
-            )
-        })
-        .map(|message| message.created_at_epoch_seconds)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
+    use crate::domain::workout_summary::{
         build_conversation, build_stable_context, build_volatile_context,
         workout_coach_system_prompt,
     };

--- a/src/adapters/rest/admin_prompt_preview.rs
+++ b/src/adapters/rest/admin_prompt_preview.rs
@@ -1,0 +1,119 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+
+use crate::config::AppState;
+use crate::domain::admin_prompt_preview::AdminPromptPreviewError;
+use crate::domain::identity::IdentityError;
+
+use super::cookies::read_cookie;
+
+#[derive(Deserialize)]
+pub struct AdminPromptPreviewPath {
+    user_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct AdminPromptPreviewQuery {
+    date: String,
+}
+
+pub async fn preview_post_workout(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(path): Path<AdminPromptPreviewPath>,
+    Query(query): Query<AdminPromptPreviewQuery>,
+) -> impl IntoResponse {
+    preview_with_surface(
+        state,
+        headers,
+        path,
+        query,
+        PreviewSurfaceRoute::PostWorkout,
+    )
+    .await
+}
+
+pub async fn preview_calendar_coach(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(path): Path<AdminPromptPreviewPath>,
+    Query(query): Query<AdminPromptPreviewQuery>,
+) -> impl IntoResponse {
+    preview_with_surface(
+        state,
+        headers,
+        path,
+        query,
+        PreviewSurfaceRoute::CalendarCoach,
+    )
+    .await
+}
+
+enum PreviewSurfaceRoute {
+    PostWorkout,
+    CalendarCoach,
+}
+
+async fn preview_with_surface(
+    state: AppState,
+    headers: HeaderMap,
+    path: AdminPromptPreviewPath,
+    query: AdminPromptPreviewQuery,
+    surface: PreviewSurfaceRoute,
+) -> axum::response::Response {
+    let Some(identity_service) = state.identity_service.clone() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+
+    let Some(session_id) = read_cookie(&headers, &state.session_cookie_name) else {
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    match identity_service.require_admin(&session_id).await {
+        Ok(_) => {}
+        Err(IdentityError::Unauthenticated) => return StatusCode::UNAUTHORIZED.into_response(),
+        Err(IdentityError::Forbidden) => return StatusCode::FORBIDDEN.into_response(),
+        Err(IdentityError::Repository(_) | IdentityError::External(_)) => {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+
+    let Some(service) = state.admin_prompt_preview_service.as_ref() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+
+    let result = match surface {
+        PreviewSurfaceRoute::PostWorkout => {
+            service
+                .preview_post_workout(&path.user_id, &query.date)
+                .await
+        }
+        PreviewSurfaceRoute::CalendarCoach => {
+            service
+                .preview_calendar_coach(&path.user_id, &query.date)
+                .await
+        }
+    };
+
+    match result {
+        Ok(response) => Json(response).into_response(),
+        Err(AdminPromptPreviewError::InvalidDate | AdminPromptPreviewError::FutureDate) => {
+            StatusCode::BAD_REQUEST.into_response()
+        }
+        Err(AdminPromptPreviewError::NoCompletedWorkoutForDate) => {
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(
+            AdminPromptPreviewError::Settings(_)
+            | AdminPromptPreviewError::Repository(_)
+            | AdminPromptPreviewError::TargetResolution(_)
+            | AdminPromptPreviewError::Llm(_),
+        ) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}

--- a/src/adapters/rest/mod.rs
+++ b/src/adapters/rest/mod.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod admin_prompt_preview;
 mod admin_task_scheduler;
 mod athlete_summary;
 mod auth;
@@ -86,6 +87,14 @@ pub fn router_with_frontend_dist(state: AppState, frontend_dist: PathBuf) -> Rou
                     post(auth::join_whitelist).layer(DefaultBodyLimit::max(4 * 1024)),
                 )
                 .route("/api/admin/system-info", get(admin::system_info))
+                .route(
+                    "/api/admin/users/{user_id}/prompt-preview/post-workout",
+                    get(admin_prompt_preview::preview_post_workout),
+                )
+                .route(
+                    "/api/admin/users/{user_id}/prompt-preview/calendar-coach",
+                    get(admin_prompt_preview::preview_calendar_coach),
+                )
                 .route(
                     "/api/admin/task-scheduler/tasks",
                     get(admin_task_scheduler::list_tasks),

--- a/src/config/app_state.rs
+++ b/src/config/app_state.rs
@@ -7,6 +7,7 @@ use std::{
 use mongodb::Client;
 
 use crate::adapters::rest::WorkoutSummarySaveNotifier;
+use crate::domain::admin_prompt_preview::AdminPromptPreviewUseCases;
 use crate::domain::athlete_summary::AthleteSummaryUseCases;
 use crate::domain::calendar::CalendarUseCases;
 use crate::domain::calendar_coach::CalendarCoachUseCases;
@@ -45,6 +46,7 @@ pub struct AppState {
     pub race_service: Option<Arc<dyn RaceUseCases>>,
     pub settings_service: Option<Arc<dyn UserSettingsUseCases>>,
     pub admin_task_scheduler_service: Option<Arc<dyn AdminTaskSchedulerUseCases>>,
+    pub admin_prompt_preview_service: Option<Arc<dyn AdminPromptPreviewUseCases>>,
     pub training_load_dashboard_service: Option<Arc<dyn TrainingLoadDashboardReadUseCases>>,
     pub athlete_summary_service: Option<Arc<dyn AthleteSummaryUseCases>>,
     pub workout_summary_service: Option<Arc<dyn WorkoutSummaryUseCases>>,
@@ -127,6 +129,7 @@ impl AppState {
             race_service: None,
             settings_service: None,
             admin_task_scheduler_service: None,
+            admin_prompt_preview_service: None,
             training_load_dashboard_service: None,
             athlete_summary_service: None,
             workout_summary_service: None,
@@ -180,6 +183,14 @@ impl AppState {
         admin_task_scheduler_service: Arc<dyn AdminTaskSchedulerUseCases>,
     ) -> Self {
         self.admin_task_scheduler_service = Some(admin_task_scheduler_service);
+        self
+    }
+
+    pub fn with_admin_prompt_preview_service(
+        mut self,
+        admin_prompt_preview_service: Arc<dyn AdminPromptPreviewUseCases>,
+    ) -> Self {
+        self.admin_prompt_preview_service = Some(admin_prompt_preview_service);
         self
     }
 

--- a/src/domain/admin_prompt_preview/error.rs
+++ b/src/domain/admin_prompt_preview/error.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdminPromptPreviewError {
+    InvalidDate,
+    FutureDate,
+    NoCompletedWorkoutForDate,
+    Settings(String),
+    Repository(String),
+    TargetResolution(String),
+    Llm(crate::domain::llm::LlmError),
+}
+
+impl fmt::Display for AdminPromptPreviewError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDate => write!(f, "date must be YYYY-MM-DD"),
+            Self::FutureDate => write!(f, "date cannot be in the future"),
+            Self::NoCompletedWorkoutForDate => {
+                write!(f, "no completed workout found for date")
+            }
+            Self::Settings(message) => write!(f, "{message}"),
+            Self::Repository(message) => write!(f, "{message}"),
+            Self::TargetResolution(message) => write!(f, "{message}"),
+            Self::Llm(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for AdminPromptPreviewError {}

--- a/src/domain/admin_prompt_preview/error.rs
+++ b/src/domain/admin_prompt_preview/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum AdminPromptPreviewError {
     InvalidDate,
     FutureDate,

--- a/src/domain/admin_prompt_preview/mod.rs
+++ b/src/domain/admin_prompt_preview/mod.rs
@@ -1,0 +1,12 @@
+mod error;
+mod model;
+mod ports;
+mod service;
+
+pub use error::AdminPromptPreviewError;
+pub use model::{
+    AdminPromptPreviewMeta, AdminPromptPreviewRequestBody, AdminPromptPreviewResponse,
+    AdminPromptPreviewSurface,
+};
+pub use ports::{AdminPromptPreviewUseCases, BoxFuture};
+pub use service::AdminPromptPreviewService;

--- a/src/domain/admin_prompt_preview/model.rs
+++ b/src/domain/admin_prompt_preview/model.rs
@@ -4,8 +4,8 @@ use crate::domain::llm::{
     LlmChatMessage, LlmToolChoice, LlmToolDefinition, PreviewProviderMessage,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AdminPromptPreviewSurface {
     PostWorkout,
     CalendarCoach,

--- a/src/domain/admin_prompt_preview/model.rs
+++ b/src/domain/admin_prompt_preview/model.rs
@@ -1,0 +1,57 @@
+use serde::Serialize;
+
+use crate::domain::llm::{
+    LlmChatMessage, LlmToolChoice, LlmToolDefinition, PreviewProviderMessage,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AdminPromptPreviewSurface {
+    PostWorkout,
+    CalendarCoach,
+}
+
+impl AdminPromptPreviewSurface {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PostWorkout => "post_workout",
+            Self::CalendarCoach => "calendar_coach",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminPromptPreviewMeta {
+    pub user_id: String,
+    pub date: String,
+    pub surface: String,
+    pub provider: String,
+    pub model: String,
+    pub focus_date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_workout_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compliance_score: Option<f64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminPromptPreviewRequestBody {
+    pub system_prompt: String,
+    pub stable_context: String,
+    pub volatile_context: String,
+    pub conversation: Vec<LlmChatMessage>,
+    pub tools: Vec<LlmToolDefinition>,
+    pub tool_choice: LlmToolChoice,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminPromptPreviewResponse {
+    pub meta: AdminPromptPreviewMeta,
+    pub request: AdminPromptPreviewRequestBody,
+    pub provider_messages: Vec<PreviewProviderMessage>,
+}

--- a/src/domain/admin_prompt_preview/ports.rs
+++ b/src/domain/admin_prompt_preview/ports.rs
@@ -1,0 +1,19 @@
+use std::{future::Future, pin::Pin};
+
+use super::{AdminPromptPreviewError, AdminPromptPreviewResponse};
+
+pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+
+pub trait AdminPromptPreviewUseCases: Send + Sync {
+    fn preview_post_workout(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> BoxFuture<Result<AdminPromptPreviewResponse, AdminPromptPreviewError>>;
+
+    fn preview_calendar_coach(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> BoxFuture<Result<AdminPromptPreviewResponse, AdminPromptPreviewError>>;
+}

--- a/src/domain/admin_prompt_preview/service.rs
+++ b/src/domain/admin_prompt_preview/service.rs
@@ -1,0 +1,421 @@
+use std::sync::Arc;
+
+use chrono::NaiveDate;
+
+use crate::domain::{
+    athlete_summary::AthleteSummaryRepository,
+    coach_conversation::{
+        assemble_calendar_coach_request, CalendarCoachPromptInput, CoachConversation,
+        CoachConversationFocus, CoachConversationMessage, CoachConversationMessageRole,
+        CoachConversationSurface,
+    },
+    completed_workouts::{CompletedWorkoutError, CompletedWorkoutReadUseCases},
+    identity::Clock,
+    llm::{current_date_string, preview_provider_messages, LlmChatRequest, UserLlmConfigProvider},
+    llm_tools::{GetSelectedWorkoutDataPort, UpdatePlannedWorkoutDataPort},
+    planned_workouts::PlannedWorkoutRepository,
+    settings::UserSettingsUseCases,
+    special_days::SpecialDayRepository,
+    training_context::{pick_representative_completed_workout_for_day, TrainingContextBuilder},
+    workout_summary::{
+        assemble_workout_summary_coach_request, CompletedWorkoutTargetUseCases, WorkoutSummary,
+        WorkoutSummaryCoachPromptInput, WorkoutSummaryRepository, ADMIN_PREVIEW_USER_MESSAGE,
+    },
+};
+
+use super::{
+    AdminPromptPreviewError, AdminPromptPreviewMeta, AdminPromptPreviewRequestBody,
+    AdminPromptPreviewResponse, AdminPromptPreviewSurface, AdminPromptPreviewUseCases, BoxFuture,
+};
+
+#[derive(Clone)]
+pub struct AdminPromptPreviewService<Time, Planned, Special>
+where
+    Time: Clock + Clone + Send + Sync + 'static,
+    Planned: PlannedWorkoutRepository + Clone + Send + Sync + 'static,
+    Special: SpecialDayRepository + Clone + Send + Sync + 'static,
+{
+    training_context_builder: Arc<dyn TrainingContextBuilder>,
+    llm_config_provider: Arc<dyn UserLlmConfigProvider>,
+    completed_workout_read: Arc<dyn CompletedWorkoutReadUseCases>,
+    planned_workout_repository: Option<Planned>,
+    special_day_repository: Option<Special>,
+    completed_workout_target_service: Arc<dyn CompletedWorkoutTargetUseCases>,
+    workout_summary_repository: Arc<dyn WorkoutSummaryRepository>,
+    athlete_summary_repository: Option<Arc<dyn AthleteSummaryRepository>>,
+    settings_service: Arc<dyn UserSettingsUseCases>,
+    data_port: Option<Arc<dyn GetSelectedWorkoutDataPort>>,
+    planned_workout_update_port: Option<Arc<dyn UpdatePlannedWorkoutDataPort>>,
+    clock: Time,
+}
+
+impl<Time, Planned, Special> AdminPromptPreviewService<Time, Planned, Special>
+where
+    Time: Clock + Clone + Send + Sync + 'static,
+    Planned: PlannedWorkoutRepository + Clone + Send + Sync + 'static,
+    Special: SpecialDayRepository + Clone + Send + Sync + 'static,
+{
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "admin prompt preview composes existing production ports without a new facade"
+    )]
+    pub fn new(
+        training_context_builder: Arc<dyn TrainingContextBuilder>,
+        llm_config_provider: Arc<dyn UserLlmConfigProvider>,
+        completed_workout_read: Arc<dyn CompletedWorkoutReadUseCases>,
+        planned_workout_repository: Option<Planned>,
+        special_day_repository: Option<Special>,
+        completed_workout_target_service: Arc<dyn CompletedWorkoutTargetUseCases>,
+        workout_summary_repository: Arc<dyn WorkoutSummaryRepository>,
+        athlete_summary_repository: Option<Arc<dyn AthleteSummaryRepository>>,
+        settings_service: Arc<dyn UserSettingsUseCases>,
+        data_port: Option<Arc<dyn GetSelectedWorkoutDataPort>>,
+        planned_workout_update_port: Option<Arc<dyn UpdatePlannedWorkoutDataPort>>,
+        clock: Time,
+    ) -> Self {
+        Self {
+            training_context_builder,
+            llm_config_provider,
+            completed_workout_read,
+            planned_workout_repository,
+            special_day_repository,
+            completed_workout_target_service,
+            workout_summary_repository,
+            athlete_summary_repository,
+            settings_service,
+            data_port,
+            planned_workout_update_port,
+            clock,
+        }
+    }
+
+    fn validate_date(&self, date: &str) -> Result<NaiveDate, AdminPromptPreviewError> {
+        let parsed = NaiveDate::parse_from_str(date, "%Y-%m-%d")
+            .map_err(|_| AdminPromptPreviewError::InvalidDate)?;
+        let today = NaiveDate::parse_from_str(&current_date_string(&self.clock), "%Y-%m-%d")
+            .map_err(|_| AdminPromptPreviewError::InvalidDate)?;
+        if parsed > today {
+            return Err(AdminPromptPreviewError::FutureDate);
+        }
+        Ok(parsed)
+    }
+
+    fn end_of_utc_day_epoch_seconds(date: NaiveDate) -> i64 {
+        date.and_hms_opt(23, 59, 59)
+            .expect("valid end-of-day timestamp")
+            .and_utc()
+            .timestamp()
+    }
+
+    fn map_response(input: MappedPreviewResponse<'_>) -> AdminPromptPreviewResponse {
+        let provider_messages = preview_provider_messages(&input.request);
+        AdminPromptPreviewResponse {
+            meta: AdminPromptPreviewMeta {
+                user_id: input.user_id.to_string(),
+                date: input.date.to_string(),
+                surface: input.surface.as_str().to_string(),
+                provider: input.provider.to_string(),
+                model: input.model.to_string(),
+                focus_date: input.date.to_string(),
+                selected_workout_id: input
+                    .post_workout
+                    .as_ref()
+                    .map(|meta| meta.selected_workout_id.clone()),
+                selection_method: input
+                    .post_workout
+                    .as_ref()
+                    .map(|meta| meta.selection_method.clone()),
+                compliance_score: input.post_workout.and_then(|meta| meta.compliance_score),
+            },
+            request: AdminPromptPreviewRequestBody {
+                system_prompt: input.request.system_prompt,
+                stable_context: input.request.stable_context,
+                volatile_context: input.request.volatile_context,
+                conversation: input.request.conversation,
+                tools: input.request.tools,
+                tool_choice: input.request.tool_choice,
+            },
+            provider_messages,
+        }
+    }
+
+    async fn load_planned_workouts(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> Result<Vec<crate::domain::planned_workouts::PlannedWorkout>, AdminPromptPreviewError> {
+        let Some(repository) = self.planned_workout_repository.as_ref() else {
+            return Ok(Vec::new());
+        };
+        repository
+            .list_by_user_id_and_date_range(user_id, date, date)
+            .await
+            .map_err(map_planned_error)
+    }
+
+    async fn load_special_days(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> Result<Vec<crate::domain::special_days::SpecialDay>, AdminPromptPreviewError> {
+        let Some(repository) = self.special_day_repository.as_ref() else {
+            return Ok(Vec::new());
+        };
+        repository
+            .list_by_user_id_and_date_range(user_id, date, date)
+            .await
+            .map_err(map_special_day_error)
+    }
+
+    async fn load_athlete_summary_text(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<String>, AdminPromptPreviewError> {
+        let Some(repository) = self.athlete_summary_repository.as_ref() else {
+            return Ok(None);
+        };
+        let summary = repository
+            .find_by_user_id(user_id)
+            .await
+            .map_err(|error| AdminPromptPreviewError::Repository(error.to_string()))?;
+        Ok(summary.map(|value| value.summary_text))
+    }
+}
+
+fn map_planned_error(
+    error: crate::domain::planned_workouts::PlannedWorkoutError,
+) -> AdminPromptPreviewError {
+    AdminPromptPreviewError::Repository(error.to_string())
+}
+
+fn map_special_day_error(
+    error: crate::domain::special_days::SpecialDayError,
+) -> AdminPromptPreviewError {
+    AdminPromptPreviewError::Repository(error.to_string())
+}
+
+fn map_completed_workout_error(error: CompletedWorkoutError) -> AdminPromptPreviewError {
+    AdminPromptPreviewError::Repository(error.to_string())
+}
+
+impl<Time, Planned, Special> AdminPromptPreviewUseCases
+    for AdminPromptPreviewService<Time, Planned, Special>
+where
+    Time: Clock + Clone + Send + Sync + 'static,
+    Planned: PlannedWorkoutRepository + Clone + Send + Sync + 'static,
+    Special: SpecialDayRepository + Clone + Send + Sync + 'static,
+{
+    fn preview_post_workout(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> BoxFuture<Result<AdminPromptPreviewResponse, AdminPromptPreviewError>> {
+        let service = self.clone();
+        let user_id = user_id.to_string();
+        let date = date.to_string();
+        Box::pin(async move { service.preview_post_workout_impl(&user_id, &date).await })
+    }
+
+    fn preview_calendar_coach(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> BoxFuture<Result<AdminPromptPreviewResponse, AdminPromptPreviewError>> {
+        let service = self.clone();
+        let user_id = user_id.to_string();
+        let date = date.to_string();
+        Box::pin(async move { service.preview_calendar_coach_impl(&user_id, &date).await })
+    }
+}
+
+impl<Time, Planned, Special> AdminPromptPreviewService<Time, Planned, Special>
+where
+    Time: Clock + Clone + Send + Sync + 'static,
+    Planned: PlannedWorkoutRepository + Clone + Send + Sync + 'static,
+    Special: SpecialDayRepository + Clone + Send + Sync + 'static,
+{
+    async fn preview_post_workout_impl(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> Result<AdminPromptPreviewResponse, AdminPromptPreviewError> {
+        let focus_date = self.validate_date(date)?;
+        let preview_epoch = Self::end_of_utc_day_epoch_seconds(focus_date);
+
+        let settings = self
+            .settings_service
+            .get_settings(user_id)
+            .await
+            .map_err(|error| AdminPromptPreviewError::Settings(error.to_string()))?;
+
+        let day_workouts = self
+            .completed_workout_read
+            .list_completed_workouts(user_id, date, date)
+            .await
+            .map_err(map_completed_workout_error)?;
+        let planned_workouts = self.load_planned_workouts(user_id, date).await?;
+        let special_days = self.load_special_days(user_id, date).await?;
+        let pick = pick_representative_completed_workout_for_day(
+            day_workouts,
+            &std::collections::HashSet::new(),
+            &planned_workouts,
+            &special_days,
+            settings
+                .cycling
+                .ftp_watts
+                .map(|value| i32::try_from(value).unwrap_or(i32::MAX)),
+        )
+        .ok_or(AdminPromptPreviewError::NoCompletedWorkoutForDate)?;
+
+        let resolved = self
+            .completed_workout_target_service
+            .resolve_completed_workout_target(user_id, &pick.workout.completed_workout_id)
+            .await
+            .map_err(|error| AdminPromptPreviewError::TargetResolution(error.to_string()))?
+            .ok_or(AdminPromptPreviewError::NoCompletedWorkoutForDate)?;
+        let workout_id = resolved.preferred_workout_id;
+
+        let training_context = self
+            .training_context_builder
+            .build_as_of(user_id, &workout_id, focus_date)
+            .await
+            .map_err(AdminPromptPreviewError::Llm)?;
+
+        let summary = self
+            .workout_summary_repository
+            .find_by_user_id_and_workout_id(user_id, &workout_id)
+            .await
+            .map_err(|error| AdminPromptPreviewError::Repository(error.to_string()))?
+            .unwrap_or_else(|| preview_workout_summary(user_id, &workout_id, preview_epoch));
+
+        let athlete_summary_text = self.load_athlete_summary_text(user_id).await?;
+        let config = self
+            .llm_config_provider
+            .get_config(user_id)
+            .await
+            .map_err(AdminPromptPreviewError::Llm)?;
+
+        let request = assemble_workout_summary_coach_request(WorkoutSummaryCoachPromptInput {
+            user_id: user_id.to_string(),
+            config: config.clone(),
+            summary,
+            training_context,
+            user_message: ADMIN_PREVIEW_USER_MESSAGE.to_string(),
+            athlete_summary_text,
+            conversation_epoch_seconds: preview_epoch,
+            today: date.to_string(),
+            data_port: self.data_port.clone(),
+            reusable_cache_id: None,
+        });
+
+        Ok(Self::map_response(MappedPreviewResponse {
+            surface: AdminPromptPreviewSurface::PostWorkout,
+            user_id,
+            date,
+            provider: config.provider.as_str(),
+            model: &config.model,
+            request,
+            post_workout: Some(PostWorkoutPreviewMeta {
+                selected_workout_id: workout_id,
+                selection_method: pick.method.as_str().to_string(),
+                compliance_score: pick.compliance_score,
+            }),
+        }))
+    }
+
+    async fn preview_calendar_coach_impl(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> Result<AdminPromptPreviewResponse, AdminPromptPreviewError> {
+        let focus_date = self.validate_date(date)?;
+        let preview_epoch = Self::end_of_utc_day_epoch_seconds(focus_date);
+
+        let training_context = self
+            .training_context_builder
+            .build_calendar_overview_context_as_of(user_id, focus_date)
+            .await
+            .map_err(AdminPromptPreviewError::Llm)?;
+        let config = self
+            .llm_config_provider
+            .get_config(user_id)
+            .await
+            .map_err(AdminPromptPreviewError::Llm)?;
+
+        let conversation = CoachConversation::new(
+            "admin-preview".to_string(),
+            user_id.to_string(),
+            CoachConversationSurface::Calendar,
+            CoachConversationFocus::Overview,
+            preview_epoch,
+        );
+        let preview_message = CoachConversationMessage {
+            id: "admin-preview-user".to_string(),
+            conversation_id: conversation.conversation_id.clone(),
+            user_id: user_id.to_string(),
+            role: CoachConversationMessageRole::User,
+            content: ADMIN_PREVIEW_USER_MESSAGE.to_string(),
+            tool_call: None,
+            reasoning_content: None,
+            created_at_epoch_seconds: preview_epoch,
+        };
+
+        let request = assemble_calendar_coach_request(CalendarCoachPromptInput {
+            user_id: user_id.to_string(),
+            config: config.clone(),
+            conversation,
+            messages: vec![preview_message],
+            training_context,
+            preview_message_id: "admin-preview-user".to_string(),
+            conversation_epoch_seconds: preview_epoch,
+            latest_user_message_epoch_seconds: Some(preview_epoch),
+            today: date.to_string(),
+            data_port: self.data_port.clone(),
+            planned_workout_update_port: self.planned_workout_update_port.clone(),
+        });
+
+        Ok(Self::map_response(MappedPreviewResponse {
+            surface: AdminPromptPreviewSurface::CalendarCoach,
+            user_id,
+            date,
+            provider: config.provider.as_str(),
+            model: &config.model,
+            request,
+            post_workout: None,
+        }))
+    }
+}
+
+struct MappedPreviewResponse<'a> {
+    surface: AdminPromptPreviewSurface,
+    user_id: &'a str,
+    date: &'a str,
+    provider: &'a str,
+    model: &'a str,
+    request: LlmChatRequest,
+    post_workout: Option<PostWorkoutPreviewMeta>,
+}
+
+struct PostWorkoutPreviewMeta {
+    selected_workout_id: String,
+    selection_method: String,
+    compliance_score: Option<f64>,
+}
+
+fn preview_workout_summary(user_id: &str, workout_id: &str, now: i64) -> WorkoutSummary {
+    WorkoutSummary {
+        id: format!("preview-{workout_id}"),
+        user_id: user_id.to_string(),
+        workout_id: workout_id.to_string(),
+        rpe: None,
+        messages: Vec::new(),
+        provider_transcript: Vec::new(),
+        saved_at_epoch_seconds: None,
+        workout_recap_text: None,
+        workout_recap_provider: None,
+        workout_recap_model: None,
+        workout_recap_generated_at_epoch_seconds: None,
+        created_at_epoch_seconds: now,
+        updated_at_epoch_seconds: now,
+    }
+}

--- a/src/domain/coach_conversation/mod.rs
+++ b/src/domain/coach_conversation/mod.rs
@@ -1,5 +1,6 @@
 mod model;
 mod ports;
+mod prompt;
 mod service;
 
 pub use model::{
@@ -15,6 +16,7 @@ pub use ports::{
     BoxFuture, CoachConversationMessageRepository, CoachConversationReplyOperationRepository,
     CoachConversationRepository,
 };
+pub use prompt::{assemble_calendar_coach_request, CalendarCoachPromptInput};
 pub use service::{
     coach_conversation_reply_task_handler, CoachConversationUseCases,
     SchedulerBackedCoachConversationService, SharedCoachConversationService,

--- a/src/domain/coach_conversation/prompt.rs
+++ b/src/domain/coach_conversation/prompt.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use crate::domain::llm::{
+    build_chat_request, LlmChatRequest, LlmChatRequestInput, LlmProviderConfig, LlmToolChoice,
+};
+use crate::domain::llm_tools::{
+    tool_definitions_for_scope, with_tool_prompt_guidance, GetSelectedWorkoutDataPort,
+    ToolExecutionContext, ToolScope,
+};
+use crate::domain::training_context::TrainingContextBuildResult;
+
+use super::{
+    service::transcript::{
+        build_calendar_conversation, build_calendar_stable_context,
+        build_calendar_volatile_context, calendar_coach_system_prompt,
+    },
+    CoachConversation, CoachConversationMessage,
+};
+
+pub struct CalendarCoachPromptInput {
+    pub user_id: String,
+    pub config: LlmProviderConfig,
+    pub conversation: CoachConversation,
+    pub messages: Vec<CoachConversationMessage>,
+    pub training_context: TrainingContextBuildResult,
+    pub preview_message_id: String,
+    pub conversation_epoch_seconds: i64,
+    pub latest_user_message_epoch_seconds: Option<i64>,
+    pub today: String,
+    pub data_port: Option<Arc<dyn GetSelectedWorkoutDataPort>>,
+    pub planned_workout_update_port:
+        Option<Arc<dyn crate::domain::llm_tools::UpdatePlannedWorkoutDataPort>>,
+}
+
+pub fn assemble_calendar_coach_request(input: CalendarCoachPromptInput) -> LlmChatRequest {
+    let tool_context = ToolExecutionContext {
+        user_id: input.user_id.clone(),
+        training_context: input.training_context.context.clone(),
+        today: input.today,
+        data_port: input.data_port,
+        planned_workout_update_port: input.planned_workout_update_port,
+    };
+    let system_prompt = with_tool_prompt_guidance(
+        &calendar_coach_system_prompt(),
+        ToolScope::CalendarCoachChat,
+        &input.config.provider,
+        &tool_context,
+    );
+    let stable_context = build_calendar_stable_context(
+        &input.conversation,
+        &input.training_context.rendered.stable_context,
+    );
+    let volatile_context = build_calendar_volatile_context(
+        &input.conversation,
+        &input.training_context.rendered.volatile_context,
+        input.conversation_epoch_seconds,
+        input.latest_user_message_epoch_seconds,
+    );
+    let conversation = build_calendar_conversation(
+        input.messages.as_slice(),
+        &input.conversation.provider_transcript,
+        &input.preview_message_id,
+    );
+    let cache_scope_key = Some(format!(
+        "calendar-coach:{}:{}",
+        input.conversation.user_id,
+        input.conversation.focus.cache_scope_suffix()
+    ));
+    let mut request = build_chat_request(LlmChatRequestInput {
+        user_id: input.user_id,
+        system_prompt,
+        stable_context,
+        volatile_context,
+        conversation,
+        cache_scope_key,
+        cache_key: None,
+        reusable_cache_id: None,
+    });
+    request.tools = tool_definitions_for_scope(
+        ToolScope::CalendarCoachChat,
+        &input.config.provider,
+        &tool_context,
+    );
+    request.tool_choice = if request.tools.is_empty() {
+        LlmToolChoice::None
+    } else {
+        LlmToolChoice::Auto
+    };
+    request
+}

--- a/src/domain/coach_conversation/service/mod.rs
+++ b/src/domain/coach_conversation/service/mod.rs
@@ -18,7 +18,7 @@ use super::{
 mod internals;
 mod request;
 mod scheduler;
-mod transcript;
+pub mod transcript;
 mod use_cases;
 
 pub use scheduler::{

--- a/src/domain/coach_conversation/service/transcript.rs
+++ b/src/domain/coach_conversation/service/transcript.rs
@@ -11,14 +11,14 @@ pub(super) fn final_assistant_text(response: &LlmChatResponse) -> Option<String>
     crate::domain::llm::final_assistant_text(response)
 }
 
-pub(super) fn calendar_coach_system_prompt() -> String {
+pub fn calendar_coach_system_prompt() -> String {
     format!(
         "{CALENDAR_COACH_SYSTEM_PROMPT_BASE} {}",
         crate::domain::llm::PACKED_TRAINING_CONTEXT_LEGEND,
     )
 }
 
-pub(super) fn build_calendar_stable_context(
+pub fn build_calendar_stable_context(
     conversation: &CoachConversation,
     packed_training_context: &str,
 ) -> String {
@@ -35,7 +35,7 @@ pub(super) fn build_calendar_stable_context(
     context
 }
 
-pub(super) fn build_calendar_volatile_context(
+pub fn build_calendar_volatile_context(
     conversation: &CoachConversation,
     packed_training_context: &str,
     current_conversation_epoch_seconds: i64,
@@ -51,7 +51,7 @@ pub(super) fn build_calendar_volatile_context(
     )
 }
 
-pub(super) fn build_calendar_conversation(
+pub fn build_calendar_conversation(
     messages: &[CoachConversationMessage],
     provider_transcript: &[LlmChatMessage],
     up_to_message_id: &str,

--- a/src/domain/completed_workouts/mod.rs
+++ b/src/domain/completed_workouts/mod.rs
@@ -5,6 +5,8 @@ mod power_curve;
 mod power_curve_repo;
 mod selection;
 mod service;
+
+pub use selection::select_visible_workouts_by_day;
 #[cfg(test)]
 mod tests;
 

--- a/src/domain/llm/mod.rs
+++ b/src/domain/llm/mod.rs
@@ -6,6 +6,7 @@ mod operation;
 mod orchestrator;
 pub(crate) mod persistence;
 mod ports;
+mod preview_messages;
 mod request_builder;
 mod transcript;
 
@@ -32,6 +33,7 @@ pub(crate) use orchestrator::{
     resolve_llm_reply_operation, LlmReplyResolutionWorkflow, ResolvedLlmReplyOperation,
 };
 pub use ports::{BoxFuture, LlmChatPort, LlmContextCacheRepository, UserLlmConfigProvider};
+pub use preview_messages::{preview_provider_messages, PreviewProviderMessage};
 pub use request_builder::{
     build_chat_request, conversation_timing_volatile_context, current_date_string,
     current_datetime_rfc3339, epoch_seconds_to_rfc3339, find_reusable_context_cache,

--- a/src/domain/llm/preview_messages.rs
+++ b/src/domain/llm/preview_messages.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+
+use super::{LlmChatMessage, LlmChatRequest, LlmMessageRole};
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PreviewProviderMessage {
+    pub role: String,
+    pub content: String,
+}
+
+pub fn preview_provider_messages(request: &LlmChatRequest) -> Vec<PreviewProviderMessage> {
+    let mut messages = Vec::new();
+    for (role, content) in [
+        ("system", request.system_prompt.as_str()),
+        ("system", request.stable_context.as_str()),
+        ("system", request.volatile_context.as_str()),
+    ] {
+        if !content.trim().is_empty() {
+            messages.push(PreviewProviderMessage {
+                role: role.to_string(),
+                content: content.to_string(),
+            });
+        }
+    }
+    messages.extend(request.conversation.iter().map(map_conversation_message));
+    messages
+}
+
+fn map_conversation_message(message: &LlmChatMessage) -> PreviewProviderMessage {
+    let role = match message.role {
+        LlmMessageRole::System => "system",
+        LlmMessageRole::User => "user",
+        LlmMessageRole::Assistant => "assistant",
+        LlmMessageRole::Tool => "tool",
+    };
+    PreviewProviderMessage {
+        role: role.to_string(),
+        content: message.content.clone(),
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_prompt_preview;
 pub mod ai_workflow;
 pub mod athlete_summary;
 pub mod calendar;

--- a/src/domain/training_context/mod.rs
+++ b/src/domain/training_context/mod.rs
@@ -11,6 +11,7 @@ pub use model::{
 };
 pub use packing::{approximate_token_count, render_training_context};
 pub use service::{
+    pick_representative_completed_workout_for_day, DayWorkoutPick, DayWorkoutPickMethod,
     DefaultTrainingContextBuilder, TrainingContextBuilder, ATHLETE_SUMMARY_FOCUS_ID,
     CALENDAR_OVERVIEW_FOCUS_ID,
 };

--- a/src/domain/training_context/service/context.rs
+++ b/src/domain/training_context/service/context.rs
@@ -642,7 +642,7 @@ pub(super) struct RecentWorkoutSummaryLookup<'a> {
     pub(super) recap_by_workout_id: &'a HashMap<String, String>,
 }
 
-pub(super) fn build_event_activity_matches(
+pub fn build_event_activity_matches(
     events: &[Event],
     activities: &[Activity],
     direct_matches: &HashMap<String, Event>,

--- a/src/domain/training_context/service/mod.rs
+++ b/src/domain/training_context/service/mod.rs
@@ -54,6 +54,11 @@ use context::{
 use dates::{activity_date, epoch_seconds_to_date, event_date};
 use history::build_recent_interval_blocks_by_activity_id;
 
+mod workout_pick;
+pub use workout_pick::{
+    pick_representative_completed_workout_for_day, DayWorkoutPick, DayWorkoutPickMethod,
+};
+
 pub trait TrainingContextBuilder: Send + Sync {
     fn build(
         &self,
@@ -61,9 +66,22 @@ pub trait TrainingContextBuilder: Send + Sync {
         workout_id: &str,
     ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
 
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        focus_date: chrono::NaiveDate,
+    ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
+
     fn build_calendar_overview_context(
         &self,
         user_id: &str,
+    ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        focus_date: chrono::NaiveDate,
     ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>>;
 
     fn build_athlete_summary_context(
@@ -332,7 +350,23 @@ where
         let builder = self.clone();
         let user_id = user_id.to_string();
         let workout_id = workout_id.to_string();
-        Box::pin(async move { builder.build_impl(&user_id, &workout_id).await })
+        Box::pin(async move { builder.build_impl(&user_id, &workout_id, None).await })
+    }
+
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        focus_date: chrono::NaiveDate,
+    ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        let builder = self.clone();
+        let user_id = user_id.to_string();
+        let workout_id = workout_id.to_string();
+        Box::pin(async move {
+            builder
+                .build_impl(&user_id, &workout_id, Some(focus_date))
+                .await
+        })
     }
 
     fn build_calendar_overview_context(
@@ -343,7 +377,21 @@ where
         let user_id = user_id.to_string();
         Box::pin(async move {
             builder
-                .build_impl(&user_id, CALENDAR_OVERVIEW_FOCUS_ID)
+                .build_impl(&user_id, CALENDAR_OVERVIEW_FOCUS_ID, None)
+                .await
+        })
+    }
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        focus_date: chrono::NaiveDate,
+    ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        let builder = self.clone();
+        let user_id = user_id.to_string();
+        Box::pin(async move {
+            builder
+                .build_impl(&user_id, CALENDAR_OVERVIEW_FOCUS_ID, Some(focus_date))
                 .await
         })
     }
@@ -354,7 +402,11 @@ where
     ) -> crate::domain::llm::BoxFuture<Result<TrainingContextBuildResult, LlmError>> {
         let builder = self.clone();
         let user_id = user_id.to_string();
-        Box::pin(async move { builder.build_impl(&user_id, ATHLETE_SUMMARY_FOCUS_ID).await })
+        Box::pin(async move {
+            builder
+                .build_impl(&user_id, ATHLETE_SUMMARY_FOCUS_ID, None)
+                .await
+        })
     }
 }
 
@@ -366,13 +418,15 @@ where
         &self,
         user_id: &str,
         workout_id: &str,
+        as_of_focus_day: Option<chrono::NaiveDate>,
     ) -> Result<TrainingContextBuildResult, LlmError> {
         let settings = self
             .settings_service
             .get_settings(user_id)
             .await
             .map_err(|error| LlmError::Internal(error.to_string()))?;
-        let today = epoch_seconds_to_date(self.clock.now_epoch_seconds());
+        let clock_today = epoch_seconds_to_date(self.clock.now_epoch_seconds());
+        let today = as_of_focus_day.unwrap_or(clock_today);
         let focus_date = self
             .resolve_focus_date(user_id, workout_id)
             .await
@@ -868,7 +922,7 @@ where
     }
 }
 
-fn build_local_events(
+pub(super) fn build_local_events(
     planned_workouts: &[PlannedWorkout],
     special_days: &[SpecialDay],
 ) -> Vec<Event> {
@@ -886,7 +940,7 @@ fn build_local_events(
     events
 }
 
-fn build_direct_event_matches(
+pub(super) fn build_direct_event_matches(
     completed_workouts: &[CompletedWorkout],
     planned_events_by_id: &HashMap<String, Event>,
 ) -> HashMap<String, Event> {

--- a/src/domain/training_context/service/workout_pick.rs
+++ b/src/domain/training_context/service/workout_pick.rs
@@ -1,0 +1,215 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::domain::{
+    completed_workouts::{select_visible_workouts_by_day, CompletedWorkout},
+    intervals::{find_best_activity_match, parse_workout_doc, Activity, Event},
+    planned_workouts::PlannedWorkout,
+    special_days::SpecialDay,
+};
+
+use super::{
+    build_direct_event_matches, build_event_activity_matches, build_local_events,
+    map_completed_workout_to_activity,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DayWorkoutPick {
+    pub workout: CompletedWorkout,
+    pub method: DayWorkoutPickMethod,
+    pub compliance_score: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DayWorkoutPickMethod {
+    SingleWorkout,
+    ComplianceMatch,
+    TrainingStressFallback,
+    LatestStartFallback,
+}
+
+impl DayWorkoutPickMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SingleWorkout => "single_workout",
+            Self::ComplianceMatch => "compliance_match",
+            Self::TrainingStressFallback => "tss_fallback",
+            Self::LatestStartFallback => "latest_start_fallback",
+        }
+    }
+}
+
+pub fn pick_representative_completed_workout_for_day(
+    day_workouts: Vec<CompletedWorkout>,
+    wahoo_entity_ids: &HashSet<String>,
+    planned_workouts: &[PlannedWorkout],
+    special_days: &[SpecialDay],
+    configured_ftp: Option<i32>,
+) -> Option<DayWorkoutPick> {
+    let visible = select_visible_workouts_by_day(day_workouts, wahoo_entity_ids);
+    pick_from_visible_workouts(&visible, planned_workouts, special_days, configured_ftp)
+}
+
+fn pick_from_visible_workouts(
+    visible: &[CompletedWorkout],
+    planned_workouts: &[PlannedWorkout],
+    special_days: &[SpecialDay],
+    configured_ftp: Option<i32>,
+) -> Option<DayWorkoutPick> {
+    match visible.len() {
+        0 => None,
+        1 => Some(DayWorkoutPick {
+            workout: visible[0].clone(),
+            method: DayWorkoutPickMethod::SingleWorkout,
+            compliance_score: None,
+        }),
+        _ => pick_best_among_visible(visible, planned_workouts, special_days, configured_ftp),
+    }
+}
+
+fn pick_best_among_visible(
+    visible: &[CompletedWorkout],
+    planned_workouts: &[PlannedWorkout],
+    special_days: &[SpecialDay],
+    configured_ftp: Option<i32>,
+) -> Option<DayWorkoutPick> {
+    let events: Vec<Event> = build_local_events(planned_workouts, special_days);
+    let activities: Vec<Activity> = visible
+        .iter()
+        .map(map_completed_workout_to_activity)
+        .collect();
+    let planned_events_by_id = events
+        .iter()
+        .map(|event| (event.id.to_string(), event.clone()))
+        .collect::<HashMap<_, _>>();
+    let direct_matches = build_direct_event_matches(visible, &planned_events_by_id);
+    let matches =
+        build_event_activity_matches(&events, &activities, &direct_matches, configured_ftp);
+
+    let mut best: Option<(f64, CompletedWorkout)> = None;
+    for workout in visible {
+        let activity_id = map_completed_workout_to_activity(workout).id;
+        let Some(event) = matches.activity_to_event.get(&activity_id) else {
+            continue;
+        };
+        let effective_ftp = workout.metrics.ftp_watts.or(configured_ftp);
+        let parsed = parse_workout_doc(event.structured_workout_text(), effective_ftp);
+        let activity = map_completed_workout_to_activity(workout);
+        let Some(candidate) =
+            find_best_activity_match(&parsed, std::slice::from_ref(&activity), effective_ftp)
+        else {
+            continue;
+        };
+        if candidate.compliance_score < 0.45 {
+            continue;
+        }
+        if best
+            .as_ref()
+            .is_none_or(|(score, _)| candidate.compliance_score > *score)
+        {
+            best = Some((candidate.compliance_score, workout.clone()));
+        }
+    }
+
+    if let Some((score, workout)) = best {
+        return Some(DayWorkoutPick {
+            workout,
+            method: DayWorkoutPickMethod::ComplianceMatch,
+            compliance_score: Some(score),
+        });
+    }
+
+    let tss_winner = visible.iter().max_by(|left, right| {
+        left.metrics
+            .training_stress_score
+            .unwrap_or(0)
+            .cmp(&right.metrics.training_stress_score.unwrap_or(0))
+            .then_with(|| left.start_date_local.cmp(&right.start_date_local))
+    })?;
+    if tss_winner.metrics.training_stress_score.is_some() {
+        return Some(DayWorkoutPick {
+            workout: tss_winner.clone(),
+            method: DayWorkoutPickMethod::TrainingStressFallback,
+            compliance_score: None,
+        });
+    }
+
+    let latest = visible
+        .iter()
+        .max_by(|left, right| left.start_date_local.cmp(&right.start_date_local))?;
+    Some(DayWorkoutPick {
+        workout: latest.clone(),
+        method: DayWorkoutPickMethod::LatestStartFallback,
+        compliance_score: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::completed_workouts::{CompletedWorkoutDetails, CompletedWorkoutMetrics};
+
+    fn sample_workout(id: &str, day: &str, tss: Option<i32>) -> CompletedWorkout {
+        CompletedWorkout::new(
+            id.to_string(),
+            "user-1".to_string(),
+            format!("{day}T10:00:00"),
+            Some(id.to_string()),
+            None,
+            Some(id.to_string()),
+            None,
+            Some("Ride".to_string()),
+            None,
+            false,
+            Some(3600),
+            Some(1000.0),
+            CompletedWorkoutMetrics {
+                training_stress_score: tss,
+                normalized_power_watts: None,
+                intensity_factor: None,
+                efficiency_factor: None,
+                variability_index: None,
+                average_power_watts: None,
+                ftp_watts: Some(250),
+                total_work_joules: None,
+                calories: None,
+                trimp: None,
+                power_load: None,
+                heart_rate_load: None,
+                pace_load: None,
+                strain_score: None,
+            },
+            CompletedWorkoutDetails {
+                intervals: Vec::new(),
+                interval_groups: Vec::new(),
+                streams: Vec::new(),
+                interval_summary: Vec::new(),
+                skyline_chart: Vec::new(),
+                power_zone_times: Vec::new(),
+                heart_rate_zone_times: Vec::new(),
+                pace_zone_times: Vec::new(),
+                gap_zone_times: Vec::new(),
+            },
+            None,
+        )
+    }
+
+    #[test]
+    fn single_visible_workout_uses_single_method() {
+        let workout = sample_workout("ride-1", "2026-05-01", Some(50));
+        let pick = pick_from_visible_workouts(std::slice::from_ref(&workout), &[], &[], Some(250))
+            .expect("pick");
+
+        assert_eq!(pick.method, DayWorkoutPickMethod::SingleWorkout);
+        assert_eq!(pick.workout.completed_workout_id, "ride-1");
+    }
+
+    #[test]
+    fn tss_fallback_prefers_higher_stress_when_no_compliance_match() {
+        let low = sample_workout("ride-low", "2026-05-01", Some(30));
+        let high = sample_workout("ride-high", "2026-05-01", Some(90));
+        let pick = pick_from_visible_workouts(&[low, high], &[], &[], Some(250)).expect("pick");
+
+        assert_eq!(pick.method, DayWorkoutPickMethod::TrainingStressFallback);
+        assert_eq!(pick.workout.completed_workout_id, "ride-high");
+    }
+}

--- a/src/domain/workout_summary/mod.rs
+++ b/src/domain/workout_summary/mod.rs
@@ -2,6 +2,7 @@ mod coach;
 mod coach_output;
 mod model;
 mod ports;
+mod prompt;
 mod save_completion_port;
 mod service;
 mod test_support;
@@ -18,6 +19,11 @@ pub use model::{
     WorkoutSummaryError,
 };
 pub use ports::{BoxFuture, CoachReplyOperationRepository, WorkoutSummaryRepository};
+pub use prompt::{
+    assemble_workout_summary_coach_request, build_conversation, build_stable_context,
+    build_volatile_context, workout_coach_system_prompt, WorkoutSummaryCoachPromptInput,
+    ADMIN_PREVIEW_USER_MESSAGE,
+};
 pub use save_completion_port::{NoopSaveWorkflowCompletionPort, SaveWorkflowCompletionPort};
 pub use service::{
     workout_summary_coach_reply_task_handler, CompletedWorkoutAliasScope,

--- a/src/domain/workout_summary/prompt.rs
+++ b/src/domain/workout_summary/prompt.rs
@@ -1,0 +1,227 @@
+use std::sync::Arc;
+
+use crate::domain::llm::{
+    build_chat_request, conversation_timing_volatile_context,
+    rebuild_conversation_with_provider_transcript, timestamped_message_content, LlmChatMessage,
+    LlmChatRequest, LlmChatRequestInput, LlmMessageRole, LlmProviderConfig, LlmToolChoice,
+    PACKED_TRAINING_CONTEXT_LEGEND,
+};
+use crate::domain::llm_tools::{
+    tool_definitions_for_scope, with_tool_prompt_guidance, GetSelectedWorkoutDataPort,
+    ToolExecutionContext, ToolScope,
+};
+use crate::domain::training_context::TrainingContextBuildResult;
+
+use super::{
+    workout_summary_coach_reply_json_schema, ConversationMessage, MessageRole, WorkoutSummary,
+};
+
+pub const ADMIN_PREVIEW_USER_MESSAGE: &str = "Preview: [admin] sample athlete message";
+
+const WORKOUT_COACH_SYSTEM_PROMPT_BASE: &str = "You are an AI cycling coach helping an athlete reflect on one completed workout. Use the packed training context as factual background. Be direct, adult, and concise. Do not flatter, hedge, or act like a yes-man. Challenge weak reasoning when the context does not support it. Keep the conversation focused and practical rather than digressive. In your first reply after a workout, ask all follow-up questions you genuinely need at once instead of stretching them across many turns. The athlete should still feel coached, not interrogated. Ask concrete questions about the workout limiter, legs, breathing, fueling, sleep, stress, pain, readiness for the next days, and any plan constraints when relevant. Add other questions only when the workout characteristics clearly justify them. You may also ask about nutrition, race strategy, or the desired direction of the next 14 days when that would materially improve the next plan. For completed interval workouts, judge execution quality primarily from packed workout evidence: bl as intended block structure/targets, pc as executed power pattern, and c5 as supporting cadence evidence. Aggregate metrics like NP, average power, IF, VI, and TSS are secondary context only and are not sufficient proof that interval blocks were or were not executed correctly. Do not conclude poor interval execution just because whole-workout averages were lowered by recovery valleys, coasting, zeros, terrain, or wind. If the packed evidence is insufficient for a confident execution judgment, inspect higher-fidelity data before making a strong claim. When workout tools are available, use them for that fallback. If you already have enough information to generate the plan, say that clearly and tell the athlete to save the summary. Return your final answer as JSON only matching the workout summary coach reply schema. The summary may use markdown. Questions may be an empty array when you are ready. Do not output any text outside the JSON object. Do not invent details beyond the provided context.";
+
+const WORKOUT_COACH_SELECTED_WORKOUT_PROMPT: &str = "Use the provided selected workout date as the active workout context for this conversation. When inspecting the current workout, prefer that exact selected workout date or id instead of inferring from nearby history.";
+
+pub struct WorkoutSummaryCoachPromptInput {
+    pub user_id: String,
+    pub config: LlmProviderConfig,
+    pub summary: WorkoutSummary,
+    pub training_context: TrainingContextBuildResult,
+    pub user_message: String,
+    pub athlete_summary_text: Option<String>,
+    pub conversation_epoch_seconds: i64,
+    pub today: String,
+    pub data_port: Option<Arc<dyn GetSelectedWorkoutDataPort>>,
+    pub reusable_cache_id: Option<String>,
+}
+
+pub fn assemble_workout_summary_coach_request(
+    input: WorkoutSummaryCoachPromptInput,
+) -> LlmChatRequest {
+    let stable_context = build_stable_context(
+        &input.summary,
+        &input.training_context.focus_date,
+        &input.training_context.rendered.stable_context,
+        input.athlete_summary_text.as_deref(),
+    );
+    let volatile_context = build_volatile_context(
+        &input.training_context.rendered.volatile_context,
+        input.conversation_epoch_seconds,
+        latest_user_message_epoch_seconds(&input.summary, input.conversation_epoch_seconds),
+    );
+    let tool_context = ToolExecutionContext {
+        user_id: input.user_id.clone(),
+        training_context: input.training_context.context.clone(),
+        today: input.today,
+        data_port: input.data_port,
+        planned_workout_update_port: None,
+    };
+    let system_prompt = with_tool_prompt_guidance(
+        &workout_coach_system_prompt(),
+        ToolScope::WorkoutSummaryChat,
+        &input.config.provider,
+        &tool_context,
+    );
+    let conversation = build_conversation(
+        input.summary.messages.as_slice(),
+        &input.summary.provider_transcript,
+        &input.user_message,
+        input.conversation_epoch_seconds,
+    );
+    let cache_scope_key = Some(format!(
+        "workout-summary:{}:{}",
+        input.user_id, input.summary.workout_id
+    ));
+    let mut request = build_chat_request(LlmChatRequestInput {
+        user_id: input.user_id,
+        system_prompt,
+        stable_context,
+        volatile_context,
+        conversation,
+        cache_scope_key,
+        cache_key: None,
+        reusable_cache_id: input.reusable_cache_id,
+    });
+    apply_tool_scope(
+        &mut request,
+        ToolScope::WorkoutSummaryChat,
+        &input.config,
+        &tool_context,
+    );
+    request
+}
+
+fn apply_tool_scope(
+    request: &mut LlmChatRequest,
+    scope: ToolScope,
+    config: &LlmProviderConfig,
+    tool_context: &ToolExecutionContext,
+) {
+    request.tools = tool_definitions_for_scope(scope, &config.provider, tool_context);
+    request.tool_choice = if request.tools.is_empty() {
+        LlmToolChoice::None
+    } else {
+        LlmToolChoice::Auto
+    };
+}
+
+pub fn workout_coach_system_prompt() -> String {
+    format!(
+        "{WORKOUT_COACH_SYSTEM_PROMPT_BASE}\n{WORKOUT_COACH_SELECTED_WORKOUT_PROMPT}\nworkout_summary_coach_reply_schema={}\n{PACKED_TRAINING_CONTEXT_LEGEND}",
+        workout_summary_coach_reply_json_schema()
+    )
+}
+
+pub fn build_stable_context(
+    summary: &WorkoutSummary,
+    selected_workout_date: &str,
+    packed_training_context: &str,
+    athlete_summary_text: Option<&str>,
+) -> String {
+    let mut context = format!(
+        "workout_summary={{\"workoutId\":\"{}\",\"rpe\":{}}}\nselected_workout={{\"workoutId\":\"{}\",\"date\":\"{}\"}}\ncurrent_workout_context=You are discussing the completed workout from {}.",
+        summary.workout_id,
+        summary
+            .rpe
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "null".to_string()),
+        summary.workout_id,
+        selected_workout_date,
+        selected_workout_date,
+    );
+
+    if let Some(summary_text) = athlete_summary_text.filter(|value| !value.trim().is_empty()) {
+        context.push_str(&format!("\nathlete_summary_text={summary_text}"));
+    }
+
+    context.push_str(&format!(
+        "\ntraining_context_stable={packed_training_context}"
+    ));
+    context
+}
+
+pub fn build_volatile_context(
+    packed_training_context: &str,
+    current_conversation_epoch_seconds: i64,
+    latest_user_message_epoch_seconds: Option<i64>,
+) -> String {
+    format!(
+        "{}\ntraining_context_volatile={packed_training_context}",
+        conversation_timing_volatile_context(
+            current_conversation_epoch_seconds,
+            latest_user_message_epoch_seconds,
+        )
+    )
+}
+
+pub fn build_conversation(
+    messages: &[ConversationMessage],
+    provider_transcript: &[LlmChatMessage],
+    user_message: &str,
+    fallback_user_message_epoch_seconds: i64,
+) -> Vec<LlmChatMessage> {
+    let conversation = messages
+        .iter()
+        .filter_map(|message| match message.role {
+            MessageRole::User => Some(LlmChatMessage {
+                role: LlmMessageRole::User,
+                content: timestamped_message_content(
+                    &message.content,
+                    message.created_at_epoch_seconds,
+                ),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+                reasoning_content: None,
+            }),
+            MessageRole::Coach => Some(LlmChatMessage {
+                role: LlmMessageRole::Assistant,
+                content: timestamped_message_content(
+                    &message.content,
+                    message.created_at_epoch_seconds,
+                ),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+                reasoning_content: None,
+            }),
+            MessageRole::Tool => None,
+        })
+        .collect::<Vec<_>>();
+
+    let mut rebuilt =
+        rebuild_conversation_with_provider_transcript(conversation, provider_transcript);
+
+    if let Some(last) = rebuilt.last_mut() {
+        if last.role == LlmMessageRole::User {
+            last.content = timestamped_message_content(
+                user_message,
+                latest_user_message_epoch_seconds_in_messages(messages)
+                    .unwrap_or(fallback_user_message_epoch_seconds),
+            );
+            return rebuilt;
+        }
+    }
+
+    rebuilt.push(LlmChatMessage::user(timestamped_message_content(
+        user_message,
+        latest_user_message_epoch_seconds_in_messages(messages)
+            .unwrap_or(fallback_user_message_epoch_seconds),
+    )));
+
+    rebuilt
+}
+
+fn latest_user_message_epoch_seconds(
+    summary: &WorkoutSummary,
+    fallback_epoch_seconds: i64,
+) -> Option<i64> {
+    latest_user_message_epoch_seconds_in_messages(&summary.messages)
+        .or(Some(fallback_epoch_seconds))
+}
+
+fn latest_user_message_epoch_seconds_in_messages(messages: &[ConversationMessage]) -> Option<i64> {
+    messages
+        .iter()
+        .rev()
+        .find(|message| matches!(message.role, MessageRole::User))
+        .map(|message| message.created_at_epoch_seconds)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ use aiwattcoach::{
         workout_summary_task_worker_config, ProviderPollingService, Settings,
         TaskSchedulerMaintenanceConfig, TaskSchedulerWorkerConfig,
     },
+    domain::admin_prompt_preview::{AdminPromptPreviewService, AdminPromptPreviewUseCases},
     domain::athlete_summary::{
         athlete_summary_generate_task_handler, AthleteSummaryService,
         SchedulerBackedAthleteSummaryService,
@@ -236,6 +237,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let athlete_summary_repository =
         MongoAthleteSummaryRepository::new(mongo_client.clone(), &mongo_database);
     athlete_summary_repository.ensure_indexes().await?;
+    let athlete_summary_repository_for_admin = athlete_summary_repository.clone();
     let athlete_summary_generation_operation_repository =
         MongoAthleteSummaryGenerationOperationRepository::new(
             mongo_client.clone(),
@@ -619,7 +621,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .with_settings_service(settings_service.clone())
         .with_context_cache_repository(Arc::new(llm_context_cache_repository.clone()))
         .with_data_port(get_selected_workout_data_port.clone())
-        .with_planned_workout_update_port(planned_workout_update_port),
+        .with_planned_workout_update_port(planned_workout_update_port.clone()),
     );
     let training_plan_direct_service = Arc::new(
         TrainingPlanGenerationService::new(
@@ -729,6 +731,23 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         shared_task_scheduler.clone(),
         UuidIdGenerator,
     ));
+    let admin_prompt_preview_service: Arc<dyn AdminPromptPreviewUseCases> =
+        Arc::new(AdminPromptPreviewService::new(
+            training_context_builder.clone(),
+            llm_config_provider.clone(),
+            completed_workout_service.clone(),
+            Some(planned_workout_repository.clone()),
+            Some(special_day_repository.clone()),
+            Arc::new(CompletedWorkoutTargetAdapter::new(
+                authoritative_completed_workout_repository.clone(),
+            )),
+            Arc::new(workout_summary_repository.clone()),
+            Some(Arc::new(athlete_summary_repository_for_admin)),
+            settings_service.clone(),
+            Some(get_selected_workout_data_port.clone()),
+            Some(planned_workout_update_port.clone()),
+            SystemClock,
+        ));
 
     let intervals_connection_tester = if dev_intervals_enabled {
         IntervalsApiAdapter::Dev(DevIntervalsClient)
@@ -748,6 +767,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         )
         .with_settings_service(settings_service)
         .with_admin_task_scheduler_service(Arc::new(shared_task_scheduler.clone()))
+        .with_admin_prompt_preview_service(admin_prompt_preview_service)
         .with_training_load_dashboard_service(training_load_dashboard_service)
         .with_calendar_service(calendar_service)
         .with_calendar_coach_service(calendar_coach_service)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -119,6 +119,7 @@
 - Read `reviewers.md` and `tasks/lessons.md` before planning and before implementation.
 - After any correction from the user, record the lesson in an appropriate category above.
 - After implementing a non-trivial change, verify: relevant test suite, `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `bun run verify:arch`, `./scripts/rebuild_graphify.sh`.
+- **This Linux dev box is RAM-limited:** use `CARGO_BUILD_JOBS=1` / `cargo -j 1`, run only one `cargo` process at a time, and prefer narrow `cargo test <filter> -- --test-threads=1` instead of full-workspace `cargo test`. Parallel `rustc` can OOM the host and kill the IDE.
 - Do not run multiple heavy verification commands in parallel on this machine.
 
 ### Git and PR workflow

--- a/tests/auth_rest/admin_routes.rs
+++ b/tests/auth_rest/admin_routes.rs
@@ -99,6 +99,46 @@ async fn admin_system_info_returns_payload_for_admin() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn admin_prompt_preview_post_workout_requires_admin() {
+    let app = auth_test_app(TestIdentityService {
+        admin_cookie_role: aiwattcoach::domain::identity::Role::User,
+        ..Default::default()
+    })
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/admin/users/user-1/prompt-preview/post-workout?date=2026-05-01")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn admin_prompt_preview_calendar_coach_returns_service_unavailable_without_wiring() {
+    let app = auth_test_app(TestIdentityService::default()).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/admin/users/user-1/prompt-preview/calendar-coach?date=2026-05-01")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn admin_task_scheduler_list_requires_admin() {
     let app = auth_test_app_with_admin_task_scheduler(
         TestIdentityService {

--- a/tests/auth_rest/admin_routes.rs
+++ b/tests/auth_rest/admin_routes.rs
@@ -5,14 +5,19 @@ use axum::{
 use serde_json::{json, Value};
 use tower::util::ServiceExt;
 
+use aiwattcoach::domain::admin_prompt_preview::{
+    AdminPromptPreviewMeta, AdminPromptPreviewRequestBody, AdminPromptPreviewResponse,
+    AdminPromptPreviewUseCases, BoxFuture as PreviewBoxFuture,
+};
+use aiwattcoach::domain::llm::{LlmToolChoice, PreviewProviderMessage};
 use aiwattcoach::domain::task_scheduler::{
     AdminTaskSchedulerUseCases, BoxFuture as TaskBoxFuture, NewTask, RetryStrategy, ScheduledTask,
     TaskListFilter, TaskListPage, TaskSchedulerError, TaskStatus,
 };
 
 use crate::shared::{
-    auth_test_app, auth_test_app_with_admin_task_scheduler, TestIdentityService,
-    RESPONSE_LIMIT_BYTES,
+    auth_test_app, auth_test_app_with_admin_prompt_preview,
+    auth_test_app_with_admin_task_scheduler, TestIdentityService, RESPONSE_LIMIT_BYTES,
 };
 
 #[tokio::test(flavor = "current_thread")]
@@ -139,6 +144,67 @@ async fn admin_prompt_preview_calendar_coach_returns_service_unavailable_without
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn admin_prompt_preview_post_workout_returns_payload_for_admin() {
+    let app = auth_test_app_with_admin_prompt_preview(
+        TestIdentityService::default(),
+        TestAdminPromptPreview,
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/admin/users/user-1/prompt-preview/post-workout?date=2026-05-01")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT_BYTES)
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["meta"]["surface"], "post_workout");
+    assert_eq!(payload["meta"]["selectedWorkoutId"], "ride-1");
+    assert_eq!(payload["request"]["systemPrompt"], "post-workout-system");
+    assert_eq!(payload["providerMessages"][0]["role"], "system");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn admin_prompt_preview_calendar_coach_returns_payload_for_admin() {
+    let app = auth_test_app_with_admin_prompt_preview(
+        TestIdentityService::default(),
+        TestAdminPromptPreview,
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/admin/users/user-1/prompt-preview/calendar-coach?date=2026-05-01")
+                .header(header::COOKIE, "aiwattcoach_session=session-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT_BYTES)
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["meta"]["surface"], "calendar_coach");
+    assert_eq!(payload["request"]["systemPrompt"], "calendar-coach-system");
+    assert_eq!(payload["providerMessages"], json!([]));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn admin_task_scheduler_list_requires_admin() {
     let app = auth_test_app_with_admin_task_scheduler(
         TestIdentityService {
@@ -262,6 +328,94 @@ async fn admin_task_scheduler_retry_rejects_completed_task() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[derive(Clone, Copy, Default)]
+struct TestAdminPromptPreview;
+
+impl AdminPromptPreviewUseCases for TestAdminPromptPreview {
+    fn preview_post_workout(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> PreviewBoxFuture<
+        Result<
+            AdminPromptPreviewResponse,
+            aiwattcoach::domain::admin_prompt_preview::AdminPromptPreviewError,
+        >,
+    > {
+        let user_id = user_id.to_string();
+        let date = date.to_string();
+        Box::pin(async move { Ok(sample_post_workout_preview(&user_id, &date)) })
+    }
+
+    fn preview_calendar_coach(
+        &self,
+        user_id: &str,
+        date: &str,
+    ) -> PreviewBoxFuture<
+        Result<
+            AdminPromptPreviewResponse,
+            aiwattcoach::domain::admin_prompt_preview::AdminPromptPreviewError,
+        >,
+    > {
+        let user_id = user_id.to_string();
+        let date = date.to_string();
+        Box::pin(async move { Ok(sample_calendar_coach_preview(&user_id, &date)) })
+    }
+}
+
+fn sample_post_workout_preview(user_id: &str, date: &str) -> AdminPromptPreviewResponse {
+    AdminPromptPreviewResponse {
+        meta: AdminPromptPreviewMeta {
+            user_id: user_id.to_string(),
+            date: date.to_string(),
+            surface: "post_workout".to_string(),
+            provider: "openrouter".to_string(),
+            model: "test-model".to_string(),
+            focus_date: date.to_string(),
+            selected_workout_id: Some("ride-1".to_string()),
+            selection_method: Some("single_workout".to_string()),
+            compliance_score: None,
+        },
+        request: AdminPromptPreviewRequestBody {
+            system_prompt: "post-workout-system".to_string(),
+            stable_context: "stable".to_string(),
+            volatile_context: "volatile".to_string(),
+            conversation: Vec::new(),
+            tools: Vec::new(),
+            tool_choice: LlmToolChoice::Auto,
+        },
+        provider_messages: vec![PreviewProviderMessage {
+            role: "system".to_string(),
+            content: "post-workout-system".to_string(),
+        }],
+    }
+}
+
+fn sample_calendar_coach_preview(user_id: &str, date: &str) -> AdminPromptPreviewResponse {
+    AdminPromptPreviewResponse {
+        meta: AdminPromptPreviewMeta {
+            user_id: user_id.to_string(),
+            date: date.to_string(),
+            surface: "calendar_coach".to_string(),
+            provider: "openrouter".to_string(),
+            model: "test-model".to_string(),
+            focus_date: date.to_string(),
+            selected_workout_id: None,
+            selection_method: None,
+            compliance_score: None,
+        },
+        request: AdminPromptPreviewRequestBody {
+            system_prompt: "calendar-coach-system".to_string(),
+            stable_context: "stable".to_string(),
+            volatile_context: "volatile".to_string(),
+            conversation: Vec::new(),
+            tools: Vec::new(),
+            tool_choice: LlmToolChoice::None,
+        },
+        provider_messages: Vec::new(),
+    }
 }
 
 #[derive(Clone, Default)]

--- a/tests/auth_rest/shared.rs
+++ b/tests/auth_rest/shared.rs
@@ -9,6 +9,7 @@ use std::{
 use aiwattcoach::{
     build_app_with_frontend_dist,
     config::{AppState, WhitelistRateLimiter},
+    domain::admin_prompt_preview::AdminPromptPreviewUseCases,
     domain::identity::{
         AppUser, AuthSession, GoogleLoginOutcome, GoogleLoginStart, GoogleLoginSuccess,
         IdentityError, IdentityUseCases, Role, WhitelistEntry,
@@ -168,6 +169,36 @@ pub(crate) async fn auth_test_app_with_settings(
             24,
         )
         .with_settings_service(std::sync::Arc::new(settings_service)),
+        dist_dir,
+    )
+}
+
+pub(crate) async fn auth_test_app_with_admin_prompt_preview(
+    identity_service: TestIdentityService,
+    admin_prompt_preview_service: impl AdminPromptPreviewUseCases + 'static,
+) -> axum::Router {
+    let settings = Settings::test_defaults();
+    let dist_dir = shared_frontend_fixture().dist_dir();
+
+    build_app_with_frontend_dist(
+        AppState::new(
+            settings.app_name,
+            settings.mongo.database,
+            test_mongo_client(&settings.mongo.uri).await,
+        )
+        .with_trust_proxy_headers(settings.trust_proxy_headers)
+        .with_whitelist_rate_limiter(WhitelistRateLimiter::new(
+            usize::MAX,
+            std::time::Duration::from_secs(60),
+        ))
+        .with_identity_service(
+            std::sync::Arc::new(identity_service),
+            "aiwattcoach_session",
+            "lax",
+            false,
+            24,
+        )
+        .with_admin_prompt_preview_service(std::sync::Arc::new(admin_prompt_preview_service)),
         dist_dir,
     )
 }

--- a/tests/calendar_coach_service/shared.rs
+++ b/tests/calendar_coach_service/shared.rs
@@ -484,6 +484,15 @@ impl TrainingContextBuilder for RecordingTrainingContextBuilder {
         })
     }
 
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build(user_id, workout_id)
+    }
+
     fn build_calendar_overview_context(
         &self,
         user_id: &str,
@@ -494,6 +503,14 @@ impl TrainingContextBuilder for RecordingTrainingContextBuilder {
             calls.lock().unwrap().push(user_id);
             Ok(Self::result_for(None, "summary"))
         })
+    }
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build_calendar_overview_context(user_id)
     }
 
     fn build_athlete_summary_context(

--- a/tests/llm_adapters/support.rs
+++ b/tests/llm_adapters/support.rs
@@ -201,11 +201,28 @@ impl TrainingContextBuilder for StubTrainingContextBuilder {
         })
     }
 
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build(user_id, workout_id)
+    }
+
     fn build_calendar_overview_context(
         &self,
         user_id: &str,
     ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
         self.build(user_id, CALENDAR_OVERVIEW_FOCUS_ID)
+    }
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build_calendar_overview_context(user_id)
     }
 
     fn build_athlete_summary_context(

--- a/tests/llm_adapters/training_plan.rs
+++ b/tests/llm_adapters/training_plan.rs
@@ -67,11 +67,28 @@ impl TrainingContextBuilder for LargeContextTrainingContextBuilder {
         })
     }
 
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build(user_id, workout_id)
+    }
+
     fn build_calendar_overview_context(
         &self,
         _user_id: &str,
     ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
         self.build("user-1", CALENDAR_OVERVIEW_FOCUS_ID)
+    }
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build_calendar_overview_context(user_id)
     }
 
     fn build_athlete_summary_context(
@@ -120,11 +137,28 @@ impl TrainingContextBuilder for UnconfiguredAvailabilityTrainingContextBuilder {
         })
     }
 
+    fn build_as_of(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build(user_id, workout_id)
+    }
+
     fn build_calendar_overview_context(
         &self,
         _user_id: &str,
     ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
         self.build("user-1", CALENDAR_OVERVIEW_FOCUS_ID)
+    }
+
+    fn build_calendar_overview_context_as_of(
+        &self,
+        user_id: &str,
+        _focus_date: chrono::NaiveDate,
+    ) -> LlmBoxFuture<Result<TrainingContextBuildResult, LlmError>> {
+        self.build_calendar_overview_context(user_id)
     }
 
     fn build_athlete_summary_context(


### PR DESCRIPTION
## Summary

- Adds admin endpoints to preview the full LLM request for a selected past date:
  - **Post-workout** — picks the representative completed workout (compliance match, then TSS / latest start fallbacks) and assembles the workout summary coach prompt.
  - **Calendar coach** — assembles the calendar overview coach prompt as-of that date.
- Adds `/admin/prompt-preview` UI (date picker capped at today, two preview actions, pretty-printed JSON).
- Extracts shared domain prompt assemblers (`workout_summary/prompt`, `coach_conversation/prompt`, `preview_messages`) and wires production workout coach through `assemble_workout_summary_coach_request`.
- Fixes admin handler order: `require_admin` before service wiring (403 vs 503).
- Documents RAM-safe local verification (`CARGO_BUILD_JOBS=1`, one `cargo` at a time) in `AGENTS.md` / `tasks/lessons.md`.

## Test plan

- [x] `cargo test admin_prompt_preview --test auth_rest -- --test-threads=1`
- [x] `cargo test single_visible_workout --lib -- --test-threads=1`
- [x] `cargo test workout_coach_system_prompt --lib -- --test-threads=1`
- [x] `bun test frontend/src/features/admin-prompt-preview/api.test.ts`
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `bun run verify:arch`
- [x] Manual: log in as admin → Prompt preview → pick date → both buttons return JSON


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Admin Prompt Preview feature enabling admins to preview assembled LLM request payloads for post-workout and calendar coach surfaces without making live provider calls
* Added admin-only navigation entry and dedicated preview page with user/date selection

## Documentation
* Added implementation plan for Admin Prompt Preview functionality
* Added local development environment guidelines for resource-constrained systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->