### PR TITLE
Fix workout-summary coach reply parsing when LLM wraps JSON after prose.

### DIFF
--- a/src/domain/workout_summary/coach_output.rs
+++ b/src/domain/workout_summary/coach_output.rs
@@ -88,19 +88,22 @@ fn extract_fenced_json(raw: &str) -> Option<&str> {
     let mut last = None;
     while let Some(rel) = raw[cursor..].find("```") {
         let open = cursor + rel + 3;
-        let inner = raw[open..]
+        let suffix = &raw[open..];
+        let body = suffix
             .strip_prefix("json")
-            .or_else(|| raw[open..].strip_prefix("JSON"))
-            .unwrap_or(&raw[open..])
-            .trim_start();
+            .or_else(|| suffix.strip_prefix("JSON"))
+            .unwrap_or(suffix);
+        let body_start = open + suffix.len().saturating_sub(body.len());
+        let inner = body.trim_start();
+        let inner_start = body_start + body.len().saturating_sub(inner.len());
         let Some(close) = inner.find("```") else {
-            cursor = open;
+            cursor = open + 1;
             continue;
         };
         if let Some(payload) = json_block_payload(inner[..close].trim()) {
             last = Some(payload);
         }
-        cursor = open + close + 3;
+        cursor = inner_start + close + 3;
     }
     last
 }
@@ -252,6 +255,16 @@ mod tests {
         .expect("prose before fenced JSON should parse");
 
         assert_eq!(parsed.content, "Solid ride.");
+    }
+
+    #[test]
+    fn parse_coach_reply_uses_last_valid_json_fence() {
+        let parsed = parse_coach_reply(
+            "Draft\n```json\n{\"summary\":\"First\",\"questions\":[]}\n```\nFinal\n```json\n{\"summary\":\"Second\",\"questions\":[]}\n```",
+        )
+        .expect("last fenced JSON should win");
+
+        assert_eq!(parsed.content, "Second");
     }
 
     #[test]

--- a/src/domain/workout_summary/coach_output.rs
+++ b/src/domain/workout_summary/coach_output.rs
@@ -80,23 +80,39 @@ fn looks_like_malformed_coach_reply_json(payload: &str) -> bool {
 }
 
 fn extract_json_payload(raw: &str) -> &str {
-    let trimmed = raw.trim();
+    extract_fenced_json(raw.trim()).unwrap_or_else(|| raw.trim())
+}
 
-    if let Some(stripped) = trimmed.strip_prefix("```") {
-        let inner = stripped.trim().trim_end_matches("```").trim();
-
-        if inner.starts_with('{') || inner.starts_with('[') {
-            return inner;
+fn extract_fenced_json(raw: &str) -> Option<&str> {
+    let mut cursor = 0;
+    let mut last = None;
+    while let Some(rel) = raw[cursor..].find("```") {
+        let open = cursor + rel + 3;
+        let inner = raw[open..]
+            .strip_prefix("json")
+            .or_else(|| raw[open..].strip_prefix("JSON"))
+            .unwrap_or(&raw[open..])
+            .trim_start();
+        let Some(close) = inner.find("```") else {
+            cursor = open;
+            continue;
+        };
+        if let Some(payload) = json_block_payload(inner[..close].trim()) {
+            last = Some(payload);
         }
-
-        if let Some((_, rest)) = inner.split_once('\n') {
-            return rest.trim();
-        }
-
-        return inner;
+        cursor = open + close + 3;
     }
+    last
+}
 
-    trimmed
+fn json_block_payload(block: &str) -> Option<&str> {
+    if block.starts_with('{') || block.starts_with('[') {
+        return Some(block);
+    }
+    block
+        .split_once('\n')
+        .map(|(_, rest)| rest.trim())
+        .filter(|rest| rest.starts_with('{') || rest.starts_with('['))
 }
 
 fn normalize_questions(
@@ -226,6 +242,16 @@ mod tests {
         .expect("code fenced JSON should parse");
 
         assert_eq!(parsed.content, "Good session.");
+    }
+
+    #[test]
+    fn parse_coach_reply_accepts_json_code_fence_after_prose() {
+        let parsed = parse_coach_reply(
+            "Teraz mam pełny obraz sesji.\n\n```json\n{\n  \"summary\": \"Solid ride.\",\n  \"questions\": []\n}\n```",
+        )
+        .expect("prose before fenced JSON should parse");
+
+        assert_eq!(parsed.content, "Solid ride.");
     }
 
     #[test]

--- a/src/domain/workout_summary/service/internals/recovery.rs
+++ b/src/domain/workout_summary/service/internals/recovery.rs
@@ -413,12 +413,12 @@ fn invalid_provider_transcript_recovery_error(
     };
 
     match crate::domain::workout_summary::parse_coach_reply(&content) {
-        Ok(_) => crate::domain::llm::LlmError::InvalidResponse(
-            "assistant reply missing final text message".to_string(),
-        ),
         Err(message) => crate::domain::llm::LlmError::InvalidResponse(format!(
             "assistant reply did not match workout summary coach schema: {message}"
         )),
+        Ok(_) => unreachable!(
+            "recovery only fails parsing after recoverable_assistant_reply returned None"
+        ),
     }
 }
 
@@ -500,6 +500,34 @@ mod tests {
         });
 
         assert!(super::recoverable_assistant_reply(&prose_json).is_some());
+
+        let schema_mismatch = CoachReplyOperation::pending(
+            "user-1".into(),
+            "workout-1".into(),
+            "message-2".into(),
+            None,
+            "coach-2".into(),
+            1,
+        )
+        .record_provider_response(PendingLlmReplyCheckpoint {
+            provider: LlmProvider::OpenAi,
+            model: "gpt-4o-mini".into(),
+            provider_request_id: None,
+            provider_cache_id: None,
+            token_usage: LlmTokenUsage::default(),
+            cache_usage: LlmCacheUsage::default(),
+            provider_transcript: vec![LlmChatMessage::assistant(
+                "Coach intro.\n\n```json\n{\"summary\":\"Broken",
+            )],
+            finish_reason: None,
+            updated_at_epoch_seconds: 2,
+        });
+
+        assert!(matches!(
+            super::invalid_provider_transcript_recovery_error(&schema_mismatch),
+            LlmError::InvalidResponse(message)
+                if message.contains("assistant reply did not match workout summary coach schema")
+        ));
     }
 
     #[tokio::test]

