### PR TITLE
fix: add text wrapping to admin prompt preview sections

### DIFF
--- a/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/StableContextSection.tsx
@@ -49,7 +49,7 @@ export function StableContextSection({ rawText }: StableContextSectionProps) {
           )}
 
           {parsed.workoutContext && (
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-slate-300">
+            <div className="whitespace-pre-wrap break-words rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-slate-300">
               {parsed.workoutContext}
             </div>
           )}
@@ -59,7 +59,7 @@ export function StableContextSection({ rawText }: StableContextSectionProps) {
               <summary className="cursor-pointer px-4 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
                 Athlete Summary
               </summary>
-              <div className="border-t border-white/5 px-4 py-3 text-sm">
+              <div className="whitespace-pre-wrap break-words border-t border-white/5 px-4 py-3 text-sm">
                 <MarkdownContent>{parsed.athleteSummary}</MarkdownContent>
               </div>
             </details>

--- a/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
+++ b/frontend/src/features/admin-prompt-preview/components/VolatileContextSection.tsx
@@ -28,7 +28,7 @@ export function VolatileContextSection({ rawText }: VolatileContextSectionProps)
       {expanded && (
         <div className="space-y-4">
           {parsed.timing && (
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm">
+            <div className="whitespace-pre-wrap break-words rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm">
               <div className="mb-1.5 text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Conversation Timing</div>
               <p className="text-slate-200">
                 Current:{' '}

--- a/frontend/src/lib/markdown/MarkdownContent.tsx
+++ b/frontend/src/lib/markdown/MarkdownContent.tsx
@@ -40,7 +40,7 @@ const mdComponents: Components = {
   code: ({ children }) => (
     <code className="rounded bg-white/10 px-1.5 py-0.5 text-xs text-amber-200">{children}</code>
   ),
-  p: ({ children }) => <p className="mb-2 leading-7">{children}</p>,
+  p: ({ children }) => <p className="mb-2 whitespace-pre-wrap break-words leading-7">{children}</p>,
   blockquote: ({ children }) => (
     <blockquote className="my-2 border-l-2 border-amber-400/30 pl-3 italic text-slate-300">
       {children}


### PR DESCRIPTION
Add whitespace-pre-wrap break-words to workoutContext, athleteSummary wrapper, conversation timing container, and markdown <p> tag to prevent long text from overflowing horizontally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and whitespace handling across preview sections and markdown content rendering for better readability of formatted text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->