--- a/src/domain/workout_summary/service/internals/recovery.rs
+++ b/src/domain/workout_summary/service/internals/recovery.rs
@@ -395,13 +395,30 @@ where
         &self,
         operation: &CoachReplyOperation,
     ) -> Result<Option<CoachReply>, WorkoutSummaryError> {
-        let error = crate::domain::llm::LlmError::InvalidResponse(
-            "assistant reply missing final text message".to_string(),
-        );
+        let error = invalid_provider_transcript_recovery_error(operation);
         let failed = operation.mark_failed(&error, self.clock.now_epoch_seconds());
         self.persist_post_provider_operation(failed, "replay_invalid_coach_reply")
             .await?;
         Err(WorkoutSummaryError::Llm(error))
+    }
+}
+
+fn invalid_provider_transcript_recovery_error(
+    operation: &CoachReplyOperation,
+) -> crate::domain::llm::LlmError {
+    let Some(content) = last_nonempty_assistant_content(&operation.provider_transcript) else {
+        return crate::domain::llm::LlmError::InvalidResponse(
+            "assistant reply missing final text message".to_string(),
+        );
+    };
+
+    match crate::domain::workout_summary::parse_coach_reply(&content) {
+        Ok(_) => crate::domain::llm::LlmError::InvalidResponse(
+            "assistant reply missing final text message".to_string(),
+        ),
+        Err(message) => crate::domain::llm::LlmError::InvalidResponse(format!(
+            "assistant reply did not match workout summary coach schema: {message}"
+        )),
     }
 }
 
@@ -430,6 +447,60 @@ mod tests {
         ExistingMessageSummaryRepository, FixedClock, FixedIds, RecordingReplyOperations,
         StubReplyOperations,
     };
+
+    #[test]
+    fn invalid_provider_transcript_recovery_error_distinguishes_missing_text_from_schema_mismatch(
+    ) {
+        use crate::domain::llm::LlmError;
+
+        let tool_only = CoachReplyOperation::pending(
+            "user-1".into(),
+            "workout-1".into(),
+            "message-1".into(),
+            None,
+            "coach-1".into(),
+            1,
+        )
+        .record_provider_response(PendingLlmReplyCheckpoint {
+            provider: LlmProvider::OpenAi,
+            model: "gpt-4o-mini".into(),
+            provider_request_id: None,
+            provider_cache_id: None,
+            token_usage: LlmTokenUsage::default(),
+            cache_usage: LlmCacheUsage::default(),
+            provider_transcript: vec![LlmChatMessage::assistant_with_tool_calls(
+                "",
+                vec![LlmToolCall {
+                    id: "tool-1".into(),
+                    name: "lookup".into(),
+                    arguments_json: "{}".into(),
+                }],
+            )],
+            finish_reason: None,
+            updated_at_epoch_seconds: 2,
+        });
+
+        assert!(matches!(
+            super::invalid_provider_transcript_recovery_error(&tool_only),
+            LlmError::InvalidResponse(message) if message == "assistant reply missing final text message"
+        ));
+
+        let prose_json = tool_only.record_provider_response(PendingLlmReplyCheckpoint {
+            provider: LlmProvider::OpenAi,
+            model: "deepseek-v4-pro".into(),
+            provider_request_id: None,
+            provider_cache_id: None,
+            token_usage: LlmTokenUsage::default(),
+            cache_usage: LlmCacheUsage::default(),
+            provider_transcript: vec![LlmChatMessage::assistant(
+                "Coach intro.\n\n```json\n{\"summary\":\"Recovered.\",\"questions\":[]}\n```",
+            )],
+            finish_reason: None,
+            updated_at_epoch_seconds: 3,
+        });
+
+        assert!(super::recoverable_assistant_reply(&prose_json).is_some());
+    }
 
     #[tokio::test]
     async fn recovery_materialization_does_not_duplicate_tool_messages() {

--- a/src/domain/workout_summary/service/internals/recovery.rs
+++ b/src/domain/workout_summary/service/internals/recovery.rs
@@ -449,8 +449,8 @@ mod tests {
     };
 
     #[test]
-    fn invalid_provider_transcript_recovery_error_distinguishes_missing_text_from_schema_mismatch(
-    ) {
+    fn invalid_provider_transcript_recovery_error_distinguishes_missing_text_from_schema_mismatch()
+    {
         use crate::domain::llm::LlmError;
 
         let tool_only = CoachReplyOperation::pending(


### PR DESCRIPTION
DeepSeek-style replies embed the schema payload in a trailing code fence, so retries could fail recovery with a misleading missing-text error even though the provider transcript was usable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of AI-generated coach responses, especially when JSON is embedded within code blocks.
  * Enhanced error handling to better distinguish between missing content and parsing failures in invalid responses.

* **Tests**
  * Added test coverage for code block JSON extraction and recovery error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